### PR TITLE
Replace removed MplCanvasAdapter.show() with ..draw()

### DIFF
--- a/lib/pyraf/GkiMpl.py
+++ b/lib/pyraf/GkiMpl.py
@@ -90,7 +90,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         self.colorManager = tkColorManager(self.irafGkiConfig)
         self.startNewPage()
         self.__gcursorObject = gkigcur.Gcursor(self)
-        self.__mca.show() # or, could: self.gRedraw() with a .show()
+        self.__mca.draw() # or, could: self.gRedraw() with a .draw()
 
     # not currently using getAdjustedHeight because the background is drawn and
     # it is not black (or the same color as the rest of the empty window)

--- a/lib/pyraf/MplCanvasAdapter.py
+++ b/lib/pyraf/MplCanvasAdapter.py
@@ -103,8 +103,7 @@ class MplCanvasAdapter(tkagg.FigureCanvasTkAgg):
 
         self.__doIdleRedraw = 0
 
-    # show and draw could be defined to catch events before passing through
-#   def show(self):  tkagg.FigureCanvasTkAgg.show(self)
+    # draw could be defined to catch events before passing through
 #   def draw(self):  tkagg.FigureCanvasTkAgg.draw(self)
 
     def wrappedRedrawOrResize(self, w=None, h=None):


### PR DESCRIPTION
The `FigureCanvasApp.show()` in matplotlib command was replaced by `draw()` in matplotlib-3.0 (2018).

Also, there was a deprecation of the `resize_event` parameter in the `FigureCanvasApp` constructor, which was deprecated in matplotlib-3.4 (2021).

Fixes: #72 

@jrthorstensen Could you make a test with this change and tell whether it works?