### PR TITLE
Remove remaining www.stsci.edu links

### DIFF
--- a/defsetup.py
+++ b/defsetup.py
@@ -228,8 +228,8 @@ setupargs = {
     'version' :			    "2.x", # see lib's __init__.py
     'description' :		    "A Python based CL for IRAF",
     'author' :			    "Rick White, Perry Greenfield, Chris Sontag",
-    'url' :			        "http://www.stsci.edu/resources/software_hardware/pyraf",
-    'license' :			    "http://www.stsci.edu/resources/software_hardware/pyraf/LICENSE",
+    'url' :			        "https://iraf-community.github.io/pyraf.html",
+    'license' :			    "BSD-3-Clause",
     'platforms' :			["unix"],
     'data_files' :			DATA_FILES,
     'scripts' :			    scriptlist,

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -93,8 +93,7 @@ try:
                 _has_aqutil = 1
             except:
                 _has_aqutil = 0
-                print "Could not import aqutil, please see the online PyRAF FAQ"
-                print "http://www.stsci.edu/institute/software_hardware/pyraf/pyraf_faq#2.6"
+                print "Could not import aqutil"
 
 except ImportError:
     _has_xutil = 0 # Unsuccessful init of XWindow


### PR DESCRIPTION
There were two links to www.stsci.edu left, which both don't work anymore. The link to the homepage is now changes to iraf-commuity, and the link to the FAQ is removed completely.

It may be a challenging TODO to dig out the original FAQ (the only one I found is a PDF).
