### PR TITLE
WIP: Improve Python 3 compatibility

### DIFF
--- a/defsetup.py
+++ b/defsetup.py
@@ -15,7 +15,7 @@ ms_windows = sys.platform.startswith('win')
 # conditional for if we should build the C code
 build_c = not ms_windows
 # so my 2.5 fink build works:
-if sys.version_info[:2] < (2,6):
+if sys.version_info[:2] < (2, 6):
     build_c = False
     ms_windows = True
 
@@ -38,9 +38,9 @@ x_libraries = 'X11'
 
 def find_x(xdir=""):
     if xdir != "":
-        add_lib_dirs.append(os.path.join(xdir,'lib64'))
-        add_lib_dirs.append(os.path.join(xdir,'lib'))
-        add_inc_dirs.append(os.path.join(xdir,'include'))
+        add_lib_dirs.append(os.path.join(xdir, 'lib64'))
+        add_lib_dirs.append(os.path.join(xdir, 'lib'))
+        add_inc_dirs.append(os.path.join(xdir, 'include'))
     elif sys.platform == 'darwin' or sys.platform.startswith('linux'):
         add_lib_dirs.append('/usr/X11R6/lib64')
         add_lib_dirs.append('/usr/X11R6/lib')
@@ -144,7 +144,7 @@ if ms_windows :
 
     # copy the pyraf main program to the name we want it installed as
     shutil.copy(
-        os.path.join( * ( scriptdir + [ 'pyraf' ] ) ) ,
+        os.path.join( * ( scriptdir + [ 'pyraf' ] ) ),
         os.path.join( * ( scriptdir + [ 'runpyraf.py' ] ) )
         )
 
@@ -225,16 +225,14 @@ if not ms_windows and sys.version_info[0] < 3:
 ## setupargs
 
 setupargs = {
-    'version' :			    "2.x", # see lib's __init__.py
-    'description' :		    "A Python based CL for IRAF",
-    'author' :			    "Rick White, Perry Greenfield, Chris Sontag",
-    'url' :			        "https://iraf-community.github.io/pyraf.html",
-    'license' :			    "BSD-3-Clause",
-    'platforms' :			["unix"],
-    'data_files' :			DATA_FILES,
-    'scripts' :			    scriptlist,
-    'ext_modules' :			PYRAF_EXTENSIONS,
-    'package_dir' :         { 'pyraf' : 'lib/pyraf' },
+    'version': "2.x", # see lib's __init__.py
+    'description': "A Python based CL for IRAF",
+    'author': "Rick White, Perry Greenfield, Chris Sontag",
+    'url': "https://iraf-community.github.io/pyraf.html",
+    'license': "BSD-3-Clause",
+    'platforms': ["unix"],
+    'data_files': DATA_FILES,
+    'scripts': scriptlist,
+    'ext_modules': PYRAF_EXTENSIONS,
+    'package_dir': { 'pyraf' : 'lib/pyraf' },
 }
-
-

--- a/defsetup.py
+++ b/defsetup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, os.path, shutil, sys, commands
 import distutils.core
@@ -61,7 +61,7 @@ def find_x(xdir=""):
         tkv = str(Tkinter.TkVersion)[:3]
         # yes, the version number of Tkinter really is a float...
         if Tkinter.TkVersion < 8.3:
-            print "Tcl/Tk v8.3 or later required\n"
+            print("Tcl/Tk v8.3 or later required\n")
             sys.exit(1)
         else:
             suffix = '.so'

--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -140,7 +140,7 @@ def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
             if not hasattr(pkg_resources, '_distribute'):
                 if not no_fake:
                     _fake_setuptools()
-                raise ImportError
+                raise ImportError()
         except ImportError:
             return _do_download(version, download_base, to_dir, download_delay)
         try:

--- a/lib/pyraf/GkiMpl.py
+++ b/lib/pyraf/GkiMpl.py
@@ -4,7 +4,7 @@ matplotlib implementation of the gki kernel class
 $Id$
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import math, sys, numpy, os
 import Tkinter as TKNTR

--- a/lib/pyraf/GkiMpl.py
+++ b/lib/pyraf/GkiMpl.py
@@ -32,11 +32,11 @@ MPL_MAJ_MIN = float(MPL_MAJ_MIN[0]+'.'+MPL_MAJ_MIN[1])
 GKI_TO_MPL_LINEWIDTH = 0.65
 
 # GKI seems to use: 0: clear, 1: solid, 2: dash, 3: dot, 4: dot-dash, 5: ?
-GKI_TO_MPL_LINESTYLE = ['None','-','--',':','-.','steps']
+GKI_TO_MPL_LINESTYLE = ['None', '-', '--', ':', '-.', 'steps']
 
 # Convert GKI alignment int values to MPL (idx 0 = default), 0 is invalid
-GKI_TO_MPL_HALIGN = ['left','center','left','right',0,0,0,0]
-GKI_TO_MPL_VALIGN = ['bottom','center',0,0,0,0,'top','bottom']
+GKI_TO_MPL_HALIGN = ['left', 'center', 'left', 'right', 0, 0, 0, 0]
+GKI_TO_MPL_VALIGN = ['bottom', 'center', 0, 0, 0, 0, 'top', 'bottom']
 # "surface dev$pix" uses idx=5, though that's not allowed
 GKI_TO_MPL_VALIGN[4]='top'
 GKI_TO_MPL_VALIGN[5]='bottom'
@@ -47,11 +47,11 @@ GKI_TEXT_Y_OFFSET = 0.005
 # marktype seems unused at present (most markers are polylines), but for
 # future use, the GIO document lists:
 #    'Acceptable choices are "point", "box", "plus", "cross", "circle" '
-GKI_TO_MPL_MARKTYPE = ['.','s','+','x','o']
+GKI_TO_MPL_MARKTYPE = ['.', 's', '+', 'x', 'o']
 
 # Convert other GKI font attributes to MPL (cannot do bold italic?)
-GKI_TO_MPL_FONTATTR = ['normal',1,2,3,4,5,6,7,'roman','greek','italic','bold',
-                       'low','medium','high']
+GKI_TO_MPL_FONTATTR = ['normal', 1, 2, 3, 4, 5, 6, 7, 'roman', 'greek', 'italic', 'bold',
+                       'low', 'medium', 'high']
 
 
 #-----------------------------------------------
@@ -69,7 +69,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         self.__ysz = height
 
         ddd = 100
-        self.__fig = Figure(figsize=(self.__xsz/(1.*ddd),self.__ysz/(1.*ddd)),
+        self.__fig = Figure(figsize=(self.__xsz/(1.*ddd), self.__ysz/(1.*ddd)),
                             dpi=ddd)
         self.__fig.set_facecolor('k') # default to black
 
@@ -162,7 +162,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
 
         # scale each patch, then apply it to the figure
         for nrpa in self.__normPatches:
-            rr = Rectangle((0,0),0,0)
+            rr = Rectangle((0, 0), 0, 0)
             rr.update_from(nrpa)
             rr.set_x(nrpa.get_x()*self.__xsz)
             rr.set_y(nrpa.get_y()*self.__ysz)
@@ -337,7 +337,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         """ Append a 2-tuple (plot_function, args) to the draw buffer """
         # Allow for this draw buffer append to be skipped at times
         if not self.__skipPlotAppends:
-            self.drawBuffer.append((plot_function,args))
+            self.drawBuffer.append((plot_function, args))
 
         # Run _noteGkiCmd here as well, as almost all gki_* funcs call us
 #       self._noteGkiCmd(plot_function)
@@ -397,9 +397,9 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         # Reshape to get x's and y's
         # arg[0] is the num pairs, so: len(arg)-1 == 2*arg[0]
         verts = gki.ndc(arg[1:])
-        rshpd = verts.reshape(arg[0],2)
-        xs = rshpd[:,0]
-        ys = rshpd[:,1]
+        rshpd = verts.reshape(arg[0], 2)
+        xs = rshpd[:, 0]
+        ys = rshpd[:, 1]
 
         # Put the normalized data into a Line2D object, append to our list.
         # Later we will scale it and append it to the fig.  For the sake of
@@ -437,9 +437,9 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         # Reshape to get x's and y's
         # arg[0] is the num pairs, so: len(arg)-1 == 2*arg[0]
         verts = gki.ndc(arg[1:])
-        rshpd = verts.reshape(arg[0],2)
-        xs = rshpd[:,0]
-        ys = rshpd[:,1]
+        rshpd = verts.reshape(arg[0], 2)
+        xs = rshpd[:, 0]
+        ys = rshpd[:, 1]
 
         # put the normalized data into a Line2D object, append to our list
         # later we will scale it and append it to the fig.  See performance
@@ -470,7 +470,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         elif textPath == textattrib.CHARPATH_DOWN:   angle = charUp+180.
 
         # return from 0-360
-        return math.fmod(angle,360.)
+        return math.fmod(angle, 360.)
 
     def gki_text(self, arg):
 
@@ -732,4 +732,4 @@ class tkColorManager:
         red = int(255*color[0])
         green = int(255*color[1])
         blue = int(255*color[2])
-        return "#%02x%02x%02x" % (red,green,blue)
+        return "#%02x%02x%02x" % (red, green, blue)

--- a/lib/pyraf/MplCanvasAdapter.py
+++ b/lib/pyraf/MplCanvasAdapter.py
@@ -4,7 +4,7 @@
 $Id$
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, matplotlib
 matplotlib.use('TkAgg') # set backend

--- a/lib/pyraf/MplCanvasAdapter.py
+++ b/lib/pyraf/MplCanvasAdapter.py
@@ -170,7 +170,7 @@ class MplCanvasAdapter(tkagg.FigureCanvasTkAgg):
             if not self.__SWCursor:
                 self.__SWCursor = FullWindowCursor(0.5, 0.5, gw)
             self.__isSWCursorActive = 1
-            gw.bind("<Motion>",self.moveCursor)
+            gw.bind("<Motion>", self.moveCursor)
         if drawToo and not self.__SWCursor.isVisible():
             self.__SWCursor.draw()
 
@@ -229,7 +229,7 @@ class MplCanvasAdapter(tkagg.FigureCanvasTkAgg):
         else:
             x = (event.x+0.5)/gw.winfo_width()
             y = 1.-(event.y+0.5)/gw.winfo_height()
-        self.__SWCursor.moveTo(x,y,SWmove=0)
+        self.__SWCursor.moveTo(x, y, SWmove=0)
 
     # moveCursorTo() is used as if it belonged to the gwidget's class
     def moveCursorTo(self, x, y, SWmove=0):

--- a/lib/pyraf/Ptkplot.py
+++ b/lib/pyraf/Ptkplot.py
@@ -58,8 +58,8 @@ cursorColor = 1
 cursorTrueColor = (1.0, 0.0, 0.0)
 # visuals that use true colors
 truevis = {
-          'truecolor' : 1,
-          'directcolor' : 1,
+          'truecolor': 1,
+          'directcolor': 1,
           }
 
 
@@ -142,7 +142,7 @@ class PyrafCanvas(Canvas):
             cursorActivate = 0
         self.redraw(self)
         if cursorActivate:
-            self.activateSWCursor(x,y)
+            self.activateSWCursor(x, y)
 
     def tkRedraw(self, *dummy):
         self.doIdleRedraw = 1
@@ -166,7 +166,7 @@ class PyrafCanvas(Canvas):
             if not self._SWCursor:
                 self._SWCursor = FullWindowCursor(0.5, 0.5, self)
             self._isSWCursorActive = 1
-            self.bind("<Motion>",self.moveCursor)
+            self.bind("<Motion>", self.moveCursor)
         if not self._SWCursor.isVisible():
             self._SWCursor.draw()
 
@@ -213,7 +213,7 @@ class PyrafCanvas(Canvas):
         else:
             x = (event.x+0.5)/self.winfo_width()
             y = 1.-(event.y+0.5)/self.winfo_height()
-        self._SWCursor.moveTo(x,y,SWmove=0)
+        self._SWCursor.moveTo(x, y, SWmove=0)
 
     def moveCursorTo(self, x, y, SWmove=0):
         self._SWCursor.moveTo(float(x)/self.width,
@@ -282,8 +282,8 @@ class FullWindowCursor:
         y  = (1.0-self.lasty)*wh
 
         # Draw the crosshairs.  __window is a Tk Canvas object
-        self.__tkHorLine = self.__window.create_line(0,y,ww,y,fill='red')
-        self.__tkVerLine = self.__window.create_line(x,0,x,wh,fill='red')
+        self.__tkHorLine = self.__window.create_line(0, y, ww, y, fill='red')
+        self.__tkVerLine = self.__window.create_line(x, 0, x, wh, fill='red')
 
     def _tkEraseCursor(self):
 

--- a/lib/pyraf/Ptkplot.py
+++ b/lib/pyraf/Ptkplot.py
@@ -5,7 +5,7 @@
 $Id$
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os
 from Tkinter import _default_root # requires 2to3

--- a/lib/pyraf/__init__.py
+++ b/lib/pyraf/__init__.py
@@ -141,7 +141,7 @@ else:
         if len(args) > 1:
             print 'Error: more than one savefile argument'
             usage()
-    except getopt.error, e:
+    except getopt.error as e:
         print str(e)
         usage()
     verbose = 0

--- a/lib/pyraf/__init__.py
+++ b/lib/pyraf/__init__.py
@@ -8,7 +8,7 @@ $Id$
 
 R. White, 2000 February 18
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from .version import *
 
@@ -25,7 +25,7 @@ if __version__.endswith('dev'):
 
 # Dump version and exit here, if requested
 if '-V' in sys.argv or '--version' in sys.argv:
-    print __version__
+    print(__version__)
     sys.stdout.flush()
     os._exit(0) # see note in usage()
 
@@ -34,10 +34,10 @@ if '-V' in sys.argv or '--version' in sys.argv:
 _verbosity_ = len([j for j in sys.argv if j in ('--verbose','-v','-vv','-vvv')])
 
 # Show version at earliest possible moment when in debugging/verbose mode.
-if _verbosity_ > 0: print 'pyraf version '+__version__
+if _verbosity_ > 0: print('pyraf version '+__version__)
 
 def usage():
-    print __main__.__doc__
+    print(__main__.__doc__)
     sys.stdout.flush()
     irafimport.restoreBuiltins()
     # exit with prejudice, not a raised exc; we don't want/need anything
@@ -52,19 +52,19 @@ import wutil
 
 # Since numpy as absolutely required for any PyRAF use, go ahead and
 # import it now, just to check it
-if _verbosity_ > 0: print "pyraf: importing numpy"
+if _verbosity_ > 0: print("pyraf: importing numpy")
 try:
     import numpy
 except ImportError:
-    print "The numpy package is required by PyRAF and was not found.  Please visit http://numpy.scipy.org"
+    print("The numpy package is required by PyRAF and was not found.  Please visit http://numpy.scipy.org")
     os._exit(1)
-if _verbosity_ > 0: print "pyraf: imported numpy"
+if _verbosity_ > 0: print("pyraf: imported numpy")
 
 # Modify the standard import mechanism to make it more
 # convenient for the iraf module
-if _verbosity_ > 0: print "pyraf: importing irafimport"
+if _verbosity_ > 0: print("pyraf: importing irafimport")
 import irafimport
-if _verbosity_ > 0: print "pyraf: imported irafimport"
+if _verbosity_ > 0: print("pyraf: imported irafimport")
 
 # this gives more useful tracebacks for CL scripts
 import cllinecache
@@ -73,7 +73,7 @@ import irafnames
 
 # initialization is silent unless program name is 'pyraf' or
 # silent flag is set on command line
-if _verbosity_ > 0: print "pyraf: setting _pyrafMain"
+if _verbosity_ > 0: print("pyraf: setting _pyrafMain")
 
 # follow links to get to the real executable filename
 executable = sys.argv[0]
@@ -86,7 +86,7 @@ runCmd = None
 import irafexecute, clcache
 from stsci.tools import capable
 
-if _verbosity_ > 0: print "pyraf: setting exit handler"
+if _verbosity_ > 0: print("pyraf: setting exit handler")
 # set up exit handler to close caches
 def _cleanup():
     if iraf: iraf.gflush()
@@ -102,14 +102,14 @@ if not _pyrafMain or ('-h' not in sys.argv and '--help' not in sys.argv):
     atexit.register(_cleanup)
     del atexit
 
-if _verbosity_ > 0: print "pyraf: finished all work prior to IRAF use"
+if _verbosity_ > 0: print("pyraf: finished all work prior to IRAF use")
 # now get ready to do the serious IRAF initialization
 if not _pyrafMain:
     # if not executing as pyraf main, just initialize iraf module
     # quietly load initial iraf symbols and packages
-    if _verbosity_ > 0: print "pyraf: initializing IRAF"
+    if _verbosity_ > 0: print("pyraf: initializing IRAF")
     import iraf
-    if _verbosity_ > 0: print "pyraf: imported iraf"
+    if _verbosity_ > 0: print("pyraf: imported iraf")
 
     # If iraf.Init() throws an exception, we cannot be confident
     # that it has initialized properly.  This can later lead to
@@ -127,9 +127,9 @@ if not _pyrafMain:
     except :
         iraf = None
         raise
-    if _verbosity_ > 0: print "pyraf: initialized IRAF"
+    if _verbosity_ > 0: print("pyraf: initialized IRAF")
 else:
-    if _verbosity_ > 0: print "pyraf: is main program"
+    if _verbosity_ > 0: print("pyraf: is main program")
     # special initialization when this is the main program
 
     # command-line options
@@ -139,10 +139,10 @@ else:
         optlist, args = getopt.getopt(sys.argv[1:], "imc:vhsney",
             ["commandwrapper=", "command=", "verbose", "help", "silent", "nosplash","ipython", "ecl"])
         if len(args) > 1:
-            print 'Error: more than one savefile argument'
+            print('Error: more than one savefile argument')
             usage()
     except getopt.error as e:
-        print str(e)
+        print(str(e))
         usage()
     verbose = 0
     doCmdline = 1
@@ -180,16 +180,16 @@ else:
             elif opt in ("-e", "--ecl"):
                 _pyrafglobals._use_ecl = True
             else:
-                print "Program bug, uninterpreted option", opt
+                print("Program bug, uninterpreted option", opt)
                 raise SystemExit()
 
     if "epyraf" in sys.argv[0]:  # See also -e and --ecl switches
         _pyrafglobals._use_ecl = True
 
-    if _verbosity_ > 0: print "pyraf: finished arg parsing"
+    if _verbosity_ > 0: print("pyraf: finished arg parsing")
 
     import iraf
-    if _verbosity_ > 0: print "pyraf: imported iraf"
+    if _verbosity_ > 0: print("pyraf: imported iraf")
     iraf.setVerbose(verbose)
     del getopt, verbose, usage, optlist
 
@@ -205,7 +205,7 @@ else:
         else:
             _splash = None
 
-    if _verbosity_ > 0: print "pyraf: splashed"
+    if _verbosity_ > 0: print("pyraf: splashed")
 
     # load initial iraf symbols and packages
 
@@ -229,7 +229,7 @@ else:
         iraf = None
         raise
     del args
-    if _verbosity_ > 0: print "pyraf: finished iraf.Init"
+    if _verbosity_ > 0: print("pyraf: finished iraf.Init")
 
     if _splash:
         _splash.Destroy()

--- a/lib/pyraf/__init__.py
+++ b/lib/pyraf/__init__.py
@@ -181,7 +181,7 @@ else:
                 _pyrafglobals._use_ecl = True
             else:
                 print "Program bug, uninterpreted option", opt
-                raise SystemExit
+                raise SystemExit()
 
     if "epyraf" in sys.argv[0]:  # See also -e and --ecl switches
         _pyrafglobals._use_ecl = True

--- a/lib/pyraf/__init__.py
+++ b/lib/pyraf/__init__.py
@@ -31,7 +31,7 @@ if '-V' in sys.argv or '--version' in sys.argv:
 
 # Do a quick, non-intrusive check to see how verbose we are.  This is
 # just for here.  This does not correctly count -v vs. -vv, -vvv, etc.
-_verbosity_ = len([j for j in sys.argv if j in ('--verbose','-v','-vv','-vvv')])
+_verbosity_ = len([j for j in sys.argv if j in ('--verbose', '-v', '-vv', '-vvv')])
 
 # Show version at earliest possible moment when in debugging/verbose mode.
 if _verbosity_ > 0: print('pyraf version '+__version__)
@@ -90,9 +90,9 @@ if _verbosity_ > 0: print("pyraf: setting exit handler")
 # set up exit handler to close caches
 def _cleanup():
     if iraf: iraf.gflush()
-    if hasattr(irafexecute,'processCache'):
+    if hasattr(irafexecute, 'processCache'):
         del irafexecute.processCache
-    if hasattr(clcache,'codeCache'):
+    if hasattr(clcache, 'codeCache'):
         del clcache.codeCache
 
 # Register the exit handler, but only if 'pyraf' is going to import fully
@@ -137,7 +137,7 @@ else:
     import getopt
     try:
         optlist, args = getopt.getopt(sys.argv[1:], "imc:vhsney",
-            ["commandwrapper=", "command=", "verbose", "help", "silent", "nosplash","ipython", "ecl"])
+            ["commandwrapper=", "command=", "verbose", "help", "silent", "nosplash", "ipython", "ecl"])
         if len(args) > 1:
             print('Error: more than one savefile argument')
             usage()

--- a/lib/pyraf/aqutil.py
+++ b/lib/pyraf/aqutil.py
@@ -5,7 +5,7 @@ bridging package so that compiling another C extension is not needed.
 $Id$
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, struct, time
 import objc

--- a/lib/pyraf/aqutil.py
+++ b/lib/pyraf/aqutil.py
@@ -103,7 +103,7 @@ def setFocusTo(windowID):
     """ Move the focus to the given window ID (see getFocalWindowID docs) """
     # We could do something fancy like create unique window id's out of the
     # process serial numbers (PSN's), but for now stick with WIN_ID_*
-    if not windowID in (WIN_ID_TERM, WIN_ID_GUI):
+    if windowID not in (WIN_ID_TERM, WIN_ID_GUI):
         raise RuntimeError("Bug: unexpected OSX windowID: "+str(windowID))
     if windowID == WIN_ID_TERM:
         focusOnTerm()

--- a/lib/pyraf/cgeneric.py
+++ b/lib/pyraf/cgeneric.py
@@ -45,7 +45,7 @@ class ContextSensitiveScanner:
             groups = m.groups()
             for i in scanner.indexlist:
                 if groups[i] is not None:
-                    scanner.index2func[i](groups[i],m,self)
+                    scanner.index2func[i](groups[i], m, self)
                     # assume there is only a single match
                     break
             else:

--- a/lib/pyraf/cgeneric.py
+++ b/lib/pyraf/cgeneric.py
@@ -19,7 +19,7 @@ $Id$
 
 Created 1999 September 10 by R. White
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 class ContextSensitiveScanner:
 
@@ -49,8 +49,8 @@ class ContextSensitiveScanner:
                     # assume there is only a single match
                     break
             else:
-                print 'cgeneric: No group found in match?'
-                print 'Returning match object for debug'
+                print('cgeneric: No group found in match?')
+                print('Returning match object for debug')
                 self.rv = m
                 return
             iend = m.end()

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -595,7 +595,7 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
         if len(ilist) == 1 and v.shape is None:
             try:
                 v.init_value = _convFunc(v, ilist[0])
-            except ValueError, e:
+            except ValueError as e:
                 self.error("Bad initial value for variable `%s': %s" %
                     (v.name, e), node)
         else:
@@ -611,7 +611,7 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
                 try:
                     for i in range(len(v.init_value)):
                         v.init_value[i] = _convFunc(v, v.init_value[i])
-                except ValueError, e:
+                except ValueError as e:
                     self.error("Bad initial value for array variable `%s': %s" %
                         (v.name, e), node)
 
@@ -1376,7 +1376,7 @@ def _convFunc(var, value):
         else:
             try:
                 return value.bool()
-            except AttributeError, e:
+            except AttributeError as e:
                 raise AttributeError(var.name + ':' + str(e))
     raise ValueError("unimplemented type `%s'" % (var.type,))
 
@@ -1628,7 +1628,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
                     try:
                         proclist[i] = v.procLine()
                         deflist[i] = v.parDefLine()
-                    except AttributeError, e:
+                    except AttributeError as e:
                         raise AttributeError(self.filename + ':' + str(e))
             # allow long argument lists to be broken across lines
             self.writeIndent("def " + self.vars.proc_name + "(")
@@ -1662,7 +1662,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
             v = self.vars.local_vars_dict[p]
             try:
                 deflist.append(v.parDefLine(local=1))
-            except AttributeError, e:
+            except AttributeError as e:
                 raise AttributeError(self.filename + ':' + str(e))
 
         if deflist:

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -80,27 +80,27 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
         if isinstance(filename, str):
             efilename = os.path.expanduser(filename)
             if usecache:
-                index, pycode = codeCache.get(efilename,mode=mode)
+                index, pycode = codeCache.get(efilename, mode=mode)
                 if pycode is not None:
                     if Verbose>1:
-                        print(efilename,"filename found in CL script cache")
+                        print(efilename, "filename found in CL script cache")
                     return pycode
             else:
                 index = None
             fh = open(efilename)
             clInput = fh.read()
             fh.close()
-        elif hasattr(filename,'read'):
+        elif hasattr(filename, 'read'):
             clInput = filename.read()
             if usecache:
-                index, pycode = codeCache.get(filename,mode=mode,source=clInput)
+                index, pycode = codeCache.get(filename, mode=mode, source=clInput)
                 if pycode is not None:
                     if Verbose>1:
-                        print(filename,"filehandle found in CL script cache")
+                        print(filename, "filehandle found in CL script cache")
                     return pycode
             else:
                 index = None
-            if hasattr(filename,'name'):
+            if hasattr(filename, 'name'):
                 efilename = filename.name
             else:
                 efilename = ''
@@ -112,10 +112,10 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
         clInput = string
         efilename = 'string_proc' # revisit this setting (tik #24), maybe '' ?
         if usecache:
-            index, pycode = codeCache.get(None,mode=mode,source=clInput)
+            index, pycode = codeCache.get(None, mode=mode, source=clInput)
             if pycode is not None:
                 if Verbose>3:
-                    print("Found in CL script cache: ",clInput.strip()[:20])
+                    print("Found in CL script cache: ", clInput.strip()[:20])
                 return pycode
         else:
             index = None
@@ -135,7 +135,7 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
     tree.filename = efilename
 
     # first pass -- get variables
-    vars = VarList(tree,mode,local_vars_list,local_vars_dict,parlist)
+    vars = VarList(tree, mode, local_vars_list, local_vars_dict, parlist)
 
     # check variable list for consistency with the given parlist
     # this may change the vars list
@@ -255,16 +255,16 @@ class FindLineNumber(GenericASTTraversal):
 
     class FoundIt(Exception): pass
 
-    def __init__(self,ast):
-        GenericASTTraversal.__init__(self,ast)
+    def __init__(self, ast):
+        GenericASTTraversal.__init__(self, ast)
         self.lineno = 0
         try:
             self.preorder()
         except self.FoundIt:
             pass
 
-    def default(self,node):
-        if hasattr(node,'lineno'):
+    def default(self, node):
+        if hasattr(node, 'lineno'):
             self.lineno = node.lineno
             raise self.FoundIt
 
@@ -282,14 +282,14 @@ class ErrorTracker:
         """Add error to the list with line number"""
 
         if not hasattr(self, 'errlist'): self._error_init()
-        self.errlist.append((self.getlineno(node),msg))
+        self.errlist.append((self.getlineno(node), msg))
 
     def warning(self, msg, node=None):
 
         """Add warning to the list with line number"""
 
         if not hasattr(self, 'errlist'): self._error_init()
-        self.warnlist.append((self.getlineno(node),"Warning: %s" % msg))
+        self.warnlist.append((self.getlineno(node), "Warning: %s" % msg))
 
     def comment(self, msg):
 
@@ -319,7 +319,7 @@ class ErrorTracker:
 
         """Print all warnings and errors and raise SyntaxError if errors were found"""
 
-        if not hasattr(self,'errlist'):
+        if not hasattr(self, 'errlist'):
             return
         if self.errlist:
             self.errlist.extend(self.warnlist)
@@ -757,7 +757,7 @@ class VarList(GenericASTTraversal, ErrorTracker):
 
         if 'mode' not in self.proc_args_dict:
             self.proc_args_list.append('mode')
-            self.proc_args_dict['mode'] = Variable('mode','string',
+            self.proc_args_dict['mode'] = Variable('mode', 'string',
                     init_value='al')
 
         self.addSpecial("$nargs", 'int', 0)
@@ -790,7 +790,7 @@ class VarList(GenericASTTraversal, ErrorTracker):
         for var in self.proc_args_list:
             v =  self.proc_args_dict[var]
             if var in _SpecialArgs:
-                print('Special',var,'=',v)
+                print('Special', var, '=', v)
             else:
                 print(v)
         print("Local variables:")
@@ -810,7 +810,7 @@ class VarList(GenericASTTraversal, ErrorTracker):
         for arg in self.proc_args_list:
             if arg in self.proc_args_dict:
                 errmsg = "Argument `%s' repeated in procedure statement %s" % \
-                        (arg,self.getProcName())
+                        (arg, self.getProcName())
                 self.error(errmsg, node)
             else:
                 self.proc_args_dict[arg] = None
@@ -878,7 +878,7 @@ _rfuncDict = {
             'bool':   'float',
             'unknown': 'float',
             'indef':  None},
-  'string':{'int':    'str',
+  'string': {'int':    'str',
             'float':  'str',
             'string': None,
             'bool':   'iraf.bool2str',
@@ -1191,7 +1191,7 @@ class GoToAnalyze(GenericASTTraversal, ErrorTracker):
             cblockid = self.current_blockid
             self.label_blockid[label] = cblockid
             # make sure all gotos for this label are in this or deeper blocks
-            for i in self.goto_blockidlist.get(label,[]):
+            for i in self.goto_blockidlist.get(label, []):
                 if self.blocks[i].blockid < cblockid:
                     self.error("GOTO branches to label `%s' in inner block"
                         % label, node)
@@ -1220,11 +1220,11 @@ _translateList = {
 # builtin task names that are translated
 
 _taskList = {
-            "print"         : "clPrint",
-            "_curpack"      : "curpack",
-            "_allocate"     : "clAllocate",
-            "_deallocate"   : "clDeallocate",
-            "_devstatus"    : "clDevstatus",
+            "print": "clPrint",
+            "_curpack": "curpack",
+            "_allocate": "clAllocate",
+            "_deallocate": "clDeallocate",
+            "_devstatus": "clDevstatus",
             }
 
 # builtin functions that are translated
@@ -1336,7 +1336,7 @@ def _convFunc(var, value):
     elif var.type == "int":
         if value is None or value == "INDEF":  # (matches _INDEFClass object)
             return "INDEF"
-        elif isinstance(value,str) and value[:1] == ")":
+        elif isinstance(value, str) and value[:1] == ")":
             # parameter indirection
             return value
         else:
@@ -1344,7 +1344,7 @@ def _convFunc(var, value):
     elif var.type == "real":
         if value is None or value == "INDEF":  # (matches _INDEFClass object)
             return "INDEF"
-        elif isinstance(value,str) and value[:1] == ")":
+        elif isinstance(value, str) and value[:1] == ")":
             # parameter indirection
             return value
         else:
@@ -1352,12 +1352,12 @@ def _convFunc(var, value):
     elif var.type == "bool":
         if value is None:
             return "INDEF"
-        elif isinstance(value, (int,float)):
+        elif isinstance(value, (int, float)):
             if value == 0:
                 return 'no'
             else:
                 return 'yes'
-        elif isinstance(value,str):
+        elif isinstance(value, str):
             s = value.lower()
             if s == "yes" or s == "y":
                 s = "yes"
@@ -1526,7 +1526,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
 
         # adjust all the line numbers up by the size of the header
         newmap = {}
-        for key,value in self._ecl_linemap.items():
+        for key, value in self._ecl_linemap.items():
             newmap[ key + lines ] = value
 
         # return a python assignment statement that initializes the dictionary
@@ -1831,7 +1831,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         self.prune()
 
     def n_param_name(self, node):
-        s = irafutils.translateName(node[0].attr,dot=1)
+        s = irafutils.translateName(node[0].attr, dot=1)
         self.write(s)
         self.prune()
 
@@ -1914,7 +1914,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
                 self.prune()
 
     def n_term(self, node):
-        if pyrafglobals._use_ecl and node[1] in ['/','%']:
+        if pyrafglobals._use_ecl and node[1] in ['/', '%']:
             kind = {"/":"divide", "%":"modulo"}[node[1]]
             self.write("taskObj._ecl_safe_%s(" % kind)
             self.preorder(node[0])
@@ -2406,7 +2406,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         if node[2].type == 'IDENT':
             s = irafutils.translateName(node[2].attr)
             v = self.vars.get(s)
-            if v and v.type in ['gcur','imcur']:
+            if v and v.type in ['gcur', 'imcur']:
                 # pass cursors by value
                 self.write('Vars.getParObject("'+s+'")')
                 self.prune()

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -1871,7 +1871,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
 
         # Add quotes to names (we're literally passing the names, not
         # the values)
-        sargs = map(repr, sargs)
+        sargs = list(map(repr, sargs))
 
         # pass in locals dictionary so we can get names of variables to set
         sargs.insert(0, "locals()")

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -4,7 +4,7 @@ $Id$
 
 R. White, 1999 December 20
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import cStringIO, os, sys
 
@@ -83,7 +83,7 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
                 index, pycode = codeCache.get(efilename,mode=mode)
                 if pycode is not None:
                     if Verbose>1:
-                        print efilename,"filename found in CL script cache"
+                        print(efilename,"filename found in CL script cache")
                     return pycode
             else:
                 index = None
@@ -96,7 +96,7 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
                 index, pycode = codeCache.get(filename,mode=mode,source=clInput)
                 if pycode is not None:
                     if Verbose>1:
-                        print filename,"filehandle found in CL script cache"
+                        print(filename,"filehandle found in CL script cache")
                     return pycode
             else:
                 index = None
@@ -115,7 +115,7 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
             index, pycode = codeCache.get(None,mode=mode,source=clInput)
             if pycode is not None:
                 if Verbose>3:
-                    print "Found in CL script cache: ",clInput.strip()[:20]
+                    print("Found in CL script cache: ",clInput.strip()[:20])
                 return pycode
         else:
             index = None
@@ -157,12 +157,12 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
     pycode.index = index
     if Verbose>1:
         if efilename == 'string_proc':
-            print >> sys.stderr, "Code-string compiled by cl2py:"
-            print >> sys.stderr, "-"*80
-            print >> sys.stderr, clInput
-            print >> sys.stderr, "-"*80
+            print("Code-string compiled by cl2py:", file=sys.stderr)
+            print("-"*80, file=sys.stderr)
+            print(clInput, file=sys.stderr)
+            print("-"*80, file=sys.stderr)
         else:
-            print >> sys.stderr, "Code-file compiled by cl2py:"+efilename
+            print("Code-file compiled by cl2py:"+efilename, file=sys.stderr)
     return pycode
 
 def checkCache(filename, pycode):
@@ -787,16 +787,16 @@ class VarList(GenericASTTraversal, ErrorTracker):
 
     def list(self):
         """List variables"""
-        print "Procedure arguments:"
+        print("Procedure arguments:")
         for var in self.proc_args_list:
             v =  self.proc_args_dict[var]
             if var in _SpecialArgs:
-                print 'Special',var,'=',v
+                print('Special',var,'=',v)
             else:
-                print v
-        print "Local variables:"
+                print(v)
+        print("Local variables:")
         for var in self.local_vars_list:
-            print self.local_vars_dict[var]
+            print(self.local_vars_dict[var])
 
     def getParList(self):
         """Return procedure arguments as IrafParList"""

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -487,8 +487,7 @@ class Variable:
             arglist.append("array_size=" + `self.shape`)
         if self.list_flag:
             arglist.append("list_flag=" + `self.list_flag`)
-        keylist = self.options.keys()
-        keylist.sort()
+        keylist = sorted(self.options.keys())
         for key in keylist:
             option = self.options[key]
             if option is not None:
@@ -1153,8 +1152,7 @@ class GoToAnalyze(GenericASTTraversal, ErrorTracker):
 
     def labels(self):
         """Get a list of known labels used in GOTOs"""
-        labels = self.goto_blockidlist.keys()
-        labels.sort()
+        labels = sorted(self.goto_blockidlist.keys())
         return labels
 
     def __contains__(self, key): return self._has(key)
@@ -1644,9 +1642,8 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         # write additional required imports
         wnewline = 0
         if not noHdr:
-            keylist = self.importDict.keys()
+            keylist = sorted(self.importDict.keys())
             if keylist:
-                keylist.sort()
                 self.writeIndent("import ")
                 self.write(", ".join(keylist))
                 wnewline = 1

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -76,8 +76,8 @@ def cl2py(filename=None, string=None, parlist=None, parfile="", mode="proc",
     if mode not in ["proc", "single"]:
         raise ValueError("Mode = `%s', must be `proc' or `single'" % (mode,))
 
-    if not filename in (None, ''):
-        if isinstance(filename,str):
+    if filename not in (None, ''):
+        if isinstance(filename, str):
             efilename = os.path.expanduser(filename)
             if usecache:
                 index, pycode = codeCache.get(efilename,mode=mode)

--- a/lib/pyraf/cl2py.py
+++ b/lib/pyraf/cl2py.py
@@ -459,7 +459,7 @@ class Variable:
             if self.init_value is None:
                 return name + "=None"
             else:
-                return name + "=" + `self.init_value`
+                return name + "=" + repr(self.init_value)
         else:
             # array
             arg = name + "=["
@@ -468,7 +468,7 @@ class Variable:
             else:
                 arglist = []
                 for iv in self.init_value:
-                    arglist.append(`iv`)
+                    arglist.append(repr(iv))
             return arg + ", ".join(arglist) + "]"
 
     def parDefLine(self, filename=None, strict=0, local=0):
@@ -476,24 +476,24 @@ class Variable:
 
         name = irafutils.translateName(self.name)
         arglist = [name,
-                "datatype=" + `self.type`,
-                "name=" + `self.getName()` ]
+                "datatype=" + repr(self.type),
+                "name=" + repr(self.getName()) ]
         # if local is set, use the default initial value instead of name
         # also set mode="u" for locals so they never prompt
         if local:
-            arglist[0] = `self.init_value`
+            arglist[0] = repr(self.init_value)
             self.options["mode"] = "u"
         if self.shape is not None:
-            arglist.append("array_size=" + `self.shape`)
+            arglist.append("array_size=" + repr(self.shape))
         if self.list_flag:
-            arglist.append("list_flag=" + `self.list_flag`)
+            arglist.append("list_flag=" + repr(self.list_flag))
         keylist = sorted(self.options.keys())
         for key in keylist:
             option = self.options[key]
             if option is not None:
-                arglist.append(key + "=" + `self.options[key]`)
-        if filename: arglist.append("filename=" + `filename`)
-        if strict: arglist.append("strict=" + `strict`)
+                arglist.append(key + "=" + repr(self.options[key]))
+        if filename: arglist.append("filename=" + repr(filename))
+        if strict: arglist.append("strict=" + repr(strict))
         return arglist
 
     def __repr__(self):
@@ -501,7 +501,7 @@ class Variable:
         if self.list_flag: s = s + "*"
         s = s + self.name
         if self.init_value is not None:
-            s = s + " = " + `self.init_value`
+            s = s + " = " + repr(self.init_value)
         optstring = "{"
         for key, value in self.options.items():
             if (value is not None) and (key != "mode" or value != "h"):
@@ -1666,7 +1666,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
             # add local and procedure parameters to Vars list
             if not noHdr:
                 self.writeIndent("Vars = IrafParList(" +
-                        `self.vars.proc_name` + ")")
+                        repr(self.vars.proc_name) + ")")
             for defargs in deflist:
                 if defargs:
                     self.writeIndent("Vars.addParam(makeIrafPar(")
@@ -1780,7 +1780,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
             else:
                 attribs.insert(0, 'iraf')
             if ipf:
-                attribs[-2] = 'getParObject(' + `attribs[-2]` +  ')'
+                attribs[-2] = 'getParObject(' + repr(attribs[-2]) +  ')'
             self.write(".".join(attribs),
                             node.requireType, node.exprType)
 
@@ -1893,17 +1893,17 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
             if s is not None:
                 self.write(s, requireType, exprType)
             elif node.type in _trailSpaceList:
-                self.write(`node`, requireType, exprType)
+                self.write(repr(node), requireType, exprType)
                 self.write(" ")
             elif node.type in _bothSpaceList:
                 self.write(" ")
                 if hasattr(node, 'trunc_int_div'):
                     self.write('//', requireType, exprType)
                 else:
-                    self.write(`node`, requireType, exprType)
+                    self.write(repr(node), requireType, exprType)
                 self.write(" ")
             else:
-                self.write(`node`, requireType, exprType)
+                self.write(repr(node), requireType, exprType)
         elif requireType != exprType:
             cf = _funcName(requireType, exprType)
             if cf is not None:
@@ -1971,7 +1971,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
     #------------------------------
 
     def n_osescape_stmt(self, node):
-        self.write("iraf.clOscmd(" + `node[0].attr` + ")")
+        self.write("iraf.clOscmd(" + repr(node[0].attr) + ")")
         self.prune()
 
     def n_assignment_stmt(self, node):

--- a/lib/pyraf/clast.py
+++ b/lib/pyraf/clast.py
@@ -2,7 +2,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 #  Copyright (c) 1998-1999 John Aycock
 #

--- a/lib/pyraf/clcache.py
+++ b/lib/pyraf/clcache.py
@@ -265,7 +265,7 @@ class _CodeCache:
                     "Filename parameter must be a string or IrafCLTask")
         index = self.getIndex(filename)
         # system cache is last in list
-        irange = range(len(self.cacheList))
+        irange = list(range(len(self.cacheList)))
         if self.useSystem: irange.reverse()
         nremoved = 0
         for i in irange:

--- a/lib/pyraf/clcache.py
+++ b/lib/pyraf/clcache.py
@@ -69,7 +69,7 @@ def _currentVersion():
 class _FileContentsCache(filecache.FileCacheDict):
     def __init__(self):
         # create file dictionary with md5 digest as value
-        filecache.FileCacheDict.__init__(self,filecache.MD5Cache)
+        filecache.FileCacheDict.__init__(self, filecache.MD5Cache)
 
 class _CodeCache:
 
@@ -123,7 +123,7 @@ class _CodeCache:
             except dirshelve.error:
                 # initial open failed -- try opening the cache read-only
                 try:
-                    fh = dirshelve.open(fname,"r")
+                    fh = dirshelve.open(fname, "r")
                     writeflag = 0
                 except dirshelve.error:
                     # give up on this file and try the next one
@@ -256,7 +256,7 @@ class _CodeCache:
         the Python code around.)
         """
 
-        if not isinstance(filename,str):
+        if not isinstance(filename, str):
             try:
                 task = filename
                 filename = task.getFullpath()
@@ -274,18 +274,18 @@ class _CodeCache:
                 if writeflag:
                     del cache[index]
                     self.warning("Removed %s from CL script cache %s" %
-                                 (filename,self.cacheFileList[i]), 2)
+                                 (filename, self.cacheFileList[i]), 2)
                     nremoved = nremoved+1
                 else:
                     self.warning("Cannot remove %s from read-only "
                                  "CL script cache %s" %
-                                 (filename,self.cacheFileList[i]))
+                                 (filename, self.cacheFileList[i]))
         if nremoved==0:
             self.warning("Did not find %s in CL script cache" % filename, 2)
 
 
 # create code cache
-userCacheDir = os.path.join(userIrafHome,'pyraf')
+userCacheDir = os.path.join(userIrafHome, 'pyraf')
 if not os.path.exists(userCacheDir):
     try:
         os.mkdir(userCacheDir)
@@ -299,9 +299,9 @@ dbfile = 'clcache'
 if DISABLE_CLCACHING:
     # since CL code caching is turned off currently for PY3K,
     # there won't be any installed there, but still play with user area
-    codeCache = _CodeCache([os.path.join(userCacheDir,dbfile),])
+    codeCache = _CodeCache([os.path.join(userCacheDir, dbfile),])
 else:
-    codeCache = _CodeCache([os.path.join(userCacheDir,dbfile),
-                            os.path.join(pyrafglobals.pyrafDir,dbfile)])
+    codeCache = _CodeCache([os.path.join(userCacheDir, dbfile),
+                            os.path.join(pyrafglobals.pyrafDir, dbfile)])
 
 del userCacheDir, dbfile

--- a/lib/pyraf/clcache.py
+++ b/lib/pyraf/clcache.py
@@ -4,7 +4,7 @@ $Id$
 
 R. White, 2000 January 19
 """
-from __future__ import division, print_function  # confidence high
+from __future__ import division, print_function
 
 import os
 import sys

--- a/lib/pyraf/cllinecache.py
+++ b/lib/pyraf/cllinecache.py
@@ -4,7 +4,7 @@ CL scripts have special filename "<CL script taskname>"
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import linecache, string, os, sys
 from stat import *

--- a/lib/pyraf/clparse.py
+++ b/lib/pyraf/clparse.py
@@ -383,7 +383,7 @@ class PrettyTree(GenericASTTraversal):
         self.nodeCount = 0
         self.preorder()
         print()
-        print(self.nodeCount,'total nodes in tree')
+        print(self.nodeCount, 'total nodes in tree')
 
     def n_NEWLINE(self, node):
         self.nodeCount = self.nodeCount + 1
@@ -396,7 +396,7 @@ class PrettyTree(GenericASTTraversal):
 
     def n_compound_stmt_exit(self, node):
         self.indent = self.indent - 1
-        self.printIndentNode(node,tail='_exit')
+        self.printIndentNode(node, tail='_exit')
         # self.default(node,tail='_exit')
 
     def n_declaration_block(self, node):
@@ -407,7 +407,7 @@ class PrettyTree(GenericASTTraversal):
 
     def n_declaration_block_exit(self, node):
         self.indent = self.indent + 1
-        self.default(node,tail='_exit')
+        self.default(node, tail='_exit')
         print()
 
     def n_BEGIN(self, node):
@@ -443,7 +443,7 @@ class PrettyTree(GenericASTTraversal):
 
     def printIndentNode(self, node, tail=''):
         self.printIndent()
-        self.default(node,tail=tail)
+        self.default(node, tail=tail)
 
     def default(self, node, tail=''):
         if node.type == '}':
@@ -474,7 +474,7 @@ class TreeList(GenericASTTraversal):
             print(node, end=' ')
 
 def treelist(ast,terminal=1):
-    PrettyTree(ast,terminal)
+    PrettyTree(ast, terminal)
 
 def getParser():
     import pyrafglobals

--- a/lib/pyraf/clparse.py
+++ b/lib/pyraf/clparse.py
@@ -4,7 +4,7 @@ $Id$
 
 R. White, 1999 August 24
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from generic import GenericASTBuilder, GenericASTTraversal
 from clast import AST
@@ -382,8 +382,8 @@ class PrettyTree(GenericASTTraversal):
         self.indent = 0
         self.nodeCount = 0
         self.preorder()
-        print
-        print self.nodeCount,'total nodes in tree'
+        print()
+        print(self.nodeCount,'total nodes in tree')
 
     def n_NEWLINE(self, node):
         self.nodeCount = self.nodeCount + 1
@@ -408,7 +408,7 @@ class PrettyTree(GenericASTTraversal):
     def n_declaration_block_exit(self, node):
         self.indent = self.indent + 1
         self.default(node,tail='_exit')
-        print
+        print()
 
     def n_BEGIN(self, node):
         self.printIndentNode(node)
@@ -435,9 +435,9 @@ class PrettyTree(GenericASTTraversal):
     # print newline and indent
 
     def printIndent(self):
-        print '\n',
+        print('\n', end=' ')
         for i in range(self.indent):
-            print '   ',
+            print('   ', end=' ')
 
     # print newline, indent, and token
 
@@ -449,7 +449,7 @@ class PrettyTree(GenericASTTraversal):
         if node.type == '}':
             self.printIndent()
         if isinstance(node, Token) or (not self.terminal):
-            print `node`+tail,
+            print(`node`+tail, end=' ')
         self.nodeCount = self.nodeCount + 1
 
 
@@ -469,9 +469,9 @@ class TreeList(GenericASTTraversal):
 
     def default(self, node):
         if node.type == 'NEWLINE':
-            print '\n' + self.indent,
+            print('\n' + self.indent, end=' ')
         elif isinstance(node, Token) or (not self.terminal):
-            print node,
+            print(node, end=' ')
 
 def treelist(ast,terminal=1):
     PrettyTree(ast,terminal)

--- a/lib/pyraf/clparse.py
+++ b/lib/pyraf/clparse.py
@@ -323,7 +323,7 @@ class CLStrictParser(GenericASTBuilder):
         # one child, but retain a few primary structural
         # elements.
         #
-        if len(args) == 1 and not atype in self.primaryTypes:
+        if len(args) == 1 and atype not in self.primaryTypes:
             return args[0]
         return GenericASTBuilder.nonterminal(self, atype, args)
 

--- a/lib/pyraf/clparse.py
+++ b/lib/pyraf/clparse.py
@@ -449,7 +449,7 @@ class PrettyTree(GenericASTTraversal):
         if node.type == '}':
             self.printIndent()
         if isinstance(node, Token) or (not self.terminal):
-            print(`node`+tail, end=' ')
+            print(repr(node)+tail, end=' ')
         self.nodeCount = self.nodeCount + 1
 
 

--- a/lib/pyraf/clscan.py
+++ b/lib/pyraf/clscan.py
@@ -982,7 +982,7 @@ def toklist(tlist,filename=None):
             else:
                 print()
         else:
-            print(`tok`, end=' ')
+            print(repr(tok), end=' ')
     if filename:
         sys.stdout.close()
         sys.stdout = sys.__stdout__

--- a/lib/pyraf/clscan.py
+++ b/lib/pyraf/clscan.py
@@ -6,7 +6,7 @@ $Id$
 
 R. White, 1999 September 10
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from cgeneric import ContextSensitiveScanner
 from generic import GenericScanner
@@ -978,11 +978,11 @@ def toklist(tlist,filename=None):
     for tok in tlist:
         if tok.type == 'NEWLINE':
             if cltoken.verbose:
-                print 'NEWLINE'
+                print('NEWLINE')
             else:
-                print
+                print()
         else:
-            print `tok`,
+            print(`tok`, end=' ')
     if filename:
         sys.stdout.close()
         sys.stdout = sys.__stdout__

--- a/lib/pyraf/clscan.py
+++ b/lib/pyraf/clscan.py
@@ -173,10 +173,10 @@ class _BasicScanner_3:
 
         nline = _countNewlines(s)
         # Recognize and remove any embedded comments
-        s = comment_pat.sub('',s)
+        s = comment_pat.sub('', s)
 
         s = filterEscapes(irafutils.removeEscapes(
-                     irafutils.stripQuotes(s),quoted=1))
+                     irafutils.stripQuotes(s), quoted=1))
         # We use a different type for quoted strings to protect them
         # against conversion to other token types by enterComputeEqnMode
         parent.addToken(type='QSTRING', attr=s)
@@ -191,10 +191,10 @@ class _BasicScanner_3:
         nline = _countNewlines(s)
 
         # Recognize and remove any embedded comments
-        s = comment_pat.sub('',s)
+        s = comment_pat.sub('', s)
 
         s = filterEscapes(irafutils.removeEscapes(
-                     irafutils.stripQuotes(s),quoted=1))
+                     irafutils.stripQuotes(s), quoted=1))
         parent.addToken(type='QSTRING', attr=s)
         parent.lineno = parent.lineno + nline
 
@@ -247,16 +247,16 @@ class _StartScanner_1(_BasicScanner_1):
     def t_help(self, s, m, parent):
         r'\?\??'
         if len(s) == 2:
-            parent.addIdent('allPkgHelp',mode=parent.default_mode)
+            parent.addIdent('allPkgHelp', mode=parent.default_mode)
         else:
-            parent.addIdent('pkgHelp',mode=parent.default_mode)
+            parent.addIdent('pkgHelp', mode=parent.default_mode)
 
 
-class _StrictStartScanner(_BasicScanner_3,_BasicScanner_2,_StartScanner_1):
+class _StrictStartScanner(_BasicScanner_3, _BasicScanner_2, _StartScanner_1):
     """Strict scanner class for tokens recognized in start-line mode"""
     pass
 
-class _StartScanner(_LaxScanner,_StrictStartScanner):
+class _StartScanner(_LaxScanner, _StrictStartScanner):
     """Scanner class for tokens recognized in start-line mode"""
     pass
 
@@ -279,7 +279,7 @@ class _CommandScanner_1(_BasicScanner_1):
         # since IRAF doesn't deal with special characters in this mode.
         # Thus PyRAF should leave them as literal backslashes within its
         # strings. Why IRAF does this I have no idea.
-        s = irafutils.removeEscapes(s).replace('\\','\\\\')
+        s = irafutils.removeEscapes(s).replace('\\', '\\\\')
         parent.addToken(type='STRING', attr=s)
         parent.lineno = parent.lineno + nline
 
@@ -301,7 +301,7 @@ class _CommandScanner_1(_BasicScanner_1):
         parent.current.append(_ACCEPT_REDIR_MODE)
 
 
-class _CommandScanner_2(_BasicScanner_2,_CommandScanner_1):
+class _CommandScanner_2(_BasicScanner_2, _CommandScanner_1):
 
     def t_keyval(self, s, m, parent):
         r'(?P<KeyName>[a-zA-Z\$_\d][a-zA-Z\$_\d.]*) [ \t]* =(?!=)'
@@ -338,11 +338,11 @@ class _CommandScanner_2(_BasicScanner_2,_CommandScanner_1):
         if s == '=':
             parent.addToken(type=s)
         else:
-            parent.addToken(type='ASSIGNOP',attr=s)
+            parent.addToken(type='ASSIGNOP', attr=s)
         parent.current.append(_COMPUTE_MODE)
 
 
-class _StrictCommandScanner(_BasicScanner_3,_CommandScanner_2):
+class _StrictCommandScanner(_BasicScanner_3, _CommandScanner_2):
 
     """Strict scanner class for tokens recognized in command mode"""
 
@@ -359,7 +359,7 @@ class _StrictCommandScanner(_BasicScanner_3,_CommandScanner_2):
         parent.current.append(_SWALLOW_NEWLINE_MODE)
 
 
-class _CommandScanner(_LaxScanner,_StrictCommandScanner):
+class _CommandScanner(_LaxScanner, _StrictCommandScanner):
     """Scanner class for tokens recognized in command mode"""
     pass
 
@@ -415,7 +415,7 @@ class _ComputeStartScanner_1(_BasicScanner_1):
         parent.current.append(_SWALLOW_NEWLINE_MODE)
 
 
-class _ComputeStartScanner_2(_BasicScanner_2,_ComputeStartScanner_1):
+class _ComputeStartScanner_2(_BasicScanner_2, _ComputeStartScanner_1):
 
     def t_keyval(self, s, m, parent):
         r'(?P<KeyName>[a-zA-Z\$_][a-zA-Z\$_\d.]*) [ \t]* =(?!=)'
@@ -438,7 +438,7 @@ class _ComputeStartScanner_2(_BasicScanner_2,_ComputeStartScanner_1):
         if s == '=':
             parent.addToken(type=s)
         else:
-            parent.addToken(type='ASSIGNOP',attr=s)
+            parent.addToken(type='ASSIGNOP', attr=s)
         parent.current.append(_COMPUTE_MODE)
 
     def t_redir(self, s, m, parent):
@@ -459,13 +459,13 @@ class _ComputeStartScanner_2(_BasicScanner_2,_ComputeStartScanner_1):
         r'(\d+[eEdD][+\-]?\d+) | (((\d*\.\d+)|(\d+\.\d*))([eEdD][+\-]?\d+)?)'
         parent.addToken(type='FLOAT', attr=s)
 
-class _StrictComputeStartScanner(_BasicScanner_3,_ComputeStartScanner_2):
+class _StrictComputeStartScanner(_BasicScanner_3, _ComputeStartScanner_2):
     """Strict scanner class for tokens recognized in initial compute mode
     (similar to command mode)
     """
     pass
 
-class _ComputeStartScanner(_LaxScanner,_StrictComputeStartScanner):
+class _ComputeStartScanner(_LaxScanner, _StrictComputeStartScanner):
     """Scanner class for tokens recognized in initial compute mode
     (similar to command mode)
     """
@@ -499,7 +499,7 @@ class _ComputeEqnScanner_1(_BasicScanner_1):
         r'\|\||&&|!'
         # split '!' off separately
         if len(s) > 1:
-            parent.addToken(type='LOGOP',attr=s)
+            parent.addToken(type='LOGOP', attr=s)
         else:
             parent.addToken(type=s)
         parent.current.append(_SWALLOW_NEWLINE_MODE)
@@ -523,7 +523,7 @@ class _ComputeEqnScanner_1(_BasicScanner_1):
         parent.current.append(_SWALLOW_NEWLINE_MODE)
 
 
-class _ComputeEqnScanner_2(_BasicScanner_2,_ComputeEqnScanner_1):
+class _ComputeEqnScanner_2(_BasicScanner_2, _ComputeEqnScanner_1):
 
     def t_keyval(self, s, m, parent):
         r'(?P<KeyName>[a-zA-Z\$_][a-zA-Z\$_\d.]*) [ \t]* =(?!=)'
@@ -547,7 +547,7 @@ class _ComputeEqnScanner_2(_BasicScanner_2,_ComputeEqnScanner_1):
 
     def t_assignop(self, s, m, parent):
         r'( [+\-*/] | // ) ='
-        parent.addToken(type='ASSIGNOP',attr=s)
+        parent.addToken(type='ASSIGNOP', attr=s)
         # switch to compute mode
         parent.current[-1] = _COMPUTE_MODE
 
@@ -556,16 +556,16 @@ class _ComputeEqnScanner_2(_BasicScanner_2,_ComputeEqnScanner_1):
         parent.addToken(type='FLOAT', attr=s)
 
 
-class _StrictComputeEqnScanner(_BasicScanner_3,_ComputeEqnScanner_2):
+class _StrictComputeEqnScanner(_BasicScanner_3, _ComputeEqnScanner_2):
 
     """Strict scanner class for tokens recognized in compute equation mode"""
 
     def t_compop(self, s, m, parent):
         r'[<>!=]=|<|>'
-        parent.addToken(type='COMPOP',attr=s)
+        parent.addToken(type='COMPOP', attr=s)
         parent.current.append(_SWALLOW_NEWLINE_MODE)
 
-class _ComputeEqnScanner(_LaxScanner,_StrictComputeEqnScanner):
+class _ComputeEqnScanner(_LaxScanner, _StrictComputeEqnScanner):
     """Scanner class for tokens recognized in compute mode"""
     pass
 
@@ -596,7 +596,7 @@ class _ComputeScanner_1(_BasicScanner_1):
         r'\|\||&&|!'
         # split '!' off separately
         if len(s) > 1:
-            parent.addToken(type='LOGOP',attr=s)
+            parent.addToken(type='LOGOP', attr=s)
         else:
             parent.addToken(type=s)
         parent.current.append(_SWALLOW_NEWLINE_MODE)
@@ -618,7 +618,7 @@ class _ComputeScanner_1(_BasicScanner_1):
         parent.current.append(_SWALLOW_NEWLINE_MODE)
 
 
-class _ComputeScanner_2(_BasicScanner_2,_ComputeScanner_1):
+class _ComputeScanner_2(_BasicScanner_2, _ComputeScanner_1):
 
     def t_keyval(self, s, m, parent):
         r'(?P<KeyName>[a-zA-Z\$_][a-zA-Z\$_\d.]*) [ \t]* =(?!=)'
@@ -642,23 +642,23 @@ class _ComputeScanner_2(_BasicScanner_2,_ComputeScanner_1):
 
     def t_assignop(self, s, m, parent):
         r'( [+\-*/] | // ) ='
-        parent.addToken(type='ASSIGNOP',attr=s)
+        parent.addToken(type='ASSIGNOP', attr=s)
 
     def t_float(self, s, m, parent):
         r'(\d+[eEdD][+\-]?\d+) | (((\d*\.\d+)|(\d+\.\d*))([eEdD][+\-]?\d+)?)'
         parent.addToken(type='FLOAT', attr=s)
 
 
-class _StrictComputeScanner(_BasicScanner_3,_ComputeScanner_2):
+class _StrictComputeScanner(_BasicScanner_3, _ComputeScanner_2):
 
     """Strict scanner class for tokens recognized in compute mode"""
 
     def t_compop(self, s, m, parent):
         r'[<>!=]=|<|>'
-        parent.addToken(type='COMPOP',attr=s)
+        parent.addToken(type='COMPOP', attr=s)
         parent.current.append(_SWALLOW_NEWLINE_MODE)
 
-class _ComputeScanner(_LaxScanner,_StrictComputeScanner):
+class _ComputeScanner(_LaxScanner, _StrictComputeScanner):
     """Scanner class for tokens recognized in compute mode"""
     pass
 
@@ -689,7 +689,7 @@ _SwallowNewlineScanner = _StrictSwallowNewlineScanner
 #                     redirection is allowed
 #---------------------------------------------------------------------
 
-class _StrictAcceptRedirScanner(_BasicScanner_3,_BasicScanner_2,
+class _StrictAcceptRedirScanner(_BasicScanner_3, _BasicScanner_2,
                                                                 _BasicScanner_1):
 
     """Strict scanner class where redirection is allowed"""
@@ -717,7 +717,7 @@ class _StrictAcceptRedirScanner(_BasicScanner_3,_BasicScanner_2,
         del parent.current[-1]
 
 
-class _AcceptRedirScanner(_LaxScanner,_StrictAcceptRedirScanner):
+class _AcceptRedirScanner(_LaxScanner, _StrictAcceptRedirScanner):
     """Scanner class where redirection is allowed"""
     pass
 
@@ -922,7 +922,7 @@ class CLScanner(ContextSensitiveScanner):
 
         else:
 
-            self.addToken(type='IDENT',attr=name)
+            self.addToken(type='IDENT', attr=name)
             if mode is not None: self.current.append(mode)
 
     def enterComputeEqnMode(self):
@@ -974,7 +974,7 @@ def toklist(tlist,filename=None):
     import cltoken
     if filename:
         import sys
-        sys.stdout = open(filename,'w')
+        sys.stdout = open(filename, 'w')
     for tok in tlist:
         if tok.type == 'NEWLINE':
             if cltoken.verbose:

--- a/lib/pyraf/cltoken.py
+++ b/lib/pyraf/cltoken.py
@@ -80,7 +80,7 @@ class Token(compmixin.ComparableMixin):
                 return rv
 
     def __getitem__(self, i):
-        raise IndexError
+        raise IndexError()
 
     def __len__(self):
         return 0

--- a/lib/pyraf/cltoken.py
+++ b/lib/pyraf/cltoken.py
@@ -2,7 +2,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 #  Copyright (c) 1998-1999 John Aycock
 #
@@ -123,7 +123,7 @@ class Token(compmixin.ComparableMixin):
                 else:
                     return _str2int(self.attr)
             except Exception as e:
-                print 'Exception', str(e)
+                print('Exception', str(e))
                 pass
         raise ValueError("Cannot convert " +
                 self.verboseRepr() + " to int")

--- a/lib/pyraf/cltoken.py
+++ b/lib/pyraf/cltoken.py
@@ -122,7 +122,7 @@ class Token(compmixin.ComparableMixin):
                     return self.attr
                 else:
                     return _str2int(self.attr)
-            except Exception, e:
+            except Exception as e:
                 print 'Exception', str(e)
                 pass
         raise ValueError("Cannot convert " +

--- a/lib/pyraf/cltoken.py
+++ b/lib/pyraf/cltoken.py
@@ -73,7 +73,7 @@ class Token(compmixin.ComparableMixin):
             if self.type in ["STRING", "QSTRING"]:
                 # add quotes to strings
                 # but replace double escapes with single escapes
-                return repr(self.attr).replace('\\\\','\\')
+                return repr(self.attr).replace('\\\\', '\\')
             else:
                 rv = self.attr
                 if rv is None: rv = self.type
@@ -91,7 +91,7 @@ class Token(compmixin.ComparableMixin):
             return self.__int__()
         elif self.type == "FLOAT":
             return self.__float__()
-        elif self.type in ["STRING","QSTRING"]:
+        elif self.type in ["STRING", "QSTRING"]:
             return self.attr
         elif self.type == "BOOL":
             return self.bool()

--- a/lib/pyraf/describe.py
+++ b/lib/pyraf/describe.py
@@ -109,7 +109,7 @@ def describe(func, name = None):
     a = describeParams(func)
     args = []
     for arg in a:
-        if type(arg) == type(""):
+        if isinstance(arg, type("")):
             args.append(arg)
         else:
             args.append("%s=%s" % (arg[0], repr(arg[1])))
@@ -126,7 +126,7 @@ def describe(func, name = None):
 
 def __getmethods(c, m):
     for k, v in c.__dict__.items():
-        if type(v) == type(__getmethods): # and k[0] != "_":
+        if isinstance(v, type(__getmethods)): # and k[0] != "_":
             if k not in m:
                 m[k] = describe(v, k), c.__name__
     for c in c.__bases__:

--- a/lib/pyraf/describe.py
+++ b/lib/pyraf/describe.py
@@ -22,7 +22,7 @@
 # http://www.pythonware.com
 #
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from dis import opname, HAVE_ARGUMENT
 

--- a/lib/pyraf/describe.py
+++ b/lib/pyraf/describe.py
@@ -61,7 +61,7 @@ CO_VARKEYWORDS = 0x0008
 def describeParams(func, name = None):
     # get argument list
 
-    code = func.func_code
+    code = func.__code__
 
     n = code.co_argcount
     a = list(code.co_varnames[:n])
@@ -86,10 +86,10 @@ def describeParams(func, name = None):
                     p = p + 1
             if vars:
                 a[i] = "(" + ", ".join(vars) + ")"
-    if func.func_defaults:
+    if func.__defaults__:
         # defaults
-        i = n - len(func.func_defaults)
-        for d in func.func_defaults:
+        i = n - len(func.__defaults__)
+        for d in func.__defaults__:
             a[i] = (a[i], d)
             i = i + 1
     if code.co_flags & CO_VARARGS:

--- a/lib/pyraf/dirdbm.py
+++ b/lib/pyraf/dirdbm.py
@@ -50,7 +50,7 @@ class _Database(object):
         elif self._writable:
             # make sure directory is writable
             try:
-                testfile = _os.path.join(directory, 'junk' + `_os.getpid()`)
+                testfile = _os.path.join(directory, 'junk' + repr(_os.getpid()))
                 fh = __builtin__.open(testfile, 'w')
                 fh.close()
                 _os.remove(testfile)

--- a/lib/pyraf/dirdbm.py
+++ b/lib/pyraf/dirdbm.py
@@ -41,7 +41,7 @@ class _Database(object):
                 # create directory if it doesn't exist
                 try:
                     _os.mkdir(directory)
-                except OSError, e:
+                except OSError as e:
                     raise IOError(str(e))
             else:
                 raise IOError("Directory "+directory+" does not exist")
@@ -54,7 +54,7 @@ class _Database(object):
                 fh = __builtin__.open(testfile, 'w')
                 fh.close()
                 _os.remove(testfile)
-            except IOError, e:
+            except IOError as e:
                 raise IOError("Directory %s cannot be opened for writing" %
                         (directory,))
         # initialize dictionary
@@ -106,7 +106,7 @@ class _Database(object):
                 fh = __builtin__.open(fname,'wb')
                 fh.write(value)
                 fh.close()
-            except IOError, e:
+            except IOError as e:
                 # clean up on IO error (e.g., if disk fills up)
                 try:
                     if _os.path.exists(fname):

--- a/lib/pyraf/dirdbm.py
+++ b/lib/pyraf/dirdbm.py
@@ -13,7 +13,7 @@ XXX keys, len are incomplete if directory is not writable?
 R. White, 2000 September 26
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, binascii, string, __builtin__
 _os = os

--- a/lib/pyraf/dirdbm.py
+++ b/lib/pyraf/dirdbm.py
@@ -35,7 +35,7 @@ class _Database(object):
     def __init__(self, directory, flag='c'):
         self._directory = directory
         self._dict = {}
-        self._writable = flag in ['w','c']
+        self._writable = flag in ['w', 'c']
         if not _os.path.exists(directory):
             if flag == 'c':
                 # create directory if it doesn't exist
@@ -88,7 +88,7 @@ class _Database(object):
         # look for file even if dict doesn't have key because
         # another process could create it
         try:
-            fh = __builtin__.open(self._getFilename(key),'rb')
+            fh = __builtin__.open(self._getFilename(key), 'rb')
             value = fh.read()
             fh.close()
             # cache object in memory
@@ -103,7 +103,7 @@ class _Database(object):
         if self._writable:
             try:
                 fname = self._getFilename(key)
-                fh = __builtin__.open(fname,'wb')
+                fh = __builtin__.open(fname, 'wb')
                 fh.write(value)
                 fh.close()
             except IOError as e:

--- a/lib/pyraf/dirshelve.py
+++ b/lib/pyraf/dirshelve.py
@@ -37,7 +37,7 @@ class Shelf(shelve.Shelf):
             # and exception
             del self.dict[key]
             raise KeyError("Corrupted or truncated file for key %s "
-                    "(bad file has been deleted)" % (`key`,))
+                    "(bad file has been deleted)" % (repr(key),))
 
     def __setitem__(self, key, value):
         f = shelve.StringIO()

--- a/lib/pyraf/dirshelve.py
+++ b/lib/pyraf/dirshelve.py
@@ -77,7 +77,7 @@ def open(filename, flag='c'):
     if PY3K:
         try:
             return shelve.DbfilenameShelf(filename, flag)
-        except Exception, ex: # is dbm.error
+        except Exception as ex: # is dbm.error
             raise dirdbm.error(str(ex))
     else:
        return DirectoryShelf(filename, flag)

--- a/lib/pyraf/dirshelve.py
+++ b/lib/pyraf/dirshelve.py
@@ -12,7 +12,7 @@ XXX by another process after open
 R. White, 2000 Sept 26
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import shelve, sys
 from stsci.tools.for2to3 import PY3K

--- a/lib/pyraf/dirshelve.py
+++ b/lib/pyraf/dirshelve.py
@@ -41,12 +41,12 @@ class Shelf(shelve.Shelf):
 
     def __setitem__(self, key, value):
         f = shelve.StringIO()
-        p = shelve.Pickler(f,1)
+        p = shelve.Pickler(f, 1)
         p.dump(value)
         self.dict[key] = f.getvalue()
 
     def close(self):
-        if hasattr(self,'dict') and hasattr(self.dict,'close'):
+        if hasattr(self, 'dict') and hasattr(self.dict, 'close'):
             try:
                 self.dict.close()
             except:

--- a/lib/pyraf/epar.py
+++ b/lib/pyraf/epar.py
@@ -4,7 +4,7 @@ $Id$
 
 M.D. De La Pena, 2000 February 04
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from stsci.tools import capable
 if capable.OF_GRAPHICS:

--- a/lib/pyraf/epar.py
+++ b/lib/pyraf/epar.py
@@ -198,7 +198,7 @@ class PyrafEparDialog(editpar.EditParDialog):
         # Skip the save if the thing being edited is an IrafParList without
         # an associated file (in which case the changes are just being
         # made in memory.)
-        if isinstance(self._taskParsObj,irafpar.IrafParList) and \
+        if isinstance(self._taskParsObj, irafpar.IrafParList) and \
            not self._taskParsObj.getFilename():
             return '' # skip it
         else:
@@ -285,7 +285,7 @@ class PyrafEparDialog(editpar.EditParDialog):
         """ Return a string to be used as the filter arg to the save file
             dialog during Save-As. """
         filt = '*.par'
-        upx = iraf.envget("uparm_aux","")
+        upx = iraf.envget("uparm_aux", "")
         if 'UPARM_AUX' in os.environ: upx = os.environ['UPARM_AUX']
         if len(upx) > 0:  filt = iraf.Expand(upx)+"/*.par"
         return filt

--- a/lib/pyraf/filecache.py
+++ b/lib/pyraf/filecache.py
@@ -178,7 +178,7 @@ class FileCacheDict:
     def add(self, filename):
         """Add filename to dictionary.  Does not overwrite existing entry."""
         abspath = self.abspath(filename)
-        if not abspath in self.data:
+        if abspath not in self.data:
             self.data[abspath] = self.__Class(abspath)
 
     def abspath(self, filename):

--- a/lib/pyraf/filecache.py
+++ b/lib/pyraf/filecache.py
@@ -28,7 +28,7 @@ $Id$
 
 R. White, 2000 October 1
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, stat, sys, hashlib
 from stsci.tools.for2to3 import PY3K

--- a/lib/pyraf/filecache.py
+++ b/lib/pyraf/filecache.py
@@ -100,7 +100,7 @@ class FileCache:
 
         if filename==None:
             filename = self.filename
-        if isinstance(filename,str):
+        if isinstance(filename, str):
             fh = open(filename, 'r')
         elif hasattr(filename, 'read'):
             fh = filename
@@ -119,7 +119,7 @@ class FileCache:
             filename = self.filename
         if not filename:
             return None
-        elif isinstance(filename,str):
+        elif isinstance(filename, str):
             st = os.stat(filename)
         elif hasattr(filename, 'fileno') and hasattr(filename, 'name'):
             fh = filename
@@ -182,7 +182,7 @@ class FileCacheDict:
             self.data[abspath] = self.__Class(abspath)
 
     def abspath(self, filename):
-        if isinstance(filename,str):
+        if isinstance(filename, str):
             return os.path.abspath(filename)
         elif hasattr(filename, 'name') and hasattr(filename, 'read'):
             return os.path.abspath(filename.name)

--- a/lib/pyraf/fontdata.py
+++ b/lib/pyraf/fontdata.py
@@ -2,7 +2,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from numpy import *
 

--- a/lib/pyraf/fontdata.py
+++ b/lib/pyraf/fontdata.py
@@ -7,218 +7,218 @@ from __future__ import division, print_function
 from numpy import *
 
 font1 = [([], []), (
-   [array([10, 10],dtype=int8), array([ 9,  9, 11, 11,  9, 11],dtype=int8)],
-   [array([35, 16],dtype=int8), array([9, 7, 7, 9, 9, 7],dtype=int8)]), (
-   [array([5, 5],dtype=int8), array([5, 5],dtype=int8),
-        array([14, 14],dtype=int8), array([14, 14],dtype=int8)],
-   [array([35, 31],dtype=int8), array([31, 35],dtype=int8),
-        array([35, 31],dtype=int8), array([31, 35],dtype=int8)]), (
-   [array([9, 6],dtype=int8), array([13, 16],dtype=int8),
-        array([20,  3],dtype=int8), array([ 2, 18],dtype=int8)],
-   [array([27, 10],dtype=int8), array([10, 27],dtype=int8),
-        array([22, 22],dtype=int8), array([15, 15],dtype=int8)]), (
-   [array([9, 9],dtype=int8),
-        array([ 1,  5, 13, 17, 17, 13,  5,  1,  1,  5, 13, 17],dtype=int8)],
-   [array([35,  8],dtype=int8),
-        array([14, 10, 10, 13, 18, 22, 22, 25, 29, 33, 33, 29],dtype=int8)]), (
-   [array([6, 3, 1, 1, 3, 6, 8, 8, 6],dtype=int8),
-        array([18,  1],dtype=int8), array([11, 11, 13, 16, 18, 18, 16, 13, 11],dtype=int8)],
-   [array([35, 35, 33, 30, 28, 28, 30, 33, 35],dtype=int8),
-        array([35,  8],dtype=int8),
-        array([13, 10,  8,  8, 10, 13, 15, 15, 13],dtype=int8)]), (
-   [array([18,  3,  3,  5,  8, 10, 10,  1,  1,  4, 11, 18],dtype=int8)],
-   [array([ 8, 28, 32, 35, 35, 32, 29, 17, 12,  8,  8, 17],dtype=int8)]), (
-   [array([ 9,  8,  9, 10,  9],dtype=int8)],
-   [array([35, 31, 31, 35, 35],dtype=int8)]), (
-   [array([11,  9,  8,  8,  9, 11],dtype=int8)],
-   [array([35, 31, 26, 17, 12,  8],dtype=int8)]), (
-   [array([ 8, 10, 11, 11, 10,  8],dtype=int8)],
-   [array([35, 31, 26, 17, 12,  8],dtype=int8)]), (
-   [array([ 1, 17],dtype=int8), array([9, 9],dtype=int8), array([ 1, 17],dtype=int8)],
-   [array([29, 14],dtype=int8), array([32, 11],dtype=int8), array([14, 29],dtype=int8)]), (
-   [array([9, 9],dtype=int8), array([ 1, 17],dtype=int8)],
-   [array([28, 12],dtype=int8), array([20, 20],dtype=int8)]), (
-   [array([8, 9, 9, 8, 8, 9],dtype=int8)],
-   [array([4, 6, 9, 9, 8, 8],dtype=int8)]), (
-   [array([ 1, 17],dtype=int8)],
-   [array([20, 20],dtype=int8)]), (
-   [array([ 9,  9, 11, 11,  9, 11],dtype=int8)],
-   [array([9, 7, 7, 9, 9, 7],dtype=int8)]), (
-   [array([ 1, 18],dtype=int8)],
-   [array([ 8, 35],dtype=int8)]), (
-   [array([ 6,  1,  1,  6, 13, 18, 18, 13,  6],dtype=int8)],
-   [array([35, 29, 14,  8,  8, 14, 29, 35, 35],dtype=int8)]), (
-   [array([ 3, 10, 10],dtype=int8)],
-   [array([29, 35,  8],dtype=int8)]), (
-   [array([ 1,  5, 14, 18, 18,  1,  1, 18],dtype=int8)],
-   [array([31, 35, 35, 31, 23, 12,  8,  8],dtype=int8)]), (
-   [array([ 1,  6, 13, 18, 18, 13,  9],dtype=int8),
-        array([13, 18, 18, 13,  6,  1],dtype=int8)],
-   [array([31, 35, 35, 31, 26, 22, 22],dtype=int8),
-        array([22, 18, 12,  8,  8, 13],dtype=int8)]), (
-   [array([14, 14, 12,  1,  1, 14],dtype=int8), array([14, 18],dtype=int8)],
-   [array([ 8, 35, 35, 17, 15, 15],dtype=int8), array([15, 15],dtype=int8)]), (
-   [array([ 2, 13, 18, 18, 13,  6,  1,  1, 18],dtype=int8)],
-   [array([ 8,  8, 13, 20, 25, 25, 21, 35, 35],dtype=int8)]), (
-   [array([ 1,  6, 13, 18, 18, 13,  6,  1,  1,  2, 10],dtype=int8)],
-   [array([19, 24, 24, 19, 13,  8,  8, 13, 19, 27, 35],dtype=int8)]), (
-   [array([ 1, 18,  6],dtype=int8)],
-   [array([35, 35,  8],dtype=int8)]), (
-   [array([ 5,  1,  1,  5,  1,  1,  5, 14, 18, 18, 14,  5],dtype=int8),
-        array([14, 18, 18, 14,  5],dtype=int8)],
-   [array([35, 31, 26, 22, 18, 12,  8,  8, 12, 18, 22, 22],dtype=int8),
-        array([22, 26, 31, 35, 35],dtype=int8)]), (
-   [array([10, 17, 18, 18, 13,  6,  1,  1,  6, 13, 18],dtype=int8)],
-   [array([ 8, 16, 24, 30, 35, 35, 30, 24, 19, 19, 24],dtype=int8)]), (
-   [array([ 9, 11, 11,  9,  9, 11],dtype=int8), array([ 9,  9, 11, 11,  9, 11],dtype=int8)],
-   [array([26, 26, 23, 23, 26, 23],dtype=int8),
-        array([16, 13, 13, 16, 16, 13],dtype=int8)]), (
-   [array([ 9, 10, 10,  9,  9, 10],dtype=int8), array([ 9, 10, 10,  9,  9, 10],dtype=int8)],
-   [array([26, 26, 23, 23, 26, 23],dtype=int8),
-        array([ 9, 12, 16, 16, 15, 15],dtype=int8)]), (
-   [array([15,  2, 15],dtype=int8)],
-   [array([28, 20, 12],dtype=int8)]), (
-   [array([17,  2],dtype=int8), array([ 2, 17],dtype=int8)],
-   [array([24, 24],dtype=int8), array([16, 16],dtype=int8)]), (
-   [array([ 2, 15,  2],dtype=int8)],
-   [array([28, 20, 12],dtype=int8)]), (
-   [array([ 3,  3,  6, 11, 15, 15,  8,  8],dtype=int8),
-        array([ 8,  8, 10, 10,  8, 10],dtype=int8)],
-   [array([29, 32, 35, 34, 31, 26, 19, 15],dtype=int8),
-        array([9, 7, 7, 9, 9, 7],dtype=int8)]), (
+   [array([10, 10], dtype=int8), array([ 9,  9, 11, 11,  9, 11], dtype=int8)],
+   [array([35, 16], dtype=int8), array([9, 7, 7, 9, 9, 7], dtype=int8)]), (
+   [array([5, 5], dtype=int8), array([5, 5], dtype=int8),
+        array([14, 14], dtype=int8), array([14, 14], dtype=int8)],
+   [array([35, 31], dtype=int8), array([31, 35], dtype=int8),
+        array([35, 31], dtype=int8), array([31, 35], dtype=int8)]), (
+   [array([9, 6], dtype=int8), array([13, 16], dtype=int8),
+        array([20,  3], dtype=int8), array([ 2, 18], dtype=int8)],
+   [array([27, 10], dtype=int8), array([10, 27], dtype=int8),
+        array([22, 22], dtype=int8), array([15, 15], dtype=int8)]), (
+   [array([9, 9], dtype=int8),
+        array([ 1,  5, 13, 17, 17, 13,  5,  1,  1,  5, 13, 17], dtype=int8)],
+   [array([35,  8], dtype=int8),
+        array([14, 10, 10, 13, 18, 22, 22, 25, 29, 33, 33, 29], dtype=int8)]), (
+   [array([6, 3, 1, 1, 3, 6, 8, 8, 6], dtype=int8),
+        array([18,  1], dtype=int8), array([11, 11, 13, 16, 18, 18, 16, 13, 11], dtype=int8)],
+   [array([35, 35, 33, 30, 28, 28, 30, 33, 35], dtype=int8),
+        array([35,  8], dtype=int8),
+        array([13, 10,  8,  8, 10, 13, 15, 15, 13], dtype=int8)]), (
+   [array([18,  3,  3,  5,  8, 10, 10,  1,  1,  4, 11, 18], dtype=int8)],
+   [array([ 8, 28, 32, 35, 35, 32, 29, 17, 12,  8,  8, 17], dtype=int8)]), (
+   [array([ 9,  8,  9, 10,  9], dtype=int8)],
+   [array([35, 31, 31, 35, 35], dtype=int8)]), (
+   [array([11,  9,  8,  8,  9, 11], dtype=int8)],
+   [array([35, 31, 26, 17, 12,  8], dtype=int8)]), (
+   [array([ 8, 10, 11, 11, 10,  8], dtype=int8)],
+   [array([35, 31, 26, 17, 12,  8], dtype=int8)]), (
+   [array([ 1, 17], dtype=int8), array([9, 9], dtype=int8), array([ 1, 17], dtype=int8)],
+   [array([29, 14], dtype=int8), array([32, 11], dtype=int8), array([14, 29], dtype=int8)]), (
+   [array([9, 9], dtype=int8), array([ 1, 17], dtype=int8)],
+   [array([28, 12], dtype=int8), array([20, 20], dtype=int8)]), (
+   [array([8, 9, 9, 8, 8, 9], dtype=int8)],
+   [array([4, 6, 9, 9, 8, 8], dtype=int8)]), (
+   [array([ 1, 17], dtype=int8)],
+   [array([20, 20], dtype=int8)]), (
+   [array([ 9,  9, 11, 11,  9, 11], dtype=int8)],
+   [array([9, 7, 7, 9, 9, 7], dtype=int8)]), (
+   [array([ 1, 18], dtype=int8)],
+   [array([ 8, 35], dtype=int8)]), (
+   [array([ 6,  1,  1,  6, 13, 18, 18, 13,  6], dtype=int8)],
+   [array([35, 29, 14,  8,  8, 14, 29, 35, 35], dtype=int8)]), (
+   [array([ 3, 10, 10], dtype=int8)],
+   [array([29, 35,  8], dtype=int8)]), (
+   [array([ 1,  5, 14, 18, 18,  1,  1, 18], dtype=int8)],
+   [array([31, 35, 35, 31, 23, 12,  8,  8], dtype=int8)]), (
+   [array([ 1,  6, 13, 18, 18, 13,  9], dtype=int8),
+        array([13, 18, 18, 13,  6,  1], dtype=int8)],
+   [array([31, 35, 35, 31, 26, 22, 22], dtype=int8),
+        array([22, 18, 12,  8,  8, 13], dtype=int8)]), (
+   [array([14, 14, 12,  1,  1, 14], dtype=int8), array([14, 18], dtype=int8)],
+   [array([ 8, 35, 35, 17, 15, 15], dtype=int8), array([15, 15], dtype=int8)]), (
+   [array([ 2, 13, 18, 18, 13,  6,  1,  1, 18], dtype=int8)],
+   [array([ 8,  8, 13, 20, 25, 25, 21, 35, 35], dtype=int8)]), (
+   [array([ 1,  6, 13, 18, 18, 13,  6,  1,  1,  2, 10], dtype=int8)],
+   [array([19, 24, 24, 19, 13,  8,  8, 13, 19, 27, 35], dtype=int8)]), (
+   [array([ 1, 18,  6], dtype=int8)],
+   [array([35, 35,  8], dtype=int8)]), (
+   [array([ 5,  1,  1,  5,  1,  1,  5, 14, 18, 18, 14,  5], dtype=int8),
+        array([14, 18, 18, 14,  5], dtype=int8)],
+   [array([35, 31, 26, 22, 18, 12,  8,  8, 12, 18, 22, 22], dtype=int8),
+        array([22, 26, 31, 35, 35], dtype=int8)]), (
+   [array([10, 17, 18, 18, 13,  6,  1,  1,  6, 13, 18], dtype=int8)],
+   [array([ 8, 16, 24, 30, 35, 35, 30, 24, 19, 19, 24], dtype=int8)]), (
+   [array([ 9, 11, 11,  9,  9, 11], dtype=int8), array([ 9,  9, 11, 11,  9, 11], dtype=int8)],
+   [array([26, 26, 23, 23, 26, 23], dtype=int8),
+        array([16, 13, 13, 16, 16, 13], dtype=int8)]), (
+   [array([ 9, 10, 10,  9,  9, 10], dtype=int8), array([ 9, 10, 10,  9,  9, 10], dtype=int8)],
+   [array([26, 26, 23, 23, 26, 23], dtype=int8),
+        array([ 9, 12, 16, 16, 15, 15], dtype=int8)]), (
+   [array([15,  2, 15], dtype=int8)],
+   [array([28, 20, 12], dtype=int8)]), (
+   [array([17,  2], dtype=int8), array([ 2, 17], dtype=int8)],
+   [array([24, 24], dtype=int8), array([16, 16], dtype=int8)]), (
+   [array([ 2, 15,  2], dtype=int8)],
+   [array([28, 20, 12], dtype=int8)]), (
+   [array([ 3,  3,  6, 11, 15, 15,  8,  8], dtype=int8),
+        array([ 8,  8, 10, 10,  8, 10], dtype=int8)],
+   [array([29, 32, 35, 34, 31, 26, 19, 15], dtype=int8),
+        array([9, 7, 7, 9, 9, 7], dtype=int8)]), (
    [array([14,  5,  1,  1,  5, 14, 18, 18, 16, 14, 13, 13, 11,
-                 8,  6,  6,  8, 11, 13],dtype=int8)],
+                 8,  6,  6,  8, 11, 13], dtype=int8)],
    [array([12, 12, 16, 27, 31, 31, 27, 19, 17, 17, 19, 23, 26,
-                 26, 23, 19, 17, 17, 19],dtype=int8)]), (
-   [array([ 1,  7, 11, 17],dtype=int8), array([ 3, 15],dtype=int8)],
-   [array([ 8, 35, 35,  8],dtype=int8), array([18, 18],dtype=int8)]), (
-   [array([ 1, 14, 18, 18, 14,  1],dtype=int8), array([14, 18, 18, 14,  1,  1],dtype=int8)],
-   [array([35, 35, 31, 26, 22, 22],dtype=int8),
-        array([22, 18, 12,  8,  8, 35],dtype=int8)]), (
-   [array([18, 13,  6,  1,  1,  6, 13, 18],dtype=int8)],
-   [array([13,  8,  8, 13, 30, 35, 35, 30],dtype=int8)]), (
-   [array([ 1, 13, 18, 18, 13,  1,  1],dtype=int8)],
-   [array([35, 35, 30, 13,  8,  8, 35],dtype=int8)]), (
-   [array([ 1,  1, 18],dtype=int8), array([ 1, 12],dtype=int8), array([ 1, 18],dtype=int8)],
-   [array([35,  8,  8],dtype=int8), array([22, 22],dtype=int8), array([35, 35],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1, 12],dtype=int8), array([ 1, 18],dtype=int8)],
-   [array([35,  8],dtype=int8), array([22, 22],dtype=int8), array([35, 35],dtype=int8)]), (
-   [array([11, 18, 18],dtype=int8), array([18, 13,  6,  1,  1,  6, 13, 18],dtype=int8)],
-   [array([18, 18,  8],dtype=int8), array([13,  8,  8, 13, 30, 35, 35, 30],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1, 18],dtype=int8), array([18, 18],dtype=int8)],
-   [array([35,  8],dtype=int8), array([21, 21],dtype=int8), array([ 8, 35],dtype=int8)]), (
-   [array([ 4, 14],dtype=int8), array([9, 9],dtype=int8), array([ 5, 14],dtype=int8)],
-   [array([35, 35],dtype=int8), array([35,  8],dtype=int8), array([8, 8],dtype=int8)]), (
-   [array([ 1,  6, 12, 17, 17],dtype=int8)],
-   [array([13,  8,  8, 13, 35],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([18,  6],dtype=int8), array([ 1, 18],dtype=int8)],
-   [array([35,  8],dtype=int8), array([ 8, 23],dtype=int8), array([18, 35],dtype=int8)]), (
-   [array([ 1,  1, 18],dtype=int8)],
-   [array([35,  8,  8],dtype=int8)]), (
-   [array([ 1,  1,  9, 17, 17],dtype=int8)],
-   [array([ 8, 35, 21, 35,  8],dtype=int8)]), (
-   [array([ 1,  1, 18, 18],dtype=int8)],
-   [array([ 8, 35,  8, 35],dtype=int8)]), (
-   [array([ 1,  6, 13, 18, 18, 13,  6,  1,  1],dtype=int8), array([13, 18],dtype=int8)],
-   [array([30, 35, 35, 30, 13,  8,  8, 13, 30],dtype=int8), array([30, 35],dtype=int8)]), (
-   [array([ 1,  1, 14, 18, 18, 14,  1],dtype=int8)],
-   [array([ 8, 35, 35, 31, 24, 20, 20],dtype=int8)]), (
-   [array([ 1,  1,  6, 13, 18, 18, 13,  6,  1],dtype=int8), array([ 8, 18],dtype=int8)],
-   [array([30, 13,  8,  8, 13, 30, 35, 35, 30],dtype=int8), array([24,  4],dtype=int8)]), (
-   [array([ 1,  1, 14, 18, 18, 14,  1],dtype=int8), array([14, 18],dtype=int8)],
-   [array([ 8, 35, 35, 31, 25, 22, 22],dtype=int8), array([22,  8],dtype=int8)]), (
-   [array([ 1,  5, 14, 18, 18, 14,  5,  1,  1,  5, 14, 18],dtype=int8)],
-   [array([12,  8,  8, 12, 17, 21, 22, 26, 31, 35, 35, 31],dtype=int8)]), (
-   [array([10, 10],dtype=int8), array([ 1, 19],dtype=int8)],
-   [array([ 8, 35],dtype=int8), array([35, 35],dtype=int8)]), (
-   [array([ 1,  1,  6, 13, 18, 18],dtype=int8)],
-   [array([35, 13,  8,  8, 13, 35],dtype=int8)]), (
-   [array([ 1,  9, 17],dtype=int8)],
-   [array([35,  8, 35],dtype=int8)]), (
-   [array([ 1,  5, 10, 15, 19],dtype=int8)],
-   [array([35,  8, 21,  8, 35],dtype=int8)]), (
-   [array([ 1, 18],dtype=int8), array([ 1, 18],dtype=int8)],
-   [array([35,  8],dtype=int8), array([ 8, 35],dtype=int8)]), (
-   [array([1, 9, 9],dtype=int8), array([ 9, 17],dtype=int8)],
-   [array([35, 23,  8],dtype=int8), array([23, 35],dtype=int8)]), (
-   [array([ 1, 18,  1, 18],dtype=int8)],
-   [array([35, 35,  8,  8],dtype=int8)]), (
-   [array([12,  7,  7, 12],dtype=int8)],
-   [array([37, 37,  7,  7],dtype=int8)]), (
-   [array([ 1, 18],dtype=int8)],
-   [array([35,  8],dtype=int8)]), (
-   [array([ 6, 11, 11,  6],dtype=int8)],
-   [array([37, 37,  7,  7],dtype=int8)]), (
-   [array([ 4,  9, 14],dtype=int8)],
-   [array([32, 35, 32],dtype=int8)]), (
-   [array([ 0, 19],dtype=int8)],
-   [array([3, 3],dtype=int8)]), (
-   [array([ 8, 10],dtype=int8)],
-   [array([35, 29],dtype=int8)]), (
-   [array([ 4, 11, 14, 14, 10,  5,  1,  1,  4, 11, 14],dtype=int8),
-        array([14, 18],dtype=int8)],
-   [array([23, 23, 20, 11,  7,  7, 11, 14, 17, 17, 15],dtype=int8),
-        array([11,  7],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1,  5, 12, 16, 16, 12,  5,  1],dtype=int8)],
-   [array([35,  8],dtype=int8), array([12,  8,  8, 12, 19, 23, 23, 19],dtype=int8)]), (
-   [array([15, 12,  5,  1,  1,  5, 12, 15],dtype=int8)],
-   [array([21, 23, 23, 19, 12,  8,  8, 10],dtype=int8)]), (
-   [array([16, 12,  5,  1,  1,  5, 12, 16],dtype=int8), array([16, 16],dtype=int8)],
-   [array([19, 23, 23, 19, 12,  8,  8, 12],dtype=int8), array([ 8, 35],dtype=int8)]), (
-   [array([ 1, 16, 16, 12,  5,  1,  1,  5, 12, 16],dtype=int8)],
-   [array([16, 16, 19, 23, 23, 19, 12,  8,  8, 11],dtype=int8)]), (
-   [array([ 3, 14],dtype=int8), array([ 7,  7, 10, 14, 16],dtype=int8)],
-   [array([23, 23],dtype=int8), array([ 8, 30, 33, 33, 31],dtype=int8)]), (
-   [array([ 1,  5, 12, 16, 16],dtype=int8),
-        array([16, 12,  5,  1,  1,  5, 12, 16],dtype=int8)],
-   [array([ 3,  0,  0,  4, 23],dtype=int8),
-        array([19, 23, 23, 19, 12,  8,  8, 12],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1,  5, 12, 16, 16],dtype=int8)],
-   [array([35,  8],dtype=int8), array([19, 23, 23, 19,  8],dtype=int8)]), (
-   [array([ 8,  8, 10, 10,  8, 10],dtype=int8), array([8, 9, 9],dtype=int8)],
-   [array([29, 27, 27, 29, 29, 27],dtype=int8), array([21, 21,  8],dtype=int8)]), (
-   [array([ 8,  8, 10, 10,  8, 10],dtype=int8), array([8, 9, 9, 7, 4, 2],dtype=int8)],
-   [array([29, 27, 27, 29, 29, 27],dtype=int8),
-        array([21, 21,  2,  0,  0,  2],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1, 13],dtype=int8), array([ 5, 16],dtype=int8)],
-   [array([35,  8],dtype=int8), array([20, 26],dtype=int8), array([22,  8],dtype=int8)]), (
-   [array([ 7,  9,  9, 11],dtype=int8)],
-   [array([35, 33, 10,  8],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([9, 9],dtype=int8),
-        array([ 1,  4,  7,  9, 11, 14, 17, 17],dtype=int8)],
-   [array([23,  8],dtype=int8), array([ 8, 20],dtype=int8),
-        array([20, 23, 23, 20, 23, 23, 20,  8],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1,  5, 12, 16, 16],dtype=int8)],
-   [array([23,  8],dtype=int8), array([19, 23, 23, 19,  8],dtype=int8)]), (
-   [array([ 1,  1,  5, 12, 16, 16, 12,  5,  1],dtype=int8)],
-   [array([19, 12,  8,  8, 12, 19, 23, 23, 19],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1,  5, 12, 16, 16, 12,  5,  1],dtype=int8)],
-   [array([23,  0],dtype=int8), array([19, 23, 23, 19, 12,  8,  8, 12],dtype=int8)]), (
-   [array([16, 16],dtype=int8), array([16, 12,  5,  1,  1,  5, 12, 16],dtype=int8)],
-   [array([23,  0],dtype=int8), array([12,  8,  8, 12, 19, 23, 23, 19],dtype=int8)]), (
-   [array([1, 1],dtype=int8), array([ 1,  5, 12, 16],dtype=int8)],
-   [array([23,  8],dtype=int8), array([19, 23, 23, 20],dtype=int8)]), (
-   [array([ 1,  5, 12, 16, 16, 12,  5,  1,  1,  5, 12, 15],dtype=int8)],
-   [array([10,  8,  8, 10, 14, 16, 16, 18, 21, 23, 23, 21],dtype=int8)]), (
-   [array([ 4, 14],dtype=int8), array([15, 13, 10,  8,  8],dtype=int8)],
-   [array([23, 23],dtype=int8), array([10,  8,  8, 10, 33],dtype=int8)]), (
-   [array([ 1,  1,  5, 12, 16],dtype=int8), array([16, 16],dtype=int8)],
-   [array([23, 12,  8,  8, 12],dtype=int8), array([ 8, 23],dtype=int8)]), (
-   [array([ 2,  9, 16],dtype=int8)],
-   [array([23,  8, 23],dtype=int8)]), (
-   [array([ 1,  5,  9, 13, 17],dtype=int8)],
-   [array([23,  8, 21,  8, 23],dtype=int8)]), (
-   [array([ 2, 16],dtype=int8), array([ 2, 16],dtype=int8)],
-   [array([23,  8],dtype=int8), array([ 8, 23],dtype=int8)]), (
-   [array([1, 9],dtype=int8), array([ 5, 17],dtype=int8)],
-   [array([23,  8],dtype=int8), array([ 0, 23],dtype=int8)]), (
-   [array([ 2, 16,  2, 16],dtype=int8)],
-   [array([23, 23,  8,  8],dtype=int8)]), (
-   [array([12, 10,  8,  8,  7,  5,  7,  8,  8, 10, 12],dtype=int8)],
-   [array([37, 37, 34, 25, 23, 22, 21, 19,  9,  7,  7],dtype=int8)]), (
-   [array([9, 9],dtype=int8), array([9, 9],dtype=int8)],
-   [array([35, 25],dtype=int8), array([18,  8],dtype=int8)]), (
-   [array([ 7,  9, 11, 11, 12, 14, 12, 11, 11,  9,  7],dtype=int8)],
-   [array([37, 37, 34, 25, 23, 22, 21, 19,  9,  7,  7],dtype=int8)]), (
-   [array([ 1,  4,  7, 12, 15, 18],dtype=int8)],
-   [array([19, 22, 22, 17, 17, 20],dtype=int8)])]
+                 26, 23, 19, 17, 17, 19], dtype=int8)]), (
+   [array([ 1,  7, 11, 17], dtype=int8), array([ 3, 15], dtype=int8)],
+   [array([ 8, 35, 35,  8], dtype=int8), array([18, 18], dtype=int8)]), (
+   [array([ 1, 14, 18, 18, 14,  1], dtype=int8), array([14, 18, 18, 14,  1,  1], dtype=int8)],
+   [array([35, 35, 31, 26, 22, 22], dtype=int8),
+        array([22, 18, 12,  8,  8, 35], dtype=int8)]), (
+   [array([18, 13,  6,  1,  1,  6, 13, 18], dtype=int8)],
+   [array([13,  8,  8, 13, 30, 35, 35, 30], dtype=int8)]), (
+   [array([ 1, 13, 18, 18, 13,  1,  1], dtype=int8)],
+   [array([35, 35, 30, 13,  8,  8, 35], dtype=int8)]), (
+   [array([ 1,  1, 18], dtype=int8), array([ 1, 12], dtype=int8), array([ 1, 18], dtype=int8)],
+   [array([35,  8,  8], dtype=int8), array([22, 22], dtype=int8), array([35, 35], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1, 12], dtype=int8), array([ 1, 18], dtype=int8)],
+   [array([35,  8], dtype=int8), array([22, 22], dtype=int8), array([35, 35], dtype=int8)]), (
+   [array([11, 18, 18], dtype=int8), array([18, 13,  6,  1,  1,  6, 13, 18], dtype=int8)],
+   [array([18, 18,  8], dtype=int8), array([13,  8,  8, 13, 30, 35, 35, 30], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1, 18], dtype=int8), array([18, 18], dtype=int8)],
+   [array([35,  8], dtype=int8), array([21, 21], dtype=int8), array([ 8, 35], dtype=int8)]), (
+   [array([ 4, 14], dtype=int8), array([9, 9], dtype=int8), array([ 5, 14], dtype=int8)],
+   [array([35, 35], dtype=int8), array([35,  8], dtype=int8), array([8, 8], dtype=int8)]), (
+   [array([ 1,  6, 12, 17, 17], dtype=int8)],
+   [array([13,  8,  8, 13, 35], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([18,  6], dtype=int8), array([ 1, 18], dtype=int8)],
+   [array([35,  8], dtype=int8), array([ 8, 23], dtype=int8), array([18, 35], dtype=int8)]), (
+   [array([ 1,  1, 18], dtype=int8)],
+   [array([35,  8,  8], dtype=int8)]), (
+   [array([ 1,  1,  9, 17, 17], dtype=int8)],
+   [array([ 8, 35, 21, 35,  8], dtype=int8)]), (
+   [array([ 1,  1, 18, 18], dtype=int8)],
+   [array([ 8, 35,  8, 35], dtype=int8)]), (
+   [array([ 1,  6, 13, 18, 18, 13,  6,  1,  1], dtype=int8), array([13, 18], dtype=int8)],
+   [array([30, 35, 35, 30, 13,  8,  8, 13, 30], dtype=int8), array([30, 35], dtype=int8)]), (
+   [array([ 1,  1, 14, 18, 18, 14,  1], dtype=int8)],
+   [array([ 8, 35, 35, 31, 24, 20, 20], dtype=int8)]), (
+   [array([ 1,  1,  6, 13, 18, 18, 13,  6,  1], dtype=int8), array([ 8, 18], dtype=int8)],
+   [array([30, 13,  8,  8, 13, 30, 35, 35, 30], dtype=int8), array([24,  4], dtype=int8)]), (
+   [array([ 1,  1, 14, 18, 18, 14,  1], dtype=int8), array([14, 18], dtype=int8)],
+   [array([ 8, 35, 35, 31, 25, 22, 22], dtype=int8), array([22,  8], dtype=int8)]), (
+   [array([ 1,  5, 14, 18, 18, 14,  5,  1,  1,  5, 14, 18], dtype=int8)],
+   [array([12,  8,  8, 12, 17, 21, 22, 26, 31, 35, 35, 31], dtype=int8)]), (
+   [array([10, 10], dtype=int8), array([ 1, 19], dtype=int8)],
+   [array([ 8, 35], dtype=int8), array([35, 35], dtype=int8)]), (
+   [array([ 1,  1,  6, 13, 18, 18], dtype=int8)],
+   [array([35, 13,  8,  8, 13, 35], dtype=int8)]), (
+   [array([ 1,  9, 17], dtype=int8)],
+   [array([35,  8, 35], dtype=int8)]), (
+   [array([ 1,  5, 10, 15, 19], dtype=int8)],
+   [array([35,  8, 21,  8, 35], dtype=int8)]), (
+   [array([ 1, 18], dtype=int8), array([ 1, 18], dtype=int8)],
+   [array([35,  8], dtype=int8), array([ 8, 35], dtype=int8)]), (
+   [array([1, 9, 9], dtype=int8), array([ 9, 17], dtype=int8)],
+   [array([35, 23,  8], dtype=int8), array([23, 35], dtype=int8)]), (
+   [array([ 1, 18,  1, 18], dtype=int8)],
+   [array([35, 35,  8,  8], dtype=int8)]), (
+   [array([12,  7,  7, 12], dtype=int8)],
+   [array([37, 37,  7,  7], dtype=int8)]), (
+   [array([ 1, 18], dtype=int8)],
+   [array([35,  8], dtype=int8)]), (
+   [array([ 6, 11, 11,  6], dtype=int8)],
+   [array([37, 37,  7,  7], dtype=int8)]), (
+   [array([ 4,  9, 14], dtype=int8)],
+   [array([32, 35, 32], dtype=int8)]), (
+   [array([ 0, 19], dtype=int8)],
+   [array([3, 3], dtype=int8)]), (
+   [array([ 8, 10], dtype=int8)],
+   [array([35, 29], dtype=int8)]), (
+   [array([ 4, 11, 14, 14, 10,  5,  1,  1,  4, 11, 14], dtype=int8),
+        array([14, 18], dtype=int8)],
+   [array([23, 23, 20, 11,  7,  7, 11, 14, 17, 17, 15], dtype=int8),
+        array([11,  7], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1,  5, 12, 16, 16, 12,  5,  1], dtype=int8)],
+   [array([35,  8], dtype=int8), array([12,  8,  8, 12, 19, 23, 23, 19], dtype=int8)]), (
+   [array([15, 12,  5,  1,  1,  5, 12, 15], dtype=int8)],
+   [array([21, 23, 23, 19, 12,  8,  8, 10], dtype=int8)]), (
+   [array([16, 12,  5,  1,  1,  5, 12, 16], dtype=int8), array([16, 16], dtype=int8)],
+   [array([19, 23, 23, 19, 12,  8,  8, 12], dtype=int8), array([ 8, 35], dtype=int8)]), (
+   [array([ 1, 16, 16, 12,  5,  1,  1,  5, 12, 16], dtype=int8)],
+   [array([16, 16, 19, 23, 23, 19, 12,  8,  8, 11], dtype=int8)]), (
+   [array([ 3, 14], dtype=int8), array([ 7,  7, 10, 14, 16], dtype=int8)],
+   [array([23, 23], dtype=int8), array([ 8, 30, 33, 33, 31], dtype=int8)]), (
+   [array([ 1,  5, 12, 16, 16], dtype=int8),
+        array([16, 12,  5,  1,  1,  5, 12, 16], dtype=int8)],
+   [array([ 3,  0,  0,  4, 23], dtype=int8),
+        array([19, 23, 23, 19, 12,  8,  8, 12], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1,  5, 12, 16, 16], dtype=int8)],
+   [array([35,  8], dtype=int8), array([19, 23, 23, 19,  8], dtype=int8)]), (
+   [array([ 8,  8, 10, 10,  8, 10], dtype=int8), array([8, 9, 9], dtype=int8)],
+   [array([29, 27, 27, 29, 29, 27], dtype=int8), array([21, 21,  8], dtype=int8)]), (
+   [array([ 8,  8, 10, 10,  8, 10], dtype=int8), array([8, 9, 9, 7, 4, 2], dtype=int8)],
+   [array([29, 27, 27, 29, 29, 27], dtype=int8),
+        array([21, 21,  2,  0,  0,  2], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1, 13], dtype=int8), array([ 5, 16], dtype=int8)],
+   [array([35,  8], dtype=int8), array([20, 26], dtype=int8), array([22,  8], dtype=int8)]), (
+   [array([ 7,  9,  9, 11], dtype=int8)],
+   [array([35, 33, 10,  8], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([9, 9], dtype=int8),
+        array([ 1,  4,  7,  9, 11, 14, 17, 17], dtype=int8)],
+   [array([23,  8], dtype=int8), array([ 8, 20], dtype=int8),
+        array([20, 23, 23, 20, 23, 23, 20,  8], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1,  5, 12, 16, 16], dtype=int8)],
+   [array([23,  8], dtype=int8), array([19, 23, 23, 19,  8], dtype=int8)]), (
+   [array([ 1,  1,  5, 12, 16, 16, 12,  5,  1], dtype=int8)],
+   [array([19, 12,  8,  8, 12, 19, 23, 23, 19], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1,  5, 12, 16, 16, 12,  5,  1], dtype=int8)],
+   [array([23,  0], dtype=int8), array([19, 23, 23, 19, 12,  8,  8, 12], dtype=int8)]), (
+   [array([16, 16], dtype=int8), array([16, 12,  5,  1,  1,  5, 12, 16], dtype=int8)],
+   [array([23,  0], dtype=int8), array([12,  8,  8, 12, 19, 23, 23, 19], dtype=int8)]), (
+   [array([1, 1], dtype=int8), array([ 1,  5, 12, 16], dtype=int8)],
+   [array([23,  8], dtype=int8), array([19, 23, 23, 20], dtype=int8)]), (
+   [array([ 1,  5, 12, 16, 16, 12,  5,  1,  1,  5, 12, 15], dtype=int8)],
+   [array([10,  8,  8, 10, 14, 16, 16, 18, 21, 23, 23, 21], dtype=int8)]), (
+   [array([ 4, 14], dtype=int8), array([15, 13, 10,  8,  8], dtype=int8)],
+   [array([23, 23], dtype=int8), array([10,  8,  8, 10, 33], dtype=int8)]), (
+   [array([ 1,  1,  5, 12, 16], dtype=int8), array([16, 16], dtype=int8)],
+   [array([23, 12,  8,  8, 12], dtype=int8), array([ 8, 23], dtype=int8)]), (
+   [array([ 2,  9, 16], dtype=int8)],
+   [array([23,  8, 23], dtype=int8)]), (
+   [array([ 1,  5,  9, 13, 17], dtype=int8)],
+   [array([23,  8, 21,  8, 23], dtype=int8)]), (
+   [array([ 2, 16], dtype=int8), array([ 2, 16], dtype=int8)],
+   [array([23,  8], dtype=int8), array([ 8, 23], dtype=int8)]), (
+   [array([1, 9], dtype=int8), array([ 5, 17], dtype=int8)],
+   [array([23,  8], dtype=int8), array([ 0, 23], dtype=int8)]), (
+   [array([ 2, 16,  2, 16], dtype=int8)],
+   [array([23, 23,  8,  8], dtype=int8)]), (
+   [array([12, 10,  8,  8,  7,  5,  7,  8,  8, 10, 12], dtype=int8)],
+   [array([37, 37, 34, 25, 23, 22, 21, 19,  9,  7,  7], dtype=int8)]), (
+   [array([9, 9], dtype=int8), array([9, 9], dtype=int8)],
+   [array([35, 25], dtype=int8), array([18,  8], dtype=int8)]), (
+   [array([ 7,  9, 11, 11, 12, 14, 12, 11, 11,  9,  7], dtype=int8)],
+   [array([37, 37, 34, 25, 23, 22, 21, 19,  9,  7,  7], dtype=int8)]), (
+   [array([ 1,  4,  7, 12, 15, 18], dtype=int8)],
+   [array([19, 22, 22, 17, 17, 20], dtype=int8)])]

--- a/lib/pyraf/generic.py
+++ b/lib/pyraf/generic.py
@@ -35,7 +35,7 @@ $Id$
 # - Add optional value parameter to GenericParser.error.
 # - Add check for assertion error in ambiguity resolution.
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 __version__ = 'SPARK-0.6.1rlw'
 
@@ -84,7 +84,7 @@ class GenericScanner:
         return '|'.join(rv)
 
     def error(self, s, pos):
-        print "Lexical error at position %s" % pos
+        print("Lexical error at position %s" % pos)
         raise SystemExit()
 
     def tokenize(self, s):
@@ -268,8 +268,9 @@ class GenericParser:
         return None
 
     def error(self, token, value=None):
-        print "Syntax error at or near `%s' token" % token
-        if value is not None: print str(value)
+        print("Syntax error at or near `%s' token" % token)
+        if value is not None:
+            print(str(value))
         raise SystemExit()
 
     def parse(self, tokens):
@@ -411,7 +412,7 @@ class GenericParser:
                         child = self.ambiguity(children)
                     except AssertionError:
                         del tokens[-1]
-                        print stack[0]
+                        print(stack[0])
                         # self.error(tokens[tokpos], 'Parsing ambiguity'+str(children[:]))
                         self.error(stack[0], 'Parsing ambiguity'+str(children[:]))
                 else:

--- a/lib/pyraf/generic.py
+++ b/lib/pyraf/generic.py
@@ -449,7 +449,7 @@ class GenericParser:
             sortlist.append((len(rhs), rule))
             name2index[rule] = i
         sortlist.sort()
-        list = map(lambda (a,b): b, sortlist)
+        list = list(map(lambda (a,b): b, sortlist))
         return children[name2index[self.resolve(list)]]
 
     def resolve(self, list):

--- a/lib/pyraf/generic.py
+++ b/lib/pyraf/generic.py
@@ -85,7 +85,7 @@ class GenericScanner:
 
     def error(self, s, pos):
         print "Lexical error at position %s" % pos
-        raise SystemExit
+        raise SystemExit()
 
     def tokenize(self, s):
         pos = 0
@@ -270,7 +270,7 @@ class GenericParser:
     def error(self, token, value=None):
         print "Syntax error at or near `%s' token" % token
         if value is not None: print str(value)
-        raise SystemExit
+        raise SystemExit()
 
     def parse(self, tokens):
         tree = {}
@@ -526,7 +526,7 @@ class GenericASTTraversal:
                     self.exitrules[name[2:-5]] = getattr(self, name)
 
     def prune(self):
-        raise GenericASTTraversalPruningException
+        raise GenericASTTraversalPruningException()
 
     def preorder(self, node=None):
         if node is None:

--- a/lib/pyraf/generic.py
+++ b/lib/pyraf/generic.py
@@ -209,7 +209,7 @@ class GenericParser:
         # make the rule/token lists
         self.makeTokenRules(first)
 
-    def makeTokenRules(self,first):
+    def makeTokenRules(self, first):
         # make dictionary indexed by (nextSymbol, nextToken) with
         # list of all rules for nextSymbol that could produce nextToken
         tokenRules = {}
@@ -318,9 +318,9 @@ class GenericParser:
                 # track items completed within this rule
                 if parent == i:
                     if lhs in completed:
-                        completed[lhs].append((item,i))
+                        completed[lhs].append((item, i))
                     else:
-                        completed[lhs] = [(item,i)]
+                        completed[lhs] = [(item, i)]
 
                 lhstuple = (lhs,)
                 for prule, ppos, pparent in states[parent]:
@@ -361,7 +361,7 @@ class GenericParser:
                     # Predictor using FIRST sets
                     # Use cached list for this (nextSym, token) combo
                     #
-                    for prule in tokenRules_get((nextSym, token.type),[]):
+                    for prule in tokenRules_get((nextSym, token.type), []):
                         state_append((prule, 0, i))
 
             #
@@ -449,7 +449,7 @@ class GenericParser:
             sortlist.append((len(rhs), rule))
             name2index[rule] = i
         sortlist.sort()
-        list = list(map(lambda (a,b): b, sortlist))
+        list = list(map(lambda (a, b): b, sortlist))
         return children[name2index[self.resolve(list)]]
 
     def resolve(self, list):

--- a/lib/pyraf/generic.py
+++ b/lib/pyraf/generic.py
@@ -285,7 +285,7 @@ class GenericParser:
             self.makeFIRST()
             self.ruleschanged = 0
 
-        for i in xrange(len(tokens)):
+        for i in range(len(tokens)):
             states[i+1] = []
 
             if states[i] == []:

--- a/lib/pyraf/gki.py
+++ b/lib/pyraf/gki.py
@@ -194,7 +194,7 @@ class EditHistory:
         edits beyond n."""
         newEditHistory = EditHistory()
         tsize = 0
-        for i in xrange(len(self.editinfo)):
+        for i in range(len(self.editinfo)):
             marker, size = self.editinfo[i]
             tsize = tsize + size
             if tsize >= n:
@@ -1404,26 +1404,26 @@ class IrafHatchFills:
         # pattern 3, vertical stripes
         p = numpy.zeros(128,numpy.int8)
         p[0:4] = [0x92,0x49,0x24,0x92]
-        for i in xrange(31):
+        for i in range(31):
             p[(i+1)*4:(i+2)*4] = p[0:4]
         self.patterns[3] = p
         # pattern 4, horizontal stripes
         p = numpy.zeros(128,numpy.int8)
         p[0:4] = [0xFF,0xFF,0xFF,0xFF]
-        for i in xrange(10):
+        for i in range(10):
             p[(i+1)*12:(i+1)*12+4] = p[0:4]
         self.patterns[4] = p
         # pattern 5, close diagonal striping
         p = numpy.zeros(128,numpy.int8)
         p[0:12] = [0x92,0x49,0x24,0x92,0x24,0x92,0x49,0x24,0x49,0x24,0x92,0x49]
-        for i in xrange(9):
+        for i in range(9):
             p[(i+1)*12:(i+2)*12] = p[0:12]
         p[120:128] = p[0:8]
         self.patterns[5] = p
         # pattern 6, diagonal stripes the other way
         p = numpy.zeros(128,numpy.int8)
         p[0:12] = [0x92,0x49,0x24,0x92,0x49,0x24,0x92,0x49,0x24,0x92,0x49,0x24]
-        for i in xrange(9):
+        for i in range(9):
             p[(i+1)*12:(i+2)*12] = p[0:12]
         p[120:128] = p[0:8]
         self.patterns[6] = p

--- a/lib/pyraf/gki.py
+++ b/lib/pyraf/gki.py
@@ -38,7 +38,7 @@ graphics kernels as directed by commands embedded in the metacode stream.
 
 $Id$
 """
-from __future__ import division
+from __future__ import division, print_function
 
 import numpy
 from types import *
@@ -411,7 +411,7 @@ class GkiBuffer:
             if buffer[ip] == NOP:
                 ip = ip+1
             elif buffer[ip] != BOI:
-                print "WARNING: missynched graphics data stream"
+                print("WARNING: missynched graphics data stream")
                 # find next possible beginning of instruction
                 ip = ip + 1
                 while ip < lenMC:
@@ -419,7 +419,7 @@ class GkiBuffer:
                     ip = ip + 1
                 else:
                     # Unable to resync
-                    print "WARNING: unable to resynchronize in graphics data stream"
+                    print("WARNING: unable to resynchronize in graphics data stream")
                     break
             else:
                 if ip+2 >= lenMC: break
@@ -433,7 +433,7 @@ class GkiBuffer:
                 if ((opcode < 0) or
                     (opcode > GKI_MAX_OP_CODE) or
                     (opcode in GKI_ILLEGAL_LIST)):
-                    print "WARNING: Illegal graphics opcode = ",opcode
+                    print("WARNING: Illegal graphics opcode = ",opcode)
                 else:
                     # normal return
                     self.nextTranslate = ip
@@ -574,7 +574,7 @@ class GkiKernel:
     def errorMessage(self, text):
 
         if self.errorMessageCount < MAX_ERROR_COUNT:
-            print text
+            print(text)
             self.errorMessageCount = self.errorMessageCount + 1
 
     def getBuffer(self):
@@ -1047,9 +1047,9 @@ class GkiNull(GkiKernel):
 
     def __init__(self):
 
-        print "No graphics display available for this session."
-        print "Graphics tasks that attempt to plot to an interactive " + \
-              "screen will fail."
+        print("No graphics display available for this session.")
+        print("Graphics tasks that attempt to plot to an interactive "
+              "screen will fail.")
         GkiKernel.__init__(self)
         self.name = 'Null'
 
@@ -1120,39 +1120,101 @@ class GkiNoisy(GkiKernel):
         GkiKernel.__init__(self)
         self.name = 'Noisy'
 
-    def control_openws(self, arg): print 'control_openws'
-    def control_closews(self, arg): print 'control_closews'
-    def control_reactivatews(self, arg): print 'control_reactivatews'
-    def control_deactivatews(self, arg): print 'control_deactivatews'
-    def control_clearws(self, arg): print 'control_clearws'
-    def control_setwcs(self, arg): print 'control_setwcs'
-    def control_getwcs(self, arg): print 'control_getwcs'
+    def control_openws(self, arg):
+        print('control_openws')
 
-    def gki_eof(self, arg): print 'gki_eof'
-    def gki_openws(self, arg): print 'gki_openws'
-    def gki_closews(self, arg): print 'gki_closews'
-    def gki_reactivatews(self, arg): print 'gki_reactivatews'
-    def gki_deactivatews(self, arg): print 'gki_deactivatews'
-    def gki_mftitle(self, arg): print 'gki_mftitle'
-    def gki_clearws(self, arg): print 'gki_clearws'
-    def gki_cancel(self, arg): print 'gki_cancel'
-    def gki_flush(self, arg): print 'gki_flush'
-    def gki_polyline(self, arg): print 'gki_polyline'
-    def gki_polymarker(self, arg): print 'gki_polymarker'
-    def gki_text(self, arg): print 'gki_text'
-    def gki_fillarea(self, arg): print 'gki_fillarea'
-    def gki_putcellarray(self, arg): print 'gki_putcellarray'
-    def gki_setcursor(self, arg): print 'gki_setcursor'
-    def gki_plset(self, arg): print 'gki_plset'
-    def gki_pmset(self, arg): print 'gki_pmset'
-    def gki_txset(self, arg): print 'gki_txset'
-    def gki_faset(self, arg): print 'gki_faset'
-    def gki_getcursor(self, arg): print 'gki_getcursor'
-    def gki_getcellarray(self, arg): print 'gki_getcellarray'
-    def gki_unknown(self, arg): print 'gki_unknown'
-    def gki_escape(self, arg): print 'gki_escape'
-    def gki_setwcs(self, arg): print 'gki_setwcs'
-    def gki_getwcs(self, arg): print 'gki_getwcs'
+    def control_closews(self, arg):
+        print('control_closews')
+
+    def control_reactivatews(self, arg):
+        print('control_reactivatews')
+
+    def control_deactivatews(self, arg):
+        print('control_deactivatews')
+
+    def control_clearws(self, arg):
+        print('control_clearws')
+
+    def control_setwcs(self, arg):
+        print('control_setwcs')
+
+    def control_getwcs(self, arg):
+        print('control_getwcs')
+
+    def gki_eof(self, arg):
+        print('gki_eof')
+
+    def gki_openws(self, arg):
+        print('gki_openws')
+
+    def gki_closews(self, arg):
+        print('gki_closews')
+
+    def gki_reactivatews(self, arg):
+        print('gki_reactivatews')
+
+    def gki_deactivatews(self, arg):
+        print('gki_deactivatews')
+
+    def gki_mftitle(self, arg):
+        print('gki_mftitle')
+
+    def gki_clearws(self, arg):
+        print('gki_clearws')
+
+    def gki_cancel(self, arg):
+        print('gki_cancel')
+
+    def gki_flush(self, arg):
+        print('gki_flush')
+
+    def gki_polyline(self, arg):
+        print('gki_polyline')
+
+    def gki_polymarker(self, arg):
+        print('gki_polymarker')
+
+    def gki_text(self, arg):
+        print('gki_text')
+
+    def gki_fillarea(self, arg):
+        print('gki_fillarea')
+
+    def gki_putcellarray(self, arg):
+        print('gki_putcellarray')
+
+    def gki_setcursor(self, arg):
+        print('gki_setcursor')
+
+    def gki_plset(self, arg):
+        print('gki_plset')
+
+    def gki_pmset(self, arg):
+        print('gki_pmset')
+
+    def gki_txset(self, arg):
+        print('gki_txset')
+
+    def gki_faset(self, arg):
+        print('gki_faset')
+
+    def gki_getcursor(self, arg):
+        print('gki_getcursor')
+
+    def gki_getcellarray(self, arg):
+        print('gki_getcellarray')
+
+    def gki_unknown(self, arg):
+        print('gki_unknown')
+
+    def gki_escape(self, arg):
+        print('gki_escape')
+
+    def gki_setwcs(self, arg):
+        print('gki_setwcs')
+
+    def gki_getwcs(self, arg):
+        print('gki_getwcs')
 
 # Dictionary of all graphcap files known so far
 

--- a/lib/pyraf/gki.py
+++ b/lib/pyraf/gki.py
@@ -91,7 +91,7 @@ GKI_ESCAPE = 25
 GKI_SETWCS = 26
 GKI_GETWCS = 27
 
-GKI_ILLEGAL_LIST = (21,22,23,24)
+GKI_ILLEGAL_LIST = (21, 22, 23, 24)
 
 CONTROL_OPENWS = 1
 CONTROL_CLOSEWS = 2
@@ -171,11 +171,11 @@ class EditHistory:
         self.editinfo = []
 
     def add(self, size, undomarker=0):
-        self.editinfo.append((undomarker,size))
+        self.editinfo.append((undomarker, size))
 
     def NEdits(self):
         count = 0
-        for undomarker,size in self.editinfo:
+        for undomarker, size in self.editinfo:
             if undomarker:
                 count = count+1
         return count
@@ -188,7 +188,7 @@ class EditHistory:
             if marker: break
         return tsize
 
-    def split(self,n):
+    def split(self, n):
         """Split edit buffer at metacode length n.  Modifies this buffer
         to stop at n and returns a new EditHistory object with any
         edits beyond n."""
@@ -433,7 +433,7 @@ class GkiBuffer:
                 if ((opcode < 0) or
                     (opcode > GKI_MAX_OP_CODE) or
                     (opcode in GKI_ILLEGAL_LIST)):
-                    print("WARNING: Illegal graphics opcode = ",opcode)
+                    print("WARNING: Illegal graphics opcode = ", opcode)
                 else:
                     # normal return
                     self.nextTranslate = ip
@@ -445,12 +445,12 @@ class GkiBuffer:
     def __len__(self):
         return self.bufferEnd
 
-    def __getitem__(self,i):
+    def __getitem__(self, i):
         if i >= self.bufferEnd:
             raise IndexError("buffer index out of range")
         return self.buffer[i]
 
-    def __getslice__(self,i,j):
+    def __getslice__(self, i, j):
         if j > self.bufferEnd: j = self.bufferEnd
         return self.buffer[i:j]
 
@@ -515,7 +515,7 @@ class GkiKernel:
         # set this without knowing what you are doing - it breaks some commonly
         # used command-line redirection within PyRAF. (thus default = False)
         if self.gkiPreferTtyIpc == None:
-            self.gkiPreferTtyIpc = pyraf.iraf.envget('gkiprefertty','') == 'yes'
+            self.gkiPreferTtyIpc = pyraf.iraf.envget('gkiprefertty', '') == 'yes'
         return self.gkiPreferTtyIpc
 
     def createFunctionTables(self):
@@ -563,7 +563,7 @@ class GkiKernel:
         buffer = self.getBuffer()
         buffer.append(gkiMetacode, isUndoable)
         # translate and display the metacode
-        self.translate(buffer,0)
+        self.translate(buffer, 0)
 
     def translate(self, gkiMetacode, redraw=0):
         # Note, during the perf. testing of #122 it was noticed that this
@@ -610,14 +610,14 @@ class GkiKernel:
         buffer = self.getBuffer()
         if buffer.undoN(nUndo):
             self.prepareToRedraw()
-            self.translate(buffer,1)
+            self.translate(buffer, 1)
 
     def redoN(self, nRedo=1):
 
         # Redo the last nRedo edits to the metacode buffer
         buffer = self.getBuffer()
         if buffer.redoN(nRedo):
-            self.translate(buffer,1)
+            self.translate(buffer, 1)
 
     def prepareToRedraw(self):
         """Hook for things that need to be done before redraw from metacode"""
@@ -633,7 +633,7 @@ class GkiKernel:
             # just redraw it
             buffer.prepareToRedraw()
             self.prepareToRedraw()
-            self.translate(buffer,1)
+            self.translate(buffer, 1)
 
     def clearReturnData(self):
 
@@ -846,7 +846,7 @@ class GkiProxy(GkiKernel):
 
     def translate(self, gkiMetacode, redraw=0):
         if not self.stdgraph: self.openKernel()
-        return self.stdgraph.translate(gkiMetacode,redraw)
+        return self.stdgraph.translate(gkiMetacode, redraw)
 
     def clearReturnData(self):
         if not self.stdgraph: self.openKernel()
@@ -861,7 +861,7 @@ class GkiProxy(GkiKernel):
     def pushStdio(self, stdin=None, stdout=None, stderr=None):
         """Push current stdio settings onto stack at set new values"""
         if self.stdgraph:
-            self.stdgraph.pushStdio(stdin,stdout,stderr)
+            self.stdgraph.pushStdio(stdin, stdout, stderr)
         #XXX still need some work here?
         self._stdioStack.append((self.stdin, self.stdout, self.stderr))
         self.stdin = stdin
@@ -898,7 +898,7 @@ class GkiProxy(GkiKernel):
 
     def append(self, arg, isUndoable=0):
         if self.stdgraph:
-            self.stdgraph.append(arg,isUndoable)
+            self.stdgraph.append(arg, isUndoable)
 
     def control(self, gkiMetacode):
         if not self.stdgraph: self.openKernel()
@@ -1010,14 +1010,14 @@ class GkiController(GkiProxy):
         """Starting with stdgraph, drill until a device is found in
         the graphcap or isn't"""
         if not device:
-            device = pyraf.iraf.envget("stdgraph","")
+            device = pyraf.iraf.envget("stdgraph", "")
         graphcap = getGraphcap()
         # protect against circular definitions
         devstr = device
         tried = {devstr: None}
         while devstr not in graphcap:
             pdevstr = devstr
-            devstr = pyraf.iraf.envget(pdevstr,"")
+            devstr = pyraf.iraf.envget(pdevstr, "")
             if not devstr:
                 raise IrafError(
                     "No entry found for specified stdgraph device `%s'" %
@@ -1223,7 +1223,7 @@ graphcapDict = {}
 def getGraphcap(filename=None):
     """Get graphcap file from filename (or cached version if possible)"""
     if filename is None:
-        filename = pyraf.iraf.osfn(pyraf.iraf.envget('graphcap','dev$graphcap'))
+        filename = pyraf.iraf.osfn(pyraf.iraf.envget('graphcap', 'dev$graphcap'))
     if filename not in graphcapDict:
         graphcapDict[filename] = graphcap.GraphCap(filename)
     return graphcapDict[filename]
@@ -1242,7 +1242,7 @@ def printPlot(window=None):
     gkibuff = window.gkibuffer.get()
     if len(gkibuff):
         graphcap = getGraphcap()
-        stdplot = pyraf.iraf.envget('stdplot','')
+        stdplot = pyraf.iraf.envget('stdplot', '')
         if not stdplot:
             msg = "No hardcopy device defined in stdplot"
         elif stdplot not in graphcap:
@@ -1299,23 +1299,23 @@ class IrafGkiConfig:
 
         # List of rgb tuples (0.0-1.0 range) for the default IRAF set of colors
         self.defaultColors = [
-                (0.,0.,0.),  # black
-                (1.,1.,1.),  # white
-                (1.,0.,0.),  # red
-                (0.,1.,0.),  # green
-                (0.,0.,1.),  # blue
-                (0.,1.,1.),  # cyan
-                (1.,1.,0.),  # yellow
-                (1.,0.,1.),  # magenta
-                (1.,1.,1.),  # white
+                (0., 0., 0.),  # black
+                (1., 1., 1.),  # white
+                (1., 0., 0.),  # red
+                (0., 1., 0.),  # green
+                (0., 0., 1.),  # blue
+                (0., 1., 1.),  # cyan
+                (1., 1., 0.),  # yellow
+                (1., 0., 1.),  # magenta
+                (1., 1., 1.),  # white
                 # (0.32,0.32,0.32),  # gray32
-                (0.18,0.31,0.31),  # IRAF blue-green
-                (1.,1.,1.),  # white
-                (1.,1.,1.),  # white
-                (1.,1.,1.),  # white
-                (1.,1.,1.),  # white
-                (1.,1.,1.),  # white
-                (1.,1.,1.),  # white
+                (0.18, 0.31, 0.31),  # IRAF blue-green
+                (1., 1., 1.),  # white
+                (1., 1., 1.),  # white
+                (1., 1., 1.),  # white
+                (1., 1., 1.),  # white
+                (1., 1., 1.),  # white
+                (1., 1., 1.),  # white
         ]
         self.cursorColor = 2  # red
         if len(self.defaultColors) != nIrafColors:
@@ -1356,13 +1356,13 @@ class IrafGkiConfig:
         hsize = hwinsize * self.UnitFontHWindowFraction
         vsize = vwinsize * self.UnitFontVWindowFraction
         if self.minUnitHFontSize is not None:
-            hsize = max(hsize,self.minUnitHFontSize)
+            hsize = max(hsize, self.minUnitHFontSize)
         if self.minUnitVFontSize is not None:
-            vsize = max(vsize,self.minUnitVFontSize)
+            vsize = max(vsize, self.minUnitVFontSize)
         if self.maxUnitHFontSize is not None:
-            hsize = min(hsize,self.maxUnitHFontSize)
+            hsize = min(hsize, self.maxUnitHFontSize)
         if self.maxUnitVFontSize is not None:
-            vsize = min(vsize,self.maxUnitVFontSize)
+            vsize = min(vsize, self.maxUnitVFontSize)
         if not self.isFixedAspectFont:
             fontAspect = vsize/hsize
         else:
@@ -1385,7 +1385,7 @@ class IrafLineStyles:
 
     def __init__(self):
 
-        self.patterns = [0x0000,0xFFFF,0x00FF,0x5555,0x33FF]
+        self.patterns = [0x0000, 0xFFFF, 0x00FF, 0x5555, 0x33FF]
 
 class IrafHatchFills:
 
@@ -1402,27 +1402,27 @@ class IrafHatchFills:
 
         self.patterns = [None]*7
         # pattern 3, vertical stripes
-        p = numpy.zeros(128,numpy.int8)
-        p[0:4] = [0x92,0x49,0x24,0x92]
+        p = numpy.zeros(128, numpy.int8)
+        p[0:4] = [0x92, 0x49, 0x24, 0x92]
         for i in range(31):
             p[(i+1)*4:(i+2)*4] = p[0:4]
         self.patterns[3] = p
         # pattern 4, horizontal stripes
-        p = numpy.zeros(128,numpy.int8)
-        p[0:4] = [0xFF,0xFF,0xFF,0xFF]
+        p = numpy.zeros(128, numpy.int8)
+        p[0:4] = [0xFF, 0xFF, 0xFF, 0xFF]
         for i in range(10):
             p[(i+1)*12:(i+1)*12+4] = p[0:4]
         self.patterns[4] = p
         # pattern 5, close diagonal striping
-        p = numpy.zeros(128,numpy.int8)
-        p[0:12] = [0x92,0x49,0x24,0x92,0x24,0x92,0x49,0x24,0x49,0x24,0x92,0x49]
+        p = numpy.zeros(128, numpy.int8)
+        p[0:12] = [0x92, 0x49, 0x24, 0x92, 0x24, 0x92, 0x49, 0x24, 0x49, 0x24, 0x92, 0x49]
         for i in range(9):
             p[(i+1)*12:(i+2)*12] = p[0:12]
         p[120:128] = p[0:8]
         self.patterns[5] = p
         # pattern 6, diagonal stripes the other way
-        p = numpy.zeros(128,numpy.int8)
-        p[0:12] = [0x92,0x49,0x24,0x92,0x49,0x24,0x92,0x49,0x24,0x92,0x49,0x24]
+        p = numpy.zeros(128, numpy.int8)
+        p[0:12] = [0x92, 0x49, 0x24, 0x92, 0x49, 0x24, 0x92, 0x49, 0x24, 0x92, 0x49, 0x24]
         for i in range(9):
             p[(i+1)*12:(i+2)*12] = p[0:12]
         p[120:128] = p[0:8]
@@ -1527,7 +1527,7 @@ class FilterStderr:
 
     def write(self, text):
         # remove GUI junk
-        edit = self.pat.sub('',text)
+        edit = self.pat.sub('', text)
         if edit: self.fh.write(edit)
 
     def flush(self):
@@ -1583,7 +1583,7 @@ def ndc(intarr):
 
 def ndcpairs(intarr):
     f = ndc(intarr)
-    return f[0::2],f[1::2]
+    return f[0::2], f[1::2]
 
 
 # This is the proxy for the current graphics kernel

--- a/lib/pyraf/gki.py
+++ b/lib/pyraf/gki.py
@@ -1015,7 +1015,7 @@ class GkiController(GkiProxy):
         # protect against circular definitions
         devstr = device
         tried = {devstr: None}
-        while not devstr in graphcap:
+        while devstr not in graphcap:
             pdevstr = devstr
             devstr = pyraf.iraf.envget(pdevstr,"")
             if not devstr:
@@ -1224,7 +1224,7 @@ def getGraphcap(filename=None):
     """Get graphcap file from filename (or cached version if possible)"""
     if filename is None:
         filename = pyraf.iraf.osfn(pyraf.iraf.envget('graphcap','dev$graphcap'))
-    if not filename in graphcapDict:
+    if filename not in graphcapDict:
         graphcapDict[filename] = graphcap.GraphCap(filename)
     return graphcapDict[filename]
 
@@ -1245,7 +1245,7 @@ def printPlot(window=None):
         stdplot = pyraf.iraf.envget('stdplot','')
         if not stdplot:
             msg = "No hardcopy device defined in stdplot"
-        elif not stdplot in graphcap:
+        elif stdplot not in graphcap:
             msg = "Unknown hardcopy device stdplot=`%s'" % stdplot
         else:
             printer = gkiiraf.GkiIrafKernel(stdplot)

--- a/lib/pyraf/gkicmd.py
+++ b/lib/pyraf/gkicmd.py
@@ -2,7 +2,7 @@
 iraf gki metacode (primarily for interactive graphics)"""
 # $Id$
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import gki, gwm
 import numpy

--- a/lib/pyraf/gkicmd.py
+++ b/lib/pyraf/gkicmd.py
@@ -15,10 +15,10 @@ def text(textstring, x, y):
     """Return metacode for text string written at x,y"""
     gkiX = gkiCoord(x)
     gkiY = gkiCoord(y)
-    data = numpy.fromstring(textstring,numpy.int8) # OK if str or uni
+    data = numpy.fromstring(textstring, numpy.int8) # OK if str or uni
     data = data.astype(numpy.int16)
     size = 6 + len(textstring)
-    metacode = numpy.zeros(size,numpy.int16)
+    metacode = numpy.zeros(size, numpy.int16)
     metacode[0] = gki.BOI
     metacode[1] = gki.GKI_TEXT
     metacode[2] = size
@@ -57,7 +57,7 @@ def markCross(x, y, size=1., xflag=0, yflag=0,
     else:
         gkiYmin = gkiCoord(0.)
         gkiYmax = gkiCoord(limit)
-    metacode = numpy.zeros(22,numpy.int16)
+    metacode = numpy.zeros(22, numpy.int16)
     i = 0
     metacode[i  ] = gki.BOI
     metacode[i+1] = gki.GKI_PLSET

--- a/lib/pyraf/gkigcur.py
+++ b/lib/pyraf/gkigcur.py
@@ -3,7 +3,7 @@ implement IRAF gcur functionality
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import string, os, sys, numpy
 import Tkinter as TKNTR

--- a/lib/pyraf/gkigcur.py
+++ b/lib/pyraf/gkigcur.py
@@ -85,16 +85,16 @@ class Gcursor:
 
     def bind(self):
 
-        self.gwidget.bind("<Button-1>",self.getMousePosition)
-        self.gwidget.bind("<Key>",self.getKey)
-        self.gwidget.bind("<Up>",self.moveUp)
-        self.gwidget.bind("<Down>",self.moveDown)
-        self.gwidget.bind("<Right>",self.moveRight)
-        self.gwidget.bind("<Left>",self.moveLeft)
-        self.gwidget.bind("<Shift-Up>",self.moveUpBig)
-        self.gwidget.bind("<Shift-Down>",self.moveDownBig)
-        self.gwidget.bind("<Shift-Right>",self.moveRightBig)
-        self.gwidget.bind("<Shift-Left>",self.moveLeftBig)
+        self.gwidget.bind("<Button-1>", self.getMousePosition)
+        self.gwidget.bind("<Key>", self.getKey)
+        self.gwidget.bind("<Up>", self.moveUp)
+        self.gwidget.bind("<Down>", self.moveDown)
+        self.gwidget.bind("<Right>", self.moveRight)
+        self.gwidget.bind("<Left>", self.moveLeft)
+        self.gwidget.bind("<Shift-Up>", self.moveUpBig)
+        self.gwidget.bind("<Shift-Down>", self.moveDownBig)
+        self.gwidget.bind("<Shift-Right>", self.moveRightBig)
+        self.gwidget.bind("<Shift-Left>", self.moveLeftBig)
 
     def unbind(self):
 
@@ -194,9 +194,9 @@ class Gcursor:
             # control-C causes interrupt
             self.window.gcurTerminate("interrupted by `^C'")
 
-        x,y = self.getNDCCursorPos()
+        x, y = self.getNDCCursorPos()
         if self.markcur and key not in 'q?:=UR':
-            metacode = gkicmd.markCross(x,y)
+            metacode = gkicmd.markCross(x, y)
             self.appendMetacode(metacode)
         if key == ':':
             colonString = self.readString(prompt=": ")
@@ -211,7 +211,7 @@ class Gcursor:
                     else:
                         self.writeString("Unimplemented CL gcur `:%s'" % colonString)
                 else:
-                    self._setRetString(key,x,y,colonString)
+                    self._setRetString(key, x, y, colonString)
         elif key == '=':
             # snap command - print the plot
             import gki
@@ -224,19 +224,19 @@ class Gcursor:
                 self.window.redrawOriginal()
             elif key == 'T':
                 textString = self.readString(prompt="Annotation string: ")
-                metacode = gkicmd.text(textString,x,y)
+                metacode = gkicmd.text(textString, x, y)
                 self.window.forceNextDraw() # we can afford a perf hit here,
                                             # a human just typed in text
                 self.appendMetacode(metacode)
             elif key == 'U':
                 self.window.undoN()
             elif key == 'C':
-                wx,wy,gwcs = self._convertXY(x,y)
-                self.writeString("%g %g" % (wx,wy))
+                wx, wy, gwcs = self._convertXY(x, y)
+                self.writeString("%g %g" % (wx, wy))
             else:
                 self.writeString("Unimplemented CL gcur command `%s'" % key)
         else:
-            self._setRetString(key,x,y,"")
+            self._setRetString(key, x, y, "")
 
     def appendMetacode(self, metacode):
         # appended code is undoable
@@ -246,13 +246,13 @@ class Gcursor:
         """Returns x,y,gwcs converted to physical units using current WCS"""
         wcs = self.window.wcs
         if wcs:
-            return wcs.get(x,y)
+            return wcs.get(x, y)
         else:
-            return (x,y,0)
+            return (x, y, 0)
 
     def _setRetString(self, key, x, y, colonString):
 
-        wx,wy,gwcs = self._convertXY(x,y)
+        wx, wy, gwcs = self._convertXY(x, y)
         if key <= ' ' or ord(key) >= 127:
             key = '\\%03o' % ord(key)
         self.retString = str(wx)+' '+str(wy)+' '+str(gwcs)+' '+key

--- a/lib/pyraf/gkiiraf.py
+++ b/lib/pyraf/gkiiraf.py
@@ -79,7 +79,7 @@ class GkiIrafKernel(gki.GkiKernel):
         if metacode:
             # write to a temporary file
             tmpfn = iraf.mktemp("iraf") + ".gki"
-            fout = open(tmpfn,'wb')
+            fout = open(tmpfn, 'wb')
             fout.write(metacode)
             fout.close()
             try:
@@ -102,6 +102,6 @@ class GkiIrafKernel(gki.GkiKernel):
                 # problems with redirection. Sometimes graphics kernel tries
                 # to read from stdin if it is not the default stdin.
 
-                self.task(tmpfn,device=device,generic="yes",Stdin=sys.__stdin__)
+                self.task(tmpfn, device=device, generic="yes", Stdin=sys.__stdin__)
             finally:
                 os.remove(tmpfn)

--- a/lib/pyraf/gkiiraf.py
+++ b/lib/pyraf/gkiiraf.py
@@ -30,7 +30,7 @@ class GkiIrafKernel(gki.GkiKernel):
 
         gki.GkiKernel.__init__(self)
         graphcap = gki.getGraphcap()
-        if not device in graphcap:
+        if device not in graphcap:
             raise iraf.IrafError(
                     "No entry found for specified stdgraph device `%s'" %
                     device)
@@ -39,7 +39,7 @@ class GkiIrafKernel(gki.GkiKernel):
         self.executable = executable = gentry['kf']
         self.taskname = taskname = gentry['tn']
         self.wcs = None
-        if not taskname in _kernelDict:
+        if taskname not in _kernelDict:
             # create special IRAF task object for this kernel
             _kernelDict[taskname] = module.IrafGKITask(taskname, executable)
         self.task = _kernelDict[taskname]

--- a/lib/pyraf/gkiiraf.py
+++ b/lib/pyraf/gkiiraf.py
@@ -3,7 +3,7 @@ OpenGL implementation of the gki kernel class
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import sys, os, string
 from stsci.tools.for2to3 import ndarr2bytes

--- a/lib/pyraf/gkitkbase.py
+++ b/lib/pyraf/gkitkbase.py
@@ -177,16 +177,16 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         # Create the root window as required, but hide it
         irafutils.init_tk_default_root()
         # note size is just an estimate that helps window manager place window
-        self.top = TKNTR.Toplevel(visual='best',width=600,height=485)
+        self.top = TKNTR.Toplevel(visual='best', width=600, height=485)
         # Read the epar options database file
         optfile = "epar.optionDB"
         try:
-            self.top.option_readfile(os.path.join(os.curdir,optfile))
+            self.top.option_readfile(os.path.join(os.curdir, optfile))
         except TKNTR.TclError:
             try:
-                self.top.option_readfile(os.path.join(userWorkingHome,optfile))
+                self.top.option_readfile(os.path.join(userWorkingHome, optfile))
             except TKNTR.TclError:
-                self.top.option_readfile(os.path.join(pyrafDir,optfile))
+                self.top.option_readfile(os.path.join(pyrafDir, optfile))
         self.top.title(windowName)
         self.top.iconname(windowName)
         self.top.protocol("WM_DELETE_WINDOW", self.gwdestroy)
@@ -326,7 +326,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         metacode = numpy.fromstring(fh.read(), numpy.int16) # OK: bytes in PY3K
         fh.close()
         self.clear(name=fname)
-        self.append(metacode,isUndoable=1)
+        self.append(metacode, isUndoable=1)
         self.forceNextDraw()
         self.redraw()
 
@@ -496,7 +496,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         else:
             menu.entryconfigure(button.lastNum, state=TKNTR.DISABLED)
         # Delete everything past the separator
-        menu.delete(str(button.sepNum),'10000')
+        menu.delete(str(button.sepNum), '10000')
         menu.add_separator()
         # Add radio buttons for pages
         # Only show limited window around active page
@@ -513,14 +513,14 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         pmax = min(pmax, lhis)
         pmin = max(0, pmin)
         h = self.history
-        for i in range(pmin,pmax):
+        for i in range(pmin, pmax):
             task = h[i][2]
             if i==pmin and pmin>0:
                 label = "<< %s" % task
             elif i==pmax-1 and pmax<lhis:
                 label = ">> %s" % task
             else:
-                label = "%2d %s" % (i+1,task)
+                label = "%2d %s" % (i+1, task)
             menu.add_radiobutton(label=label, command=self.selectedPage,
                                  value=i, variable=self.bttnVar)
         # Make sure pageVar matches the real index value
@@ -543,13 +543,13 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def backPage(self):
         self.prePageSelect()
-        n = max(0,self._currentPage-1)
+        n = max(0, self._currentPage-1)
         self.pageVar.set(n)
         self.bttnVar.set(n)
 
     def nextPage(self):
         self.prePageSelect()
-        n = max(0,min(self._currentPage+1, len(self.history)-1))
+        n = max(0, min(self._currentPage+1, len(self.history)-1))
         self.pageVar.set(n)
         self.bttnVar.set(n)
 
@@ -596,7 +596,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         winVar = self.manager.getWindowVar()
         winList = sorted(self.manager.windowNames())
         # Delete everything past the separator
-        menu.delete('1','10000')
+        menu.delete('1', '10000')
         menu.add_separator()
         # Add radio buttons for windows
         for i in range(len(winList)):
@@ -665,7 +665,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
         self.gwidget.activate()
 
-    def errorMessage(self,text):
+    def errorMessage(self, text):
 
         """Truncate number of error messages produced in a plot."""
 

--- a/lib/pyraf/gkitkbase.py
+++ b/lib/pyraf/gkitkbase.py
@@ -594,8 +594,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
         menu = self.windowMenu.menu
         winVar = self.manager.getWindowVar()
-        winList = self.manager.windowNames()
-        winList.sort()
+        winList = sorted(self.manager.windowNames())
         # Delete everything past the separator
         menu.delete('1','10000')
         menu.add_separator()

--- a/lib/pyraf/gkitkbase.py
+++ b/lib/pyraf/gkitkbase.py
@@ -3,7 +3,7 @@ Tk gui implementation for the gki plot widget
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import numpy, os, sys, string, time
 import Tkinter as TKNTR # requires 2to3
@@ -671,10 +671,10 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         """Truncate number of error messages produced in a plot."""
 
         if self._errorMessageCount < self.MAX_ERROR_COUNT:
-            print text
+            print(text)
             self._errorMessageCount = self._errorMessageCount + 1
         elif self._errorMessageCount == self.MAX_ERROR_COUNT:
-            print "\nAdditional graphics error messages suppressed"
+            print("\nAdditional graphics error messages suppressed")
             self._errorMessageCount = self._errorMessageCount + 1
 
     def flush(self):

--- a/lib/pyraf/gkitkbase.py
+++ b/lib/pyraf/gkitkbase.py
@@ -917,7 +917,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
         if not self.wcs:
             self.errorMessage("Error: can't append to a nonexistent plot!")
-            raise IrafError
+            raise IrafError()
         if self.returnData:
             self.returnData = self.returnData + self.wcs.pack()
         else:

--- a/lib/pyraf/gkitkplot.py
+++ b/lib/pyraf/gkitkplot.py
@@ -332,7 +332,7 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
                    - numpy.array([0.,1.]))).astype(numpy.int32)
         # Lack of intrinsic Tk point mode means that they must be explicitly
         # looped over.
-        for i in xrange(npts):
+        for i in range(npts):
             gw.create_rectangle(scaled[i,0], scaled[i,1],
                                 scaled[i,0], scaled[i,1],
                                 fill=color, outline='')

--- a/lib/pyraf/gkitkplot.py
+++ b/lib/pyraf/gkitkplot.py
@@ -4,7 +4,7 @@ Tkplot implementation of the gki kernel class
 $Id$
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import numpy, sys, string
 import Tkinter as TKNTR # requires 2to3

--- a/lib/pyraf/gkitkplot.py
+++ b/lib/pyraf/gkitkplot.py
@@ -12,7 +12,7 @@ from stsci.tools.for2to3 import ndarr2str
 import wutil, Ptkplot
 import gki, gkitkbase, gkigcur, tkplottext, textattrib, irafgwcs
 
-TK_LINE_STYLE_PATTERNS = ['.','.','_','.','.._']
+TK_LINE_STYLE_PATTERNS = ['.', '.', '_', '.', '.._']
 
 #-----------------------------------------------
 
@@ -146,7 +146,7 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
 
         """append a 2-tuple (tkplot_function, args) to the glBuffer"""
 
-        self.drawBuffer.append((tkplot_function,args))
+        self.drawBuffer.append((tkplot_function, args))
 
     def gki_clearws(self, arg):
 
@@ -278,8 +278,8 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         # Have Tk remove all previously plotted objects
         self.gwidget.delete(TKNTR.ALL)
         # Clear the screen
-        self.tkplot_faset(0,0)
-        self.tkplot_fillarea(numpy.array([0.,0.,1.,0.,1.,1.,0.,1.]))
+        self.tkplot_faset(0, 0)
+        self.tkplot_fillarea(numpy.array([0., 0., 1., 0., 1., 1., 0., 1.]))
         # Plot the current buffer
         for (function, args) in self.drawBuffer.get():
             function(*args)
@@ -312,9 +312,9 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         gw = self.gwidget
         h = gw.winfo_height()
         w = gw.winfo_width()
-        scaled = (numpy.array([w,-h]) *
+        scaled = (numpy.array([w, -h]) *
                   (numpy.reshape(vertices, (npts, 2))
-                   - numpy.array([0.,1.])))
+                   - numpy.array([0., 1.])))
         gw.create_line(*(tuple(scaled.ravel().astype(numpy.int32))), **options)
 
     def tkplot_polymarker(self, vertices):
@@ -327,18 +327,18 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         gw = self.gwidget
         h = gw.winfo_height()
         w = gw.winfo_width()
-        scaled = (numpy.array([w,-h]) *
+        scaled = (numpy.array([w, -h]) *
                   (numpy.reshape(vertices, (npts, 2))
-                   - numpy.array([0.,1.]))).astype(numpy.int32)
+                   - numpy.array([0., 1.]))).astype(numpy.int32)
         # Lack of intrinsic Tk point mode means that they must be explicitly
         # looped over.
         for i in range(npts):
-            gw.create_rectangle(scaled[i,0], scaled[i,1],
-                                scaled[i,0], scaled[i,1],
+            gw.create_rectangle(scaled[i, 0], scaled[i, 1],
+                                scaled[i, 0], scaled[i, 1],
                                 fill=color, outline='')
     def tkplot_text(self, x, y, text):
 
-        tkplottext.softText(self,x,y,text)
+        tkplottext.softText(self, x, y, text)
 
     def tkplot_fillarea(self, vertices):
 
@@ -355,12 +355,12 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         gw = self.gwidget
         h = gw.winfo_height()
         w = gw.winfo_width()
-        scaled = (numpy.array([w,-h]) *
+        scaled = (numpy.array([w, -h]) *
                   (numpy.reshape(vertices, (npts, 2))
-                   - numpy.array([0.,1.])))
+                   - numpy.array([0., 1.])))
         coords = tuple(scaled.ravel().astype(numpy.int32))
         if fa.fillstyle == 1: # hollow
-            gw.create_line(*(coords+(coords[0],coords[1])), **options)
+            gw.create_line(*(coords+(coords[0], coords[1])), **options)
         else: # solid or clear cases
             gw.create_polygon(*coords, **options)
 
@@ -443,4 +443,4 @@ class tkColorManager:
         red = int(255*color[0])
         green = int(255*color[1])
         blue = int(255*color[2])
-        return "#%02x%02x%02x" % (red,green,blue)
+        return "#%02x%02x%02x" % (red, green, blue)

--- a/lib/pyraf/graphcap.py
+++ b/lib/pyraf/graphcap.py
@@ -117,7 +117,7 @@ class Device(compmixin.ComparableMixin):
     def getAttribute(self, attrName):
         thedict = self.dict[self.devname]
         value = None
-        while 1:
+        while True:
             if attrName in thedict:
                 value = thedict[attrName]
                 break

--- a/lib/pyraf/graphcap.py
+++ b/lib/pyraf/graphcap.py
@@ -2,7 +2,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import string
 from stsci.tools import compmixin
@@ -52,7 +52,7 @@ def getAttributes(entry):
                     try:
                         value = float(attrval[1:])
                     except ValueError:
-                        print "problem reading graphcap"
+                        print("problem reading graphcap")
                         raise
             elif attrval[0] == '@':
                 # implies false
@@ -95,7 +95,7 @@ class GraphCap(filecache.FileCache):
         """Get up-to-date version of dictionary"""
         thedict = self.get()
         if not key in thedict:
-            print "Error: device not found in graphcap"
+            print("Error: device not found in graphcap")
             raise KeyError()
         return Device(thedict, key)
 

--- a/lib/pyraf/graphcap.py
+++ b/lib/pyraf/graphcap.py
@@ -84,7 +84,7 @@ class GraphCap(filecache.FileCache):
 
     def updateValue(self):
         """Called on init and if file changes"""
-        lines = open(self.filename,'r').readlines()
+        lines = open(self.filename, 'r').readlines()
         mergedlines = merge(lines)
         self.dict = getDevices(mergedlines)
 

--- a/lib/pyraf/graphcap.py
+++ b/lib/pyraf/graphcap.py
@@ -94,7 +94,7 @@ class GraphCap(filecache.FileCache):
     def __getitem__(self, key):
         """Get up-to-date version of dictionary"""
         thedict = self.get()
-        if not key in thedict:
+        if key not in thedict:
             print("Error: device not found in graphcap")
             raise KeyError()
         return Device(thedict, key)

--- a/lib/pyraf/graphcap.py
+++ b/lib/pyraf/graphcap.py
@@ -96,7 +96,7 @@ class GraphCap(filecache.FileCache):
         thedict = self.get()
         if not key in thedict:
             print "Error: device not found in graphcap"
-            raise KeyError
+            raise KeyError()
         return Device(thedict, key)
 
     def has_key(self, key): return self._has(key)

--- a/lib/pyraf/gwm.py
+++ b/lib/pyraf/gwm.py
@@ -4,7 +4,7 @@ use by python plotting
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, string
 from stsci.tools import capable
@@ -93,7 +93,7 @@ class GraphicsWindowManager(gki.GkiProxy):
         windowName = str(windowName).strip()
         window = self.windows.get(windowName)
         if window is None:
-            print "error: graphics window `%s' doesn't exist" % (windowName,)
+            print("error: graphics window `%s' doesn't exist" % (windowName,))
         else:
             changeActiveWindow = (self.stdgraph == window)
             window.top.destroy()
@@ -141,25 +141,25 @@ def _setGraphicsWindowManager():
                 import gkitkplot
                 kernel = gkitkplot.GkiTkplotKernel
             elif kernelname == "opengl":
-                print "OpenGL kernel no longer exists, using default instead"
+                print("OpenGL kernel no longer exists, using default instead")
                 kernelname = "default"
             elif kernelname == "matplotlib":
                 try:
                     import GkiMpl
                     kernel = GkiMpl.GkiMplKernel
                 except ImportError:
-                    print "matplotlib is not installed, using default instead"
+                    print("matplotlib is not installed, using default instead")
                     kernelname = "default"
             else:
-                print 'Graphics kernel specified by "PYRAFGRAPHICS='+ \
-                       kernelname+'" not found.'
-                print "Using default kernel instead."
+                print('Graphics kernel specified by "PYRAFGRAPHICS='+ \
+                       kernelname+'" not found.')
+                print("Using default kernel instead.")
                 kernelname = "default"
         else:
             kernelname = "default"
 
         if 'PYRAFGRAPHICS_TEST' in os.environ:
-            print "Using graphics kernel: "+kernelname
+            print("Using graphics kernel: "+kernelname)
         if kernelname == "default":
             import gkitkplot
             kernel = gkitkplot.GkiTkplotKernel

--- a/lib/pyraf/gwm.py
+++ b/lib/pyraf/gwm.py
@@ -82,7 +82,7 @@ class GraphicsWindowManager(gki.GkiProxy):
 
     def windowNames(self):
         """Return list of all window names"""
-        return self.windows.keys()
+        return list(self.windows.keys())
 
     def getWindowVar(self):
         """Return Tk variable associated with selected window"""
@@ -114,7 +114,7 @@ class GraphicsWindowManager(gki.GkiProxy):
                 else:
                     # something's messed up
                     # change to randomly selected active window
-                    wname = self.windows.keys()[0]
+                    wname = list(self.windows.keys())[0]
                 self.windowVar.set(wname)
             wutil.focusController.removeFocusEntity(windowName)
 

--- a/lib/pyraf/gwm.py
+++ b/lib/pyraf/gwm.py
@@ -49,7 +49,7 @@ class GraphicsWindowManager(gki.GkiProxy):
     def getNewWindowName(self, root="graphics"):
         """Return a new (unused) window name of form root+number"""
         number = 1
-        while 1:
+        while True:
             windowName = root + str(number)
             if windowName not in self.windows:
                 return windowName

--- a/lib/pyraf/gwm.py
+++ b/lib/pyraf/gwm.py
@@ -78,7 +78,7 @@ class GraphicsWindowManager(gki.GkiProxy):
             self.stdgraph = self.windows[windowName]
             self.stdgraph.activate()
             # register with focus manager
-            wutil.focusController.addFocusEntity(windowName,self.stdgraph)
+            wutil.focusController.addFocusEntity(windowName, self.stdgraph)
 
     def windowNames(self):
         """Return list of all window names"""

--- a/lib/pyraf/gwm.py
+++ b/lib/pyraf/gwm.py
@@ -51,7 +51,7 @@ class GraphicsWindowManager(gki.GkiProxy):
         number = 1
         while 1:
             windowName = root + str(number)
-            if not windowName in self.windows:
+            if windowName not in self.windows:
                 return windowName
             number = number + 1
 
@@ -61,7 +61,7 @@ class GraphicsWindowManager(gki.GkiProxy):
             windowName = str(windowName).strip()
         if not windowName:
             windowName = self.getNewWindowName()
-        if not windowName in self.windows:
+        if windowName not in self.windows:
             self.windows[windowName] = self.GkiKernelClass(windowName, self)
             self.createList.append(windowName)
         if self.windowVar is None:

--- a/lib/pyraf/ipython_api.py
+++ b/lib/pyraf/ipython_api.py
@@ -135,7 +135,7 @@ class IPython_PyRAF_Integrator(object):
 
 
     def __init__(self, clemulate=1, cmddict={},
-                 cmdchars=("a-zA-Z_.","0-9")):
+                 cmdchars=("a-zA-Z_.", "0-9")):
         import re, sys, os
         self.reword = re.compile('[a-z]*')
         self._cl_emulation = clemulate
@@ -237,7 +237,7 @@ class IPython_PyRAF_Integrator(object):
             method_name = self.cmddict.get(cmd)
         if method_name is None:
             # no method, but have a look at it anyway
-            return self.default(cmd,line,i)
+            return self.default(cmd, line, i)
         else:
             # if in cmddict, there must be a method by this name
             f = getattr(self, method_name)
@@ -274,7 +274,7 @@ class IPython_PyRAF_Integrator(object):
             return line
         elif cmd in self._ipython_magic and cmd not in ['cd']:
             return line
-        elif not hasattr(iraf,cmd):
+        elif not hasattr(iraf, cmd):
             # not an IRAF command
             #XXX Eventually want to improve error message for
             #XXX case where user intended to use IRAF syntax but
@@ -292,7 +292,7 @@ class IPython_PyRAF_Integrator(object):
                 return line
             # check for some Python operator keywords
             mm = self.reword.match(line[i:])
-            if mm.group() in ["is","in","and","or","not"]:
+            if mm.group() in ["is", "in", "and", "or", "not"]:
                 return line
         elif line[i:i+1] == '(':
             if cmd in ['type', 'dir', 'set']:
@@ -309,7 +309,7 @@ class IPython_PyRAF_Integrator(object):
                 #XXX this find() may be improved with latest Python readline features
                 j = line.find(cmd)
                 return line[:j] + 'iraf.' + line[j:]
-        elif not callable(getattr(iraf,cmd)):
+        elif not callable(getattr(iraf, cmd)):
             # variable from iraf module is not callable task (e.g.,
             # yes, no, INDEF, etc.) -- add 'iraf.' so it can be used
             # as a variable and execute as Python
@@ -373,9 +373,9 @@ class IPython_PyRAF_Integrator(object):
 
     def _evaluate_flag(self, flag, usage):
         try:
-            if flag in [None,"", "on","ON", "On", "True","TRUE","true"]:
+            if flag in [None, "", "on", "ON", "On", "True", "TRUE", "true"]:
                 return True
-            elif flag in ["off","OFF","Off","False","FALSE","false"]:
+            elif flag in ["off", "OFF", "Off", "False", "FALSE", "false"]:
                 return False
             else:
                 return int(flag)
@@ -402,7 +402,7 @@ class IPython_PyRAF_Integrator(object):
         """
         magic, flag = line.split()
         if self._evaluate_flag(flag, "set_pyraf_magic <magic_function>"):
-            self._debug("PyRAF magic for", magic,"on")
+            self._debug("PyRAF magic for", magic, "on")
             while magic in self._ipython_magic:  # should only be one
                 self._ipython_magic.remove(magic)
         else:

--- a/lib/pyraf/ipython_api.py
+++ b/lib/pyraf/ipython_api.py
@@ -14,7 +14,7 @@ $Id$
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 #*****************************************************************************
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 VERY_OLD_IPY = True # this means prior to v0.12
 try:
@@ -49,7 +49,7 @@ _locals = globals()
 # del iraf, __version__, makeIrafPar, yes, no, INDEF, EOF, logout, quit, exit
 
 if '-nobanner' not in sys.argv and '--no-banner' not in sys.argv:
-    print "\nPyRAF", __version__, "Copyright (c) 2002 AURA"
+    print("\nPyRAF", __version__, "Copyright (c) 2002 AURA")
 
 # Start up command line wrapper keeping definitions in main name space
 # Keep the command-line object in namespace too for access to history
@@ -381,7 +381,7 @@ class IPython_PyRAF_Integrator(object):
                 return int(flag)
         except:
             import sys
-            print >>sys.stderr, "usage:", usage,  "[on | off]"
+            print("usage:", usage,  "[on | off]", file=sys.stderr)
             raise
 
     def _get_IP(self, IP):
@@ -393,8 +393,8 @@ class IPython_PyRAF_Integrator(object):
     def _debug(self, *args):
         import sys
         for a in args:
-            print >>sys.stderr, a,
-        print >>sys.stderr
+            print(a, end=' ', file=sys.stderr)
+        print(file=sys.stderr)
 
     def set_pyraf_magic(self, IP, line):
         """Setting flag="1" Enables PyRAF to intepret a magic
@@ -445,7 +445,7 @@ if VERY_OLD_IPY:
     __PyRAF.use_pyraf_traceback(feedback=fb)
 else:
     if '-nobanner' not in sys.argv and '--no-banner' not in sys.argv:
-        print "PyRAF traceback not enabled"
+        print("PyRAF traceback not enabled")
 del fb
 
 del IPythonIrafCompleter, IPython_PyRAF_Integrator, IrafCompleter

--- a/lib/pyraf/ipython_api.py
+++ b/lib/pyraf/ipython_api.py
@@ -180,7 +180,7 @@ class IPython_PyRAF_Integrator(object):
             # this is pretty far into IPython, i.e. very breakable
             # lsmagic() returns a dict of 2 dicts: 'cell', and 'line'
             if hasattr(self._ipython_api, 'magics_manager'):
-                self._ipython_magic = self._ipython_api.magics_manager.lsmagic()['line'].keys()
+                self._ipython_magic = list(self._ipython_api.magics_manager.lsmagic()['line'].keys())
             else:
                 print('Please upgrade your version of IPython.')
             pfmgr = self._ipython_api.prefilter_manager

--- a/lib/pyraf/iraf.py
+++ b/lib/pyraf/iraf.py
@@ -4,7 +4,7 @@ $Id$
 
 R. White, 1999 Jan 25
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from iraffunctions import *
 

--- a/lib/pyraf/irafcompleter.py
+++ b/lib/pyraf/irafcompleter.py
@@ -332,7 +332,7 @@ class IrafCompleter(Completer):
         """Return matches for iraf.package.task.param..."""
         head = ".".join(fields[:-1])
         tail = fields[-1]
-        matches = eval("%s.getAllMatches(%s)" % (head, `tail`))
+        matches = eval("%s.getAllMatches(%s)" % (head, repr(tail)))
         def addhead(s, head=head+"."): return head+s
         return map(addhead, matches)
 

--- a/lib/pyraf/irafcompleter.py
+++ b/lib/pyraf/irafcompleter.py
@@ -100,7 +100,7 @@ class IrafCompleter(Completer):
         if os.path.exists(hfile):
             try:
                 readline.read_history_file(hfile)
-            except IOError, e:
+            except IOError as e:
                 # we do NOT want this to prevent startup.  see ticket #132
                 print 'ERROR reading "'+hfile+'" -> '+str(e)
 

--- a/lib/pyraf/irafcompleter.py
+++ b/lib/pyraf/irafcompleter.py
@@ -334,7 +334,7 @@ class IrafCompleter(Completer):
         tail = fields[-1]
         matches = eval("%s.getAllMatches(%s)" % (head, repr(tail)))
         def addhead(s, head=head+"."): return head+s
-        return map(addhead, matches)
+        return list(map(addhead, matches))
 
 def activate(c="\t"):
     completer.activate(c)

--- a/lib/pyraf/irafcompleter.py
+++ b/lib/pyraf/irafcompleter.py
@@ -33,7 +33,7 @@ except ImportError:
 # dictionaries mapping between characters and readline names
 char2lab = {}
 lab2char = {}
-for i in range(1,27):
+for i in range(1, 27):
     char = chr(i)
     ichar = chr(ord('a')+i-1)
     lab = "Control-%s" % ichar
@@ -93,10 +93,10 @@ class IrafCompleter(Completer):
         self.completionChar = char
         # remove dash from delimiter set (fix submitted by Joe P. Ninan 4/16/14)
         delims = readline.get_completer_delims()
-        delims = delims.replace('-','')
+        delims = delims.replace('-', '')
         readline.set_completer_delims(delims)
         # load any cmd history
-        hfile = os.getenv('HOME','.')+os.sep+'.pyraf_history'
+        hfile = os.getenv('HOME', '.')+os.sep+'.pyraf_history'
         if os.path.exists(hfile):
             try:
                 readline.read_history_file(hfile)
@@ -183,7 +183,7 @@ class IrafCompleter(Completer):
             else:
                 if not hasattr(self, "namespace"):
                     self.namespace = {}
-                return Completer.global_matches(self,text)
+                return Completer.global_matches(self, text)
         else:
             taskname = m.group(1)
             # check for pipe/redirection using last non-blank character
@@ -298,14 +298,14 @@ class IrafCompleter(Completer):
                 fields.insert(0, 'iraf')
                 matches = self.taskdot_matches(fields)
                 try:
-                    matches.extend(Completer.attr_matches(self,text))
+                    matches.extend(Completer.attr_matches(self, text))
                 except KeyboardInterrupt:
                     raise
                 except:
                     pass
                 return matches
             else:
-                return Completer.attr_matches(self,text)
+                return Completer.attr_matches(self, text)
         else:
             # Check first character following initial alphabetic string
             # If next char is alphabetic (or null) use filename matches
@@ -318,7 +318,7 @@ class IrafCompleter(Completer):
                 if fields[0] == "iraf":
                     return self.taskdot_matches(fields)
                 else:
-                    return Completer.attr_matches(self,text)
+                    return Completer.attr_matches(self, text)
             else:
                 #XXX Could try to match pset.param keywords too?
                 lt = len(line)-len(text)

--- a/lib/pyraf/irafcompleter.py
+++ b/lib/pyraf/irafcompleter.py
@@ -14,7 +14,7 @@ $Id$
 
 RLW, 2000 February 13
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import __builtin__
 import __main__
@@ -102,7 +102,7 @@ class IrafCompleter(Completer):
                 readline.read_history_file(hfile)
             except IOError as e:
                 # we do NOT want this to prevent startup.  see ticket #132
-                print 'ERROR reading "'+hfile+'" -> '+str(e)
+                print('ERROR reading "'+hfile+'" -> '+str(e))
 
     def deactivate(self):
         """Turn off completion, restoring old behavior for character"""

--- a/lib/pyraf/irafdisplay.py
+++ b/lib/pyraf/irafdisplay.py
@@ -28,7 +28,7 @@ replacement for CDL.
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, numpy, socket, sys
 from stsci.tools.for2to3 import PY3K, bytes_write, ndarr2bytes

--- a/lib/pyraf/irafdisplay.py
+++ b/lib/pyraf/irafdisplay.py
@@ -43,7 +43,7 @@ except:
         raise
 
 # FCNTL is deprecated in Python 2.2
-if hasattr(fcntl,'F_SETFL') or fcntl==None:
+if hasattr(fcntl, 'F_SETFL') or fcntl==None:
     FCNTL = fcntl
 else:
     import FCNTL
@@ -110,7 +110,7 @@ def _open(imtdev=None):
     if domain == "unix" and len(fields) == 2:
         return UnixImageDisplay(fields[1])
     elif domain == "fifo" and len(fields) == 3:
-        return FifoImageDisplay(fields[1],fields[2])
+        return FifoImageDisplay(fields[1], fields[2])
     elif domain == "inet" and (2 <= len(fields) <= 3):
         try:
             port = int(fields[1])
@@ -162,11 +162,11 @@ class ImageDisplay:
         # only part up to newline is real data
         return s.split("\n")[0]
 
-    def _writeHeader(self,tid,subunit,thingct,x,y,z,t):
+    def _writeHeader(self, tid, subunit, thingct, x, y, z, t):
 
         """Write request to image display"""
 
-        a = numpy.array([tid,thingct,subunit,0,x,y,z,t], numpy.int16)
+        a = numpy.array([tid, thingct, subunit, 0, x, y, z, t], numpy.int16)
         # Compute the checksum
         sum = numpy.add.reduce(a)
         sum = 0xffff - (sum & 0xffff)

--- a/lib/pyraf/irafdisplay.py
+++ b/lib/pyraf/irafdisplay.py
@@ -130,9 +130,9 @@ class ImageDisplay:
     """Interface to IRAF-compatible image display"""
 
     # constants for cursor read
-    _IIS_READ = 0100000
-    _IMC_SAMPLE = 0040000
-    _IMCURSOR = 020
+    _IIS_READ = 0o100000
+    _IMC_SAMPLE = 0o040000
+    _IMCURSOR = 0o20
     _SZ_IMCURVAL = 160
 
     def __init__(self):

--- a/lib/pyraf/irafdisplay.py
+++ b/lib/pyraf/irafdisplay.py
@@ -99,7 +99,7 @@ def _open(imtdev=None):
         for imtdev in defaults:
             try:
                 return _open(imtdev)
-            except IOError, error:
+            except IOError as error:
                 pass
         raise IOError("Cannot open image display")
     # substitute user id in name (multiple times) if necessary
@@ -225,7 +225,7 @@ class FifoImageDisplay(ImageDisplay):
             fcntl.fcntl(self._fdin, FCNTL.F_SETFL, os.O_RDONLY)
             self._fdout = os.open(outfile, os.O_WRONLY | os.O_NDELAY)
             fcntl.fcntl(self._fdout, FCNTL.F_SETFL, os.O_WRONLY)
-        except OSError, error:
+        except OSError as error:
             raise IOError("Cannot open image display (%s)" % (error,))
         except AttributeError:
             raise RuntimeError("Image fcntl is not supported on this platform")
@@ -245,7 +245,7 @@ class UnixImageDisplay(ImageDisplay):
             self._socket = socket.socket(family, type)
             self._socket.connect(filename)
             self._fdin = self._fdout = self._socket.fileno()
-        except socket.error, error:
+        except socket.error as error:
             raise IOError("Cannot open image display")
 
     def close(self):
@@ -311,7 +311,7 @@ class ImageDisplayProxy(ImageDisplay):
             # Null value indicates display was probably closed
             if value:
                 return value
-        except IOError, error:
+        except IOError as error:
             pass
         # This error can occur if image display was closed.
         # If a new display has been started then closing and

--- a/lib/pyraf/irafecl.py
+++ b/lib/pyraf/irafecl.py
@@ -367,7 +367,7 @@ class EclTraceback(EclBase):
             del e._ecl_suppress_first_trace
         else:
             self._ecl_trace("  ", repr(cl_code))
-        self._ecl_trace("      line %d: %s" % (lineno , cl_file))
+        self._ecl_trace("      line %d: %s" % (lineno, cl_file))
         parent = _ecl_parent_task()
         if parent:
             parent_lineno = self._ecl_get_lineno()

--- a/lib/pyraf/irafecl.py
+++ b/lib/pyraf/irafecl.py
@@ -1,7 +1,7 @@
 """This module adds IRAF ECL style error handling to PyRAF."""
 # $Id$
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import inspect, sys
 from stsci.tools.irafglobals import Verbose
@@ -167,8 +167,8 @@ class EclBase:
         self.setParList(*args, **kw)
 
         if Verbose>1:
-            print "run %s (%s: %s)" % (self._name,
-                    self.__class__.__name__, self._fullpath)
+            print("run %s (%s: %s)" % (self._name,
+                    self.__class__.__name__, self._fullpath))
             if self._runningParList:
                 self._runningParList.lParam()
 
@@ -188,7 +188,7 @@ class EclBase:
                 self._run(redirKW, specialKW)
                 self._updateParList(save)
                 if Verbose>1:
-                    print >> sys.stderr, 'Successful task termination'
+                    print('Successful task termination', file=sys.stderr)
             finally:
                 rv = self._resetRedir(resetList, closeFHList)
                 self._deleteRunningParList()

--- a/lib/pyraf/irafecl.py
+++ b/lib/pyraf/irafecl.py
@@ -202,7 +202,7 @@ class EclBase:
         if erract.ecl:
             try:
                 return _runcore()
-            except Exception, e:
+            except Exception as e:
                 self._ecl_handle_error(e)
         else:
             return _runcore()

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -176,8 +176,7 @@ class _ProcessCache:
         If all processes are locked, delete oldest locked process.
         """
         # each entry contains rank (to sort and find oldest) and process
-        values = self._data.values()
-        values.sort()
+        values = sorted(self._data.values())
         if len(self._locked) < len(self._data):
             # find and delete oldest unlocked process
             for rank, proxy in values:
@@ -290,8 +289,7 @@ class _ProcessCache:
 
     def list(self):
         """List processes sorted from newest to oldest with locked flag"""
-        values = self._data.values()
-        values.sort()
+        values = sorted(self._data.values())
         values.reverse()
         n = 0
         for rank, proxy in values:

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -284,7 +284,7 @@ class _ProcessCache:
         else:
             for rank, proxy in self._data.values():
                 executable = proxy.process.executable
-                if not executable in self._locked:
+                if executable not in self._locked:
                     self.terminate(executable)
 
     def list(self):

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -27,7 +27,7 @@ test_probe = False
 
 #stdgraph = None
 
-IPC_PREFIX = ndarr2bytes(numpy.array([0o1120],numpy.int16))
+IPC_PREFIX = ndarr2bytes(numpy.array([0o1120], numpy.int16))
 
 # weirdo protocol to get output from task back to subprocess
 # definitions from cl/task.h and lib/clio.h
@@ -332,7 +332,7 @@ def IrafExecute(task, envdict, stdin=None, stdout=None, stderr=None,
             # do graphics task initialization
             gki.kernel.taskStart(taskname)
             focusMark = wutil.focusController.getCurrentMark()
-            gki.kernel.pushStdio(None,None,None)
+            gki.kernel.pushStdio(None, None, None)
         try:
             irafprocess.run(task, pstdin=stdin, pstdout=stdout, pstderr=stderr)
         finally:
@@ -466,9 +466,9 @@ class IrafProcess:
         # stdinIsatty flag is used in xfer to decide whether to
         # read inputs in blocks or not.  As long as input comes
         # from __stdin__, consider it equivalent to a tty.
-        self.stdinIsatty = (hasattr(stdin,'isatty') and stdin.isatty()) or \
+        self.stdinIsatty = (hasattr(stdin, 'isatty') and stdin.isatty()) or \
                 self.stdin == sys.__stdin__
-        self.stdoutIsatty = hasattr(stdout,'isatty') and stdout.isatty()
+        self.stdoutIsatty = hasattr(stdout, 'isatty') and stdout.isatty()
 
         # stdinIsraw flag is used in xfer to decide whether to
         # read inputs as RAW input or not.
@@ -643,7 +643,7 @@ class IrafProcess:
                 xmit()
             elif msg[:4] == 'bye\n':
                 return
-            elif msg5 in ['error','ERROR']:
+            elif msg5 in ['error', 'ERROR']:
                 errno, text = self._scanErrno(msg)
                 raise IrafProcessError("IRAF task terminated abnormally\n"+msg,
                                        errno=errno, errmsg=text, errtask=self.task.getName())
@@ -749,7 +749,7 @@ class IrafProcess:
                     pmsg = pobj.get(lpar=1)
                 else:
                     # replace all newlines in strings with "\n"
-                    pmsg = pmsg.replace('\n','\\n')
+                    pmsg = pmsg.replace('\n', '\\n')
                 pmsg = pmsg + '\n'
             except EOFError:
                 pmsg = 'EOF\n'
@@ -769,13 +769,13 @@ class IrafProcess:
         newvalue = group('svalue')
         self.msg = self.msg[mcmd.end():]
         try:
-            self.task.setParam(paramname,newvalue)
+            self.task.setParam(paramname, newvalue)
         except ValueError as e:
             # on ValueError, just print warning and then force set
             if Verbose>0:
                 self.stderr.write('Warning: %s\n' % (e,))
                 self.stderr.flush()
-            self.task.setParam(paramname,newvalue,check=0)
+            self.task.setParam(paramname, newvalue, check=0)
 
     def xmit(self):
 
@@ -935,7 +935,7 @@ class IrafProcess:
         """
         msg = self.msg
         try:
-            i = msg.find(",",5)
+            i = msg.find(",", 5)
             if i<0 or msg[-2:] != ")\n": raise ValueError()
             chan = int(msg[5:i])
             nbytes = int(msg[i+1:-2])
@@ -1040,7 +1040,7 @@ def Iraf2AscString(iraf_string):
 
 def log_task_comm(pfx, strbuf, expectAsStr, shorten=True):
     import some_pkg_w_a_log_func as L
-    assert isinstance(strbuf, (str,unicode,bytes)), "?!: "+str(type(strbuf))
+    assert isinstance(strbuf, (str, unicode, bytes)), "?!: "+str(type(strbuf))
     if expectAsStr:
         assert isinstance(strbuf, str), "Unexpected type: "+str(type(strbuf))
     if isinstance(strbuf, (str, unicode)):

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -938,7 +938,7 @@ class IrafProcess:
         msg = self.msg
         try:
             i = msg.find(",",5)
-            if i<0 or msg[-2:] != ")\n": raise ValueError
+            if i<0 or msg[-2:] != ")\n": raise ValueError()
             chan = int(msg[5:i])
             nbytes = int(msg[i+1:-2])
             self.msg = ''

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -318,7 +318,7 @@ def IrafExecute(task, envdict, stdin=None, stdout=None, stderr=None,
     try:
         # Start 'er up
         irafprocess = processCache.get(task, envdict)
-    except (IrafError, subproc.SubprocessError, IrafProcessError), value:
+    except (IrafError, subproc.SubprocessError, IrafProcessError) as value:
         raise
         raise IrafProcessError("Cannot start IRAF executable\n%s" % value)
 
@@ -352,11 +352,11 @@ def IrafExecute(task, envdict, stdin=None, stdout=None, stderr=None,
         # On keyboard interrupt (^C), kill the subprocess
         processCache.kill(irafprocess)
         raise
-    except (IrafError, IrafProcessError), exc:
+    except (IrafError, IrafProcessError) as exc:
         # on error, kill the subprocess, then re-raise the original exception
         try:
             processCache.kill(irafprocess)
-        except Exception, exc2:
+        except Exception as exc2:
             # append new exception text to previous one (right thing to do?)
             exc.args = exc.args + exc2.args
         raise exc
@@ -530,12 +530,12 @@ class IrafProcess:
             self.writeString("bye\n")
             if self.process.wait(0.5):
                 return
-        except (IrafProcessError, subproc.SubprocessError), e:
+        except (IrafProcessError, subproc.SubprocessError) as e:
             pass
         # No more Mr. Nice Guy
         try:
             self.process.die()
-        except subproc.SubprocessError, e:
+        except subproc.SubprocessError as e:
             if Verbose>0:
                 # too bad, if we can't kill it assume it is already dead
                 self.stderr.write("Warning: cannot terminate process %s\n" %
@@ -594,7 +594,7 @@ class IrafProcess:
                                    struct.pack('=h', len(dsection)) +
                                    tobytes(dsection))
                 i = i + block
-        except subproc.SubprocessError, e:
+        except subproc.SubprocessError as e:
             raise IrafProcessError("Error in write: %s" % str(e))
 
     def read(self):
@@ -611,7 +611,7 @@ class IrafProcess:
             # read the rest
             data = self.process.read(nbytes) # read returns bytes
             return data
-        except subproc.SubprocessError, e:
+        except subproc.SubprocessError as e:
             raise IrafProcessError("Error in read: %s" % str(e))
 
     def slave(self):
@@ -772,7 +772,7 @@ class IrafProcess:
         self.msg = self.msg[mcmd.end():]
         try:
             self.task.setParam(paramname,newvalue)
-        except ValueError, e:
+        except ValueError as e:
             # on ValueError, just print warning and then force set
             if Verbose>0:
                 self.stderr.write('Warning: %s\n' % (e,))

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -2,7 +2,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, re, signal, string, struct, sys, time, types, numpy, cStringIO
 from stsci.tools import irafutils
@@ -225,7 +225,7 @@ class _ProcessCache:
         for taskname in args:
             task = pyraf.iraf.getTask(taskname, found=1)
             if task is None:
-                print "No such task `%s'" % taskname
+                print("No such task `%s'" % taskname)
             elif task.__class__.__name__ == "IrafTask":
                 # cache only executable tasks (not CL tasks, etc.)
                 executable = task.getFullpath()
@@ -298,9 +298,9 @@ class _ProcessCache:
             n = n+1
             executable = proxy.process.executable
             if executable in self._locked:
-                print "%2d: L %s" % (n, executable)
+                print("%2d: L %s" % (n, executable))
             else:
-                print "%2d:   %s" % (n, executable)
+                print("%2d:   %s" % (n, executable))
 
     def __del__(self):
         self._locked = {}

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -627,7 +627,7 @@ class IrafProcess:
         par_set = self.par_set
         executeClCommand = self.executeClCommand
 
-        while 1:
+        while True:
 
             # each read may return multiple lines; only
             # read new data when old has been used up

--- a/lib/pyraf/irafexecute.py
+++ b/lib/pyraf/irafexecute.py
@@ -27,7 +27,7 @@ test_probe = False
 
 #stdgraph = None
 
-IPC_PREFIX = ndarr2bytes(numpy.array([01120],numpy.int16))
+IPC_PREFIX = ndarr2bytes(numpy.array([0o1120],numpy.int16))
 
 # weirdo protocol to get output from task back to subprocess
 # definitions from cl/task.h and lib/clio.h

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -302,7 +302,7 @@ def _getIrafEnv(file='/usr/local/bin/cl',vars=('IRAFARCH','iraf')):
     f = open(newfile, 'w')
     f.writelines(newlines)
     f.close()
-    _os.chmod(newfile,0700)
+    _os.chmod(newfile,0o700)
     # run new script and capture output
     fh = _StringIO.StringIO()
     status = clOscmd(newfile,Stdout=fh)

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -2988,10 +2988,10 @@ def clCompatibilityMode(verbose=0, _save=0):
                 prompt = loadedPath[-1].getName()[:2] + '> '
             else:
                 prompt = 'cl> '
-            line = raw_input(prompt)
+            line = input(prompt)
             # simple continuation escape handling
             while line[-1:] == '\\':
-                line = line + '\n' + raw_input(prompt2)
+                line = line + '\n' + input(prompt2)
             line = line.strip()
             if line in _exitCommands:
                 break

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -1160,7 +1160,7 @@ def real(x):
             if m:
                 x = x[0:m.start()]
             f = map(float,x.split(":"))
-            f = map(abs, f)
+            f = list(map(abs, f))
             return sign*clSexagesimal(*f)
         else:
             x = _re.sub("[EdD]", "e", x, count=1)
@@ -1225,7 +1225,7 @@ def radix(value, base=10, length=0):
     while lvalue > 0 or lvalue < -1:
         lvalue, digit = divmod(lvalue, base)
         outdigits.append(int(digit))
-    outdigits = map(lambda index: _radixDigits[index], outdigits)
+    outdigits = [_radixDigits[index] for index in outdigits]
     # zero-pad if needed (automatically do so for negative numbers)
     if ivalue < 0:
         maxlen = 32
@@ -2276,7 +2276,7 @@ def teal(taskArg, **kw):
 def edit(*args):
     """Edit text files"""
     editor = envget('editor')
-    margs = map(Expand, args)
+    margs = list(map(Expand, args))
     _os.system(' '.join([editor,]+margs))
 
 _clearString = None

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -534,7 +534,7 @@ def handleRedirAndSaveKwds(target):
         redirKW, closeFHList = redirProcess(kw)
         if '_save' in kw: del kw['_save']
         if len(kw):
-            raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+            raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
         resetList = redirApply(redirKW)
         try:
             # call 'target' to do the interesting work of this function
@@ -771,19 +771,19 @@ def getPkg(pkgname,found=0):
 
 def getTaskList():
     """Returns list of names of all defined IRAF tasks"""
-    return _tasks.keys()
+    return list(_tasks.keys())
 
 def getTaskObjects():
     """Returns list of all defined IrafTask objects"""
-    return _tasks.values()
+    return list(_tasks.values())
 
 def getPkgList():
     """Returns list of names of all defined IRAF packages"""
-    return _pkgs.keys()
+    return list(_pkgs.keys())
 
 def getLoadedList():
     """Returns list of names of all loaded IRAF packages"""
-    return _loaded.keys()
+    return list(_loaded.keys())
 
 def getVarDict():
     """Returns dictionary all IRAF variables"""
@@ -791,7 +791,7 @@ def getVarDict():
 
 def getVarList():
     """Returns list of names of all IRAF variables"""
-    return _varDict.keys()
+    return list(_varDict.keys())
 
 # -----------------------------------------------------
 # listAll, listPkg, listLoaded, listTasks, listCurrent, listVars:
@@ -1771,7 +1771,7 @@ def fscan(theLocals, line, *namelist, **kw):
     else:
         strconv = n*[None]
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     n_actual = 0        # this will be the actual number of values converted
     for i in range(n):
         # even messier: special handling for struct type variables, which
@@ -1846,7 +1846,7 @@ def fscanf(theLocals, line, format, *namelist, **kw):
         f = ['']
         n = 1
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     n_actual = 0        # this will be the actual number of values converted
     for i in range(n):
         cmd = namelist[i] + ' = ' + `f[i]`
@@ -2058,7 +2058,7 @@ def clOscmd(s, **kw):
     redirKW, closeFHList = redirProcess(kw)
     if '_save' in kw: del kw['_save']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     resetList = redirApply(redirKW)
     try:
         # if first character of s is '!' then force to Bourne shell
@@ -2213,7 +2213,7 @@ def dparam(*args, **kw):
         cl = kw['cl']
         del kw['cl']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     for taskname in args:
         try:
             taskname.dParam(cl=cl)
@@ -2242,7 +2242,7 @@ def unlearn(*args, **kw):
         force = kw['force'] in (True, '+', 'yes')
         del kw['force']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     for taskname in args:
         try: # maybe it is an IRAF task name
             getTask(taskname).unlearn()
@@ -2358,7 +2358,7 @@ def pyexecute(filename, **kw):
                 "`%s' to `%s'" % (pkgname, spkgname))
         pkgname = spkgname
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     # execute code in a new namespace (including PkgName, PkgBinary)
     efilename = Expand(filename)
     namespace = {'PkgName': pkgname, 'PkgBinary': pkgbinary,
@@ -2485,7 +2485,7 @@ def clProcedure(input=None, mode="", DOLLARnargs=0, **kw):
     redirKW, closeFHList = redirProcess(kw)
     if '_save' in kw: del kw['_save']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     # get the input
     if 'stdin' in redirKW:
         stdin = redirKW['stdin']
@@ -2580,7 +2580,7 @@ def task(*args, **kw):
         raise SyntaxError("More than one `=' in task definition")
     elif len(kw) < 1:
         raise SyntaxError("Must be at least one `=' in task definition")
-    s = kw.keys()[0]
+    s = list(kw.keys())[0]
     value = kw[s]
     # To handle when actual CL code is given, not a file name, we will
     # replace the code with the name of the tmp file that we write it to.
@@ -2646,7 +2646,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
     redirKW, closeFHList = redirProcess(kw)
     if '_save' in kw: del kw['_save']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     resetList = redirApply(redirKW)
     try:
         if pkgname is None:
@@ -3053,7 +3053,7 @@ def clExecute(s, locals=None, mode="proc",
 
     redirKW, closeFHList = redirProcess(kw)
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `kw.keys()`)
+        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
     resetList = redirApply(redirKW)
     try:
         global _clExecuteCount

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -1025,7 +1025,7 @@ def mktemp(root):
     """Make a temporary filename starting with root"""
     global _tmpfileCounter
     basename = root + repr(_os.getpid())
-    while 1:
+    while True:
         _tmpfileCounter = _tmpfileCounter + 1
         if _tmpfileCounter <= 26:
             # use letters to start

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -534,7 +534,7 @@ def handleRedirAndSaveKwds(target):
         redirKW, closeFHList = redirProcess(kw)
         if '_save' in kw: del kw['_save']
         if len(kw):
-            raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+            raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
         resetList = redirApply(redirKW)
         try:
             # call 'target' to do the interesting work of this function
@@ -754,7 +754,7 @@ def getPkg(pkgname,found=0):
         if isinstance(pkgname,_iraftask.IrafPkg):
             return pkgname
         if not pkgname:
-            raise TypeError("Bad package name `%s'" % `pkgname`)
+            raise TypeError("Bad package name `%s'" % repr(pkgname))
         # undo any modifications to the pkgname
         pkgname = _irafutils.untranslateName(pkgname)
         return _pkgs[pkgname]
@@ -1024,7 +1024,7 @@ _tmpfileCounter = 0
 def mktemp(root):
     """Make a temporary filename starting with root"""
     global _tmpfileCounter
-    basename = root + `_os.getpid()`
+    basename = root + repr(_os.getpid())
     while 1:
         _tmpfileCounter = _tmpfileCounter + 1
         if _tmpfileCounter <= 26:
@@ -1032,7 +1032,7 @@ def mktemp(root):
             suffix = chr(ord("a")+_tmpfileCounter-1)
         else:
             # use numbers once we've used up letters
-            suffix = "_" + `_tmpfileCounter-26`
+            suffix = "_" + repr(_tmpfileCounter-26)
         file = basename + suffix
         if not _os.path.exists(Expand(file)):
             return file
@@ -1726,7 +1726,7 @@ def boolean(value):
                 return ival
         except (ValueError, OverflowError):
             pass
-    raise ValueError("Illegal boolean value %s" % `value`)
+    raise ValueError("Illegal boolean value %s" % repr(value))
 
 
 # -----------------------------------------------------
@@ -1776,7 +1776,7 @@ def fscan(theLocals, line, *namelist, **kw):
     else:
         strconv = n*[None]
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     n_actual = 0        # this will be the actual number of values converted
     for i in range(n):
         # even messier: special handling for struct type variables, which
@@ -1802,13 +1802,13 @@ def fscan(theLocals, line, *namelist, **kw):
                             (line, pat))
                 iend = mm.end()
             if line[-1:] == '\n':
-                cmd = namelist[i] + ' = ' + `line[iend:-1]`
+                cmd = namelist[i] + ' = ' + repr(line[iend:-1])
             else:
-                cmd = namelist[i] + ' = ' + `line[iend:]`
+                cmd = namelist[i] + ' = ' + repr(line[iend:])
         elif strconv[i]:
-            cmd = namelist[i] + ' = ' + strconv[i] + '(' + `f[i]` + ')'
+            cmd = namelist[i] + ' = ' + strconv[i] + '(' + repr(f[i]) + ')'
         else:
-            cmd = namelist[i] + ' = ' + `f[i]`
+            cmd = namelist[i] + ' = ' + repr(f[i])
         try:
             exec(cmd, theLocals)
             n_actual += 1
@@ -1851,10 +1851,10 @@ def fscanf(theLocals, line, format, *namelist, **kw):
         f = ['']
         n = 1
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     n_actual = 0        # this will be the actual number of values converted
     for i in range(n):
-        cmd = namelist[i] + ' = ' + `f[i]`
+        cmd = namelist[i] + ' = ' + repr(f[i])
         try:
             exec(cmd, theLocals)
             n_actual += 1
@@ -1885,7 +1885,7 @@ def _isStruct(theLocals, name, checklegal=0):
     c = name.split('.')
     if len(c)>1:
         # must get the parameter object, not the value
-        c[-1] = 'getParObject(%s)' % `c[-1]`
+        c[-1] = 'getParObject(%s)' % repr(c[-1])
     fname = '.'.join(c)
     try:
         par = eval(fname, theLocals)
@@ -2063,7 +2063,7 @@ def clOscmd(s, **kw):
     redirKW, closeFHList = redirProcess(kw)
     if '_save' in kw: del kw['_save']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     resetList = redirApply(redirKW)
     try:
         # if first character of s is '!' then force to Bourne shell
@@ -2218,7 +2218,7 @@ def dparam(*args, **kw):
         cl = kw['cl']
         del kw['cl']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     for taskname in args:
         try:
             taskname.dParam(cl=cl)
@@ -2247,7 +2247,7 @@ def unlearn(*args, **kw):
         force = kw['force'] in (True, '+', 'yes')
         del kw['force']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     for taskname in args:
         try: # maybe it is an IRAF task name
             getTask(taskname).unlearn()
@@ -2363,7 +2363,7 @@ def pyexecute(filename, **kw):
                 "`%s' to `%s'" % (pkgname, spkgname))
         pkgname = spkgname
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     # execute code in a new namespace (including PkgName, PkgBinary)
     efilename = Expand(filename)
     namespace = {'PkgName': pkgname, 'PkgBinary': pkgbinary,
@@ -2490,7 +2490,7 @@ def clProcedure(input=None, mode="", DOLLARnargs=0, **kw):
     redirKW, closeFHList = redirProcess(kw)
     if '_save' in kw: del kw['_save']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     # get the input
     if 'stdin' in redirKW:
         stdin = redirKW['stdin']
@@ -2651,7 +2651,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
     redirKW, closeFHList = redirProcess(kw)
     if '_save' in kw: del kw['_save']
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     resetList = redirApply(redirKW)
     try:
         if pkgname is None:
@@ -2856,7 +2856,7 @@ def printf(format, *args):
         raise IrafError(str(e))
     except TypeError as e:
         raise IrafError('%s\nFormat/datatype mismatch in printf '
-                '(format is %s)' % (str(e), `format`))
+                '(format is %s)' % (str(e), repr(format)))
 
 # _backDir is previous working directory
 
@@ -3058,7 +3058,7 @@ def clExecute(s, locals=None, mode="proc",
 
     redirKW, closeFHList = redirProcess(kw)
     if len(kw):
-        raise TypeError('unexpected keyword argument: ' + `list(kw.keys())`)
+        raise TypeError('unexpected keyword argument: ' + repr(list(kw.keys())))
     resetList = redirApply(redirKW)
     try:
         global _clExecuteCount

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -184,7 +184,7 @@ def Init(doprint=1,hush=0,savefile=None):
             try:
                 d = _getIrafEnv()
                 for key, value in d.items():
-                    if not key in _os.environ:
+                    if key not in _os.environ:
                         _os.environ[key] = value
                 iraf = _os.environ['iraf']
                 arch = _os.environ['IRAFARCH']
@@ -594,9 +594,12 @@ def load(pkgname,args=(),kw=None,doprint=1,hush=0,save=1):
     else:
         p = getPkg(pkgname)
     if kw is None: kw = {}
-    if not '_doprint' in kw: kw['_doprint'] = doprint
-    if not '_hush' in kw: kw['_hush'] = hush
-    if not '_save' in kw: kw['_save'] = save
+    if '_doprint' not in kw:
+        kw['_doprint'] = doprint
+    if '_hush' not in kw:
+        kw['_hush'] = hush
+    if '_save' not in kw:
+        kw['_save'] = save
     p.run(*tuple(args), **kw)
 
 # -----------------------------------------------------
@@ -610,8 +613,10 @@ def run(taskname,args=(),kw=None,save=1):
     else:
         t = getTask(taskname)
     if kw is None: kw = {}
-    if not '_save' in kw: kw['_save'] = save
-##     if not '_parent' in kw: kw['parent'] = "'iraf.cl'"
+    if '_save' not in kw:
+        kw['_save'] = save
+    #  if '_parent' not in kw:
+    #      kw['parent'] = "'iraf.cl'"
     t.run(*tuple(args), **kw)
 
 
@@ -2132,7 +2137,7 @@ def stty(terminal=None, **kw):
         set(terminal=expkw['terminal'])
         # They are setting the terminal type.  Let's at least try to
         # get the dimensions if not given. This is more than the CL does.
-        if (not 'nlines' in kw) and (not 'ncols' in kw) and \
+        if ('nlines' not in kw) and ('ncols' not in kw) and \
            _sys.stdout.isatty():
             try:
                 nlines,ncols = _wutil.getTermWindowSize()
@@ -2656,7 +2661,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
             lp.reverse()
             for pkg in lp:
                 pkgname = pkg.getName()
-                if not pkgname in printed:
+                if pkgname not in printed:
                     printed[pkgname] = 1
                     print('    %s' % pkgname)
             rv1 = (PkgName, PkgBinary)
@@ -3471,7 +3476,7 @@ def redirProcess(kw):
             del kw[key]
     # Now handle IRAF semantics for redirection of stderr to mean stdout
     # also redirects to stderr file handle if Stdout not also specified
-    if 'stderr' in redirKW and not 'stdout' in redirKW:
+    if 'stderr' in redirKW and 'stdout' not in redirKW:
         redirKW['stdout'] = redirKW['stderr']
     return redirKW, closeFHList
 

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -2877,7 +2877,8 @@ def chdir(directory=None):
     if not isinstance(directory, (str,unicode)):
         raise IrafError("Illegal non-string value for directory:"+ \
               +repr(directory))
-    if Verbose > 2: print(('chdir to: '+str(directory)))
+    if Verbose > 2:
+        print('chdir to: '+str(directory))
     # Check for (1) local directory and (2) iraf variable
     # when given an argument like 'dev'.  In IRAF 'cd dev' is
     # the same as 'cd ./dev' if there is a local directory named

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -706,7 +706,7 @@ def getTask(taskname, found=0):
         sp = fullname[0].split('.')
         name = sp[-1]
         pkglist = [ sp[0] ]
-        for i in xrange(len(fullname)-1):
+        for i in range(len(fullname)-1):
             sp = fullname[i+1].split('.')
             if name != sp[-1]:
                 if len(fullname)>3:
@@ -723,7 +723,7 @@ def getTask(taskname, found=0):
     # trylist has a list of several candidate tasks that differ
     # only in package.  Search loaded packages in reverse to find
     # which one was loaded most recently.
-    for i in xrange(len(loadedPath)):
+    for i in range(len(loadedPath)):
         pkg = loadedPath[-1-i].getName()
         if pkg in pkglist:
             # Got it at last
@@ -824,7 +824,7 @@ def listPkgs():
     else:
         keylist.sort()
         # append '/' to identify packages
-        for i in xrange(len(keylist)): keylist[i] = keylist[i] + '/'
+        for i in range(len(keylist)): keylist[i] = keylist[i] + '/'
         _irafutils.printCols(keylist)
 
 @handleRedirAndSaveKwds
@@ -836,7 +836,7 @@ def listLoaded():
     else:
         keylist.sort()
         # append '/' to identify packages
-        for i in xrange(len(keylist)): keylist[i] = keylist[i] + '/'
+        for i in range(len(keylist)): keylist[i] = keylist[i] + '/'
         _irafutils.printCols(keylist)
 
 @handleRedirAndSaveKwdsPlus
@@ -901,7 +901,7 @@ def listCurrent(n=1, hidden=0):
     if len(loadedPath):
         if n > len(loadedPath): n = len(loadedPath)
         plist = n*[None]
-        for i in xrange(n):
+        for i in range(n):
             plist[i] = loadedPath[-1-i].getName()
         listTasks(plist,hidden=hidden)
     else:

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -753,10 +753,10 @@ def getPkg(pkgname,found=0):
         # undo any modifications to the pkgname
         pkgname = _irafutils.untranslateName(pkgname)
         return _pkgs[pkgname]
-    except _minmatch.AmbiguousKeyError, e:
+    except _minmatch.AmbiguousKeyError as e:
         # re-raise the error with a bit more info
         raise e.__class__("Package "+pkgname+": "+str(e))
-    except KeyError, e:
+    except KeyError as e:
         if found: return None
         raise KeyError("Package `%s' not found" % (pkgname,))
 
@@ -859,7 +859,7 @@ def listTasks(pkglist=None, hidden=0, **kw):
                 else:
                     _writeError('Package %s has not been loaded' %
                             pthis.getName())
-            except KeyError, e:
+            except KeyError as e:
                 _writeError(str(e))
     if not len(pkgdict):
         print('No packages to list')
@@ -926,7 +926,7 @@ def which(*args):
         try:
             print(getTask(arg).getPkgname())
             # or: getTask(arg).getPkgname()+"."+getTask(arg).getName()
-        except _minmatch.AmbiguousKeyError, e:
+        except _minmatch.AmbiguousKeyError as e:
             print(str(e))
         except (KeyError, TypeError):
             if deftask(arg):
@@ -1482,7 +1482,7 @@ def defpar(paramname):
     try:
         value = clParGet(paramname,prompt=0)
         return 1
-    except IrafError, e:
+    except IrafError as e:
         # treat all errors (including ambiguous task and parameter names)
         # as a missing parameter
         return 0
@@ -1652,7 +1652,7 @@ def deftask(taskname):
         import pyraf.iraf
         t = getattr(pyraf.iraf, taskname)
         return 1
-    except AttributeError, e:
+    except AttributeError as e:
         # treat all errors (including ambiguous task names) as a missing task
         return 0
 
@@ -1662,7 +1662,7 @@ def defpac(pkgname):
     try:
         t = getPkg(pkgname)
         return t.isLoaded()
-    except KeyError, e:
+    except KeyError as e:
         # treat all errors (including ambiguous package names) as a missing pkg
         return 0
 
@@ -1919,7 +1919,7 @@ def scan(theLocals, *namelist, **kw):
         else:
             args = (theLocals, repr(line),) + namelist
             return fscan(*args, **kw)
-    except Exception, ex:
+    except Exception as ex:
         print('iraf.scan exception: '+str(ex))
     finally:
         # note return value not used here
@@ -1947,7 +1947,7 @@ def scanf(theLocals, format, *namelist, **kw):
         else:
             args = (theLocals, repr(line), format,) + namelist
             return fscanf(*args, **kw)
-    except Exception, ex:
+    except Exception as ex:
         print('iraf.scanf exception: '+str(ex))
     finally:
         # note return value not used here
@@ -2230,7 +2230,7 @@ def update(*args):
     for taskname in args:
         try:
             getTask(taskname).saveParList()
-        except KeyError, e:
+        except KeyError as e:
             _writeError("Warning: Could not find task %s for update" %
                     taskname)
 
@@ -2246,7 +2246,7 @@ def unlearn(*args, **kw):
     for taskname in args:
         try: # maybe it is an IRAF task name
             getTask(taskname).unlearn()
-        except KeyError, e:
+        except KeyError as e:
             try: # maybe it is a task which uses .cfg files
                 ans = _teal.unlearn(taskname, deleteAll=force)
                 if ans != 0:
@@ -2529,7 +2529,7 @@ def hidetask(*args):
     for taskname in args:
         try:
             getTask(taskname).setHidden()
-        except KeyError, e:
+        except KeyError as e:
             _writeError("Warning: Could not find task %s to hide" %
                     taskname)
 
@@ -2847,9 +2847,9 @@ def printf(format, *args):
     try:
         _sys.stdout.write(format % tuple(args))
         _sys.stdout.flush()
-    except ValueError, e:
+    except ValueError as e:
         raise IrafError(str(e))
-    except TypeError, e:
+    except TypeError as e:
         raise IrafError('%s\nFormat/datatype mismatch in printf '
                 '(format is %s)' % (str(e), `format`))
 
@@ -3033,7 +3033,7 @@ def clArray(array_size, datatype, name="<anonymous>", mode="h",
         return _irafpar.makeIrafPar(init_value, name=name, datatype=datatype,
                 mode=mode, min=min, max=max, enum=enum, prompt=prompt,
                 array_size=array_size, strict=strict)
-    except ValueError, e:
+    except ValueError as e:
         raise ValueError("Error creating Cl array `%s'\n%s" %
                 (name, str(e)))
 

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -2363,7 +2363,7 @@ def pyexecute(filename, **kw):
     efilename = Expand(filename)
     namespace = {'PkgName': pkgname, 'PkgBinary': pkgbinary,
         '__file__': efilename}
-    execfile(efilename, namespace)
+    exec(compile(open(efilename, "rb").read(), efilename, 'exec'), namespace)
 
 # history routines
 

--- a/lib/pyraf/iraffunctions.py
+++ b/lib/pyraf/iraffunctions.py
@@ -34,7 +34,7 @@ def setVerbose(value=1, **kw):
     cannot avail itself of the decorator which wraps redirProcess since it
     needs to be defined here up front.
     """
-    if isinstance(value,(str,unicode)):
+    if isinstance(value, (str, unicode)):
         try:
             value = int(value)
         except ValueError:
@@ -172,7 +172,7 @@ def Init(doprint=1,hush=0,savefile=None):
     """Basic initialization of IRAF environment"""
     global _pkgs, cl
     if savefile is not None:
-        restoreFromFile(savefile,doprint=doprint)
+        restoreFromFile(savefile, doprint=doprint)
         return
     if len(_pkgs) == 0:
         try:
@@ -211,16 +211,16 @@ Ureka installation (see http://ssb.stsci.edu/ureka).  Also be sure to run the
                arch == 'suse':
             import resource
             if resource.getrlimit(resource.RLIMIT_STACK)[1]==-1 :
-                resource.setrlimit(resource.RLIMIT_STACK,(-1,-1))
+                resource.setrlimit(resource.RLIMIT_STACK, (-1, -1))
             else:
                 pass
         else:
             pass
 
         # ensure trailing slash is present
-        iraf = _os.path.join(iraf,'')
-        host = _os.environ.get('host', _os.path.join(iraf,'unix',''))
-        hlib = _os.environ.get('hlib', _os.path.join(host,'hlib',''))
+        iraf = _os.path.join(iraf, '')
+        host = _os.environ.get('host', _os.path.join(iraf, 'unix', ''))
+        hlib = _os.environ.get('hlib', _os.path.join(host, 'hlib', ''))
         tmp = _os.environ.get('tmp', '/tmp/')
         set(iraf = iraf)
         set(host = host)
@@ -243,7 +243,7 @@ Ureka installation (see http://ssb.stsci.edu/ureka).  Also be sure to run the
         # add the cl as a task, because its parameters are sometimes needed,
         # but make it a hidden task
         # cl is implemented as a Python task
-        cl = IrafTaskFactory('','cl','','cl$cl.par','clpackage','bin$',
+        cl = IrafTaskFactory('', 'cl', '', 'cl$cl.par', 'clpackage', 'bin$',
                 function=_clProcedure)
         cl.setHidden()
 
@@ -275,13 +275,13 @@ Ureka installation (see http://ssb.stsci.edu/ureka).  Also be sure to run the
         loadedPath.append(clpkg)
         if doprint: listTasks('clpackage')
 
-def _getIrafEnv(file='/usr/local/bin/cl',vars=('IRAFARCH','iraf')):
+def _getIrafEnv(file='/usr/local/bin/cl',vars=('IRAFARCH', 'iraf')):
     """Returns dictionary of environment vars defined in cl startup file"""
     if not _irafinst.EXISTS:
         return {'iraf': '/iraf/is/not/here/', 'IRAFARCH': 'arch_is_unused'}
     if not _os.path.exists(file):
         raise IOError("CL startup file %s does not exist" % file)
-    lines = open(file,'r').readlines()
+    lines = open(file, 'r').readlines()
     # replace commands that exec cl with commands to print environment vars
     pat = _re.compile(r'^\s*exec\s+')
     newlines = []
@@ -302,10 +302,10 @@ def _getIrafEnv(file='/usr/local/bin/cl',vars=('IRAFARCH','iraf')):
     f = open(newfile, 'w')
     f.writelines(newlines)
     f.close()
-    _os.chmod(newfile,0o700)
+    _os.chmod(newfile, 0o700)
     # run new script and capture output
     fh = _StringIO.StringIO()
-    status = clOscmd(newfile,Stdout=fh)
+    status = clOscmd(newfile, Stdout=fh)
     if status:
         raise IOError("Execution error in script %s (derived from %s)" %
             (newfile, file))
@@ -316,7 +316,7 @@ def _getIrafEnv(file='/usr/local/bin/cl',vars=('IRAFARCH','iraf')):
     d = {}
     for entry in result:
         if entry.find('=') >= 0:
-            key, value = entry.split('=',1)
+            key, value = entry.split('=', 1)
             d[key] = value
     return d
 
@@ -397,10 +397,10 @@ def saveToFile(savefile, **kw):
     else:
         # if clobber is not set, do not overwrite file
         savefile = Expand(savefile)
-        if (not kw.get('clobber')) and envget("clobber","") != yes and _os.path.exists(savefile):
+        if (not kw.get('clobber')) and envget("clobber", "") != yes and _os.path.exists(savefile):
             raise IOError("Output file `%s' already exists" % savefile)
         # open binary pickle file
-        fh = open(savefile,'wb')
+        fh = open(savefile, 'wb')
         doclose = 1
     # make a shallow copy of the dictionary and edit out
     # functions, modules, and objects named in _unsavedVarsDict
@@ -414,7 +414,7 @@ def saveToFile(savefile, **kw):
     # save just the value of Verbose, not the object
     global Verbose
     gdict['Verbose'] = Verbose.get()
-    p = _pickle.Pickler(fh,1)
+    p = _pickle.Pickler(fh, 1)
     p.dump(gdict)
     if doclose:
         fh.close()
@@ -458,7 +458,7 @@ def restoreFromFile(savefile, doprint=1, **kw):
     import pyraf
     import irafpar, cltoken
     for module in (__main__, pyraf, irafpar, irafglobals, cltoken):
-        if hasattr(module,'INDEF'): module.INDEF = INDEF
+        if hasattr(module, 'INDEF'): module.INDEF = INDEF
 
     # replace cl in the iraf module (and possibly other locations)
     global cl
@@ -475,7 +475,7 @@ def _addPkg(pkg):
     """Add an IRAF package to the packages list"""
     global _pkgs
     name = pkg.getName()
-    _pkgs.add(name,pkg)
+    _pkgs.add(name, pkg)
     # add package to global namespaces
     _irafnames.strategy.addPkg(pkg)
     # packages are tasks too, so add to task lists
@@ -493,11 +493,11 @@ def _addTask(task, pkgname=None):
     if not pkgname: pkgname = task.getPkgname()
     fullname = pkgname + '.' + name
     _tasks[fullname] = task
-    _mmtasks.add(name,fullname)
+    _mmtasks.add(name, fullname)
     # add task to global namespaces
     _irafnames.strategy.addTask(task)
     # add task to list for its package
-    getPkg(pkgname).addTask(task,fullname)
+    getPkg(pkgname).addTask(task, fullname)
 
 
 # --------------------------------------------------------------------------
@@ -589,7 +589,7 @@ def addLoaded(pkg):
 
 def load(pkgname,args=(),kw=None,doprint=1,hush=0,save=1):
     """Load an IRAF package by name"""
-    if isinstance(pkgname,_iraftask.IrafPkg):
+    if isinstance(pkgname, _iraftask.IrafPkg):
         p = pkgname
     else:
         p = getPkg(pkgname)
@@ -608,7 +608,7 @@ def load(pkgname,args=(),kw=None,doprint=1,hush=0,save=1):
 
 def run(taskname,args=(),kw=None,save=1):
     """Run an IRAF task by name"""
-    if isinstance(taskname,_iraftask.IrafTask):
+    if isinstance(taskname, _iraftask.IrafTask):
         t = taskname
     else:
         t = getTask(taskname)
@@ -652,9 +652,9 @@ def getTask(taskname, found=0):
     if task is not found.
     """
 
-    if isinstance(taskname,_iraftask.IrafTask):
+    if isinstance(taskname, _iraftask.IrafTask):
         return taskname
-    elif not isinstance(taskname, (str,unicode)):
+    elif not isinstance(taskname, (str, unicode)):
         raise TypeError("Argument to getTask is not a string or IrafTask instance")
 
     # undo any modifications to the taskname
@@ -663,7 +663,7 @@ def getTask(taskname, found=0):
     # Try assuming fully qualified name first
     task = _tasks.get(taskname)
     if task is not None:
-        if Verbose>1: print('found',taskname,'in task list')
+        if Verbose>1: print('found', taskname, 'in task list')
         return task
 
     # Look it up in the minimum-match dictionary
@@ -678,7 +678,7 @@ def getTask(taskname, found=0):
     if len(fullname) == 1:
         # unambiguous match
         task = _tasks[fullname[0]]
-        if Verbose>1: print('found',task.getName(),'in task list')
+        if Verbose>1: print('found', task.getName(), 'in task list')
         return task
 
     # Ambiguous match is OK only if taskname is the full name
@@ -751,7 +751,7 @@ def getPkg(pkgname,found=0):
     is not found.
     """
     try:
-        if isinstance(pkgname,_iraftask.IrafPkg):
+        if isinstance(pkgname, _iraftask.IrafPkg):
             return pkgname
         if not pkgname:
             raise TypeError("Bad package name `%s'" % repr(pkgname))
@@ -854,7 +854,7 @@ def listTasks(pkglist=None, hidden=0, **kw):
         pkgdict = _pkgs
     else:
         pkgdict = {}
-        if isinstance(pkglist, (str,unicode,_iraftask.IrafPkg)):
+        if isinstance(pkglist, (str, unicode, _iraftask.IrafPkg)):
             pkglist = [ pkglist ]
         for p in pkglist:
             try:
@@ -878,9 +878,9 @@ def listTasks(pkglist=None, hidden=0, **kw):
         pkg, task = tname.split('.')
         tobj = _tasks[tname]
         if hidden or not tobj.isHidden():
-            if isinstance(tobj,_iraftask.IrafPkg):
+            if isinstance(tobj, _iraftask.IrafPkg):
                 task = task + '/'
-            elif isinstance(tobj,_iraftask.IrafPset):
+            elif isinstance(tobj, _iraftask.IrafPset):
                 task = task + '@'
             if pkg == lastpkg:
                 tlist.append(task)
@@ -903,7 +903,7 @@ def listCurrent(n=1, hidden=0):
         plist = n*[None]
         for i in range(n):
             plist[i] = loadedPath[-1-i].getName()
-        listTasks(plist,hidden=hidden)
+        listTasks(plist, hidden=hidden)
     else:
         print('No IRAF tasks defined')
 
@@ -998,7 +998,7 @@ def clParGet(paramname,pkg=None,native=1,mode=None,prompt=1):
     # if taskname is '_', use current package as task
     if paramname[:2] == "_.":
         paramname = pkg.getName() + paramname[1:]
-    return pkg.getParam(paramname,native=native,mode=mode,prompt=prompt)
+    return pkg.getParam(paramname, native=native, mode=mode, prompt=prompt)
 
 def envget(var,default=None):
     """Get value of IRAF or OS environment variable"""
@@ -1053,7 +1053,7 @@ def isNullFile(s):
     else:
         return 0
 
-def substr(s,first,last):
+def substr(s, first, last):
     """Return sub-string using IRAF 1-based indexing"""
     if s == INDEF: return INDEF
     # If the first index is zero, always return a zero-length string
@@ -1075,7 +1075,7 @@ def isindef(s):
 def stridx(test, s):
     """Return index of first occurrence of any of the characters in 'test'
     that are in 's' using IRAF 1-based indexing"""
-    if INDEF in (s,test): return INDEF
+    if INDEF in (s, test): return INDEF
     _pos2 = len(s)
     for _char in test:
         _pos = s.find(_char)
@@ -1089,7 +1089,7 @@ def stridx(test, s):
 def strldx(test, s):
     """Return index of last occurrence of any of the characters in 'test'
     that are in 's' using IRAF 1-based indexing"""
-    if INDEF in (s,test): return INDEF
+    if INDEF in (s, test): return INDEF
     _pos2 = -1
     for _char in test:
         _pos = s.rfind(_char)
@@ -1107,13 +1107,13 @@ def strupr(s):
     if s == INDEF: return INDEF
     return s.upper()
 
-def strstr(str1,str2):
+def strstr(str1, str2):
     """Search for first occurrence of 'str1' in 'str2', returns index
     of the start of 'str1' or zero if not found.  IRAF 1-based indexing"""
-    if INDEF in (str1,str2): return INDEF
+    if INDEF in (str1, str2): return INDEF
     return str2.find(str1)+1
 
-def strlstr(str1,str2):
+def strlstr(str1, str2):
     """Search for last occurrence of 'str1' in 'str2', returns index
     of the start of 'str1' or zero if not found.  IRAF 1-based indexing"""
     if INDEF in (str1, str2): return INDEF
@@ -1147,7 +1147,7 @@ def real(x):
     """Return real/float representation of x"""
     if x == INDEF:
         return INDEF
-    elif isinstance(x, (str,unicode)):
+    elif isinstance(x, (str, unicode)):
         x = x.strip()
         if x.find(':') >= 0:
             #...handle the special a:b:c case here...
@@ -1159,7 +1159,7 @@ def real(x):
             m = _re.search(r"[^0-9:.]", x)
             if m:
                 x = x[0:m.start()]
-            f = map(float,x.split(":"))
+            f = map(float, x.split(":"))
             f = list(map(abs, f))
             return sign*clSexagesimal(*f)
         else:
@@ -1175,7 +1175,7 @@ def integer(x):
     """Return integer representation of x"""
     if x==INDEF:
         return INDEF
-    elif isinstance(x, (str,unicode)):
+    elif isinstance(x, (str, unicode)):
         x = x.strip()
         i = 0
         j = len(x)
@@ -1191,7 +1191,7 @@ def integer(x):
 
 def mod(a, b):
     """Return a modulo b"""
-    if INDEF in (a,b): return INDEF
+    if INDEF in (a, b): return INDEF
     return (a % b)
 
 def nint(x):
@@ -1209,7 +1209,7 @@ def radix(value, base=10, length=0):
     bit-pattern of the twos-complement integer (even for base 10) rather
     than a signed value.  This is consistent with IRAF's behavior.
     """
-    if INDEF in (value,base,length): return INDEF
+    if INDEF in (value, base, length): return INDEF
     if not (2 <= base <= 36):
         raise ValueError("base must be between 2 and 36 (inclusive)")
     ivalue = int(value)
@@ -1285,12 +1285,12 @@ def tan(value):
     else:
         return _math.tan(value)
 
-def atan2(x,y):
+def atan2(x, y):
     """Trigonometric 2-argument arctangent function.  Result in radians."""
-    if INDEF in (x,y):
+    if INDEF in (x, y):
         return INDEF
     else:
-        return _math.atan2(x,y)
+        return _math.atan2(x, y)
 
 def dsin(value):
     """Trigonometric sine function.  Input in degrees."""
@@ -1327,12 +1327,12 @@ def dtan(value):
     else:
         return _math.tan(_math.radians(value))
 
-def datan2(x,y):
+def datan2(x, y):
     """Trigonometric 2-argument arctangent function.  Result in degrees."""
-    if INDEF in (x,y):
+    if INDEF in (x, y):
         return INDEF
     else:
-        return _math.degrees(_math.atan2(x,y))
+        return _math.degrees(_math.atan2(x, y))
 
 def exp(value):
     """Exponential function"""
@@ -1383,12 +1383,12 @@ def maximum(*args):
     else:
         return max(*args)
 
-def hypot(x,y):
+def hypot(x, y):
     """Return the Euclidean distance, sqrt(x*x + y*y)."""
-    if INDEF in (x,y):
+    if INDEF in (x, y):
         return INDEF
     else:
-        return _math.hypot(x,y)
+        return _math.hypot(x, y)
 
 def sign(value):
     """Sign of argument (-1 or 1)"""
@@ -1403,19 +1403,19 @@ def clNot(value):
     if value==INDEF: return INDEF
     return ~(int(value))
 
-def clAnd(x,y):
+def clAnd(x, y):
     """Bitwise boolean AND of two integers"""
-    if INDEF in (x,y): return INDEF
+    if INDEF in (x, y): return INDEF
     return x&y
 
-def clOr(x,y):
+def clOr(x, y):
     """Bitwise boolean OR of two integers"""
-    if INDEF in (x,y): return INDEF
+    if INDEF in (x, y): return INDEF
     return x|y
 
-def clXor(x,y):
+def clXor(x, y):
     """Bitwise eXclusive OR of two integers"""
-    if INDEF in (x,y): return INDEF
+    if INDEF in (x, y): return INDEF
     return x^y
 
 def osfn(filename):
@@ -1431,7 +1431,7 @@ def osfn(filename):
     if filename == INDEF: return INDEF
     ename = Expand(filename)
     dlist = [s.strip() for s in ename.split(_os.sep)]
-    if len(dlist)==1 and dlist[0] not in [_os.curdir,_os.pardir]:
+    if len(dlist)==1 and dlist[0] not in [_os.curdir, _os.pardir]:
         return dlist[0]
 
     # I use string.join instead of os.path.join here because
@@ -1440,7 +1440,7 @@ def osfn(filename):
     epath = _os.sep.join(dlist)
     fname = _os.path.abspath(epath)
     # append '/' if relative directory was at end or filename ends with '/'
-    if fname[-1] != _os.sep and dlist[-1] in ['', _os.curdir,_os.pardir]:
+    if fname[-1] != _os.sep and dlist[-1] in ['', _os.curdir, _os.pardir]:
         fname = fname + _os.sep
     return fname
 
@@ -1485,7 +1485,7 @@ def defpar(paramname):
     """Returns true if parameter is defined"""
     if paramname == INDEF: return INDEF
     try:
-        value = clParGet(paramname,prompt=0)
+        value = clParGet(paramname, prompt=0)
         return 1
     except IrafError as e:
         # treat all errors (including ambiguous task and parameter names)
@@ -1504,7 +1504,7 @@ def fp_equal(x, y):
     """Floating point compare  to within machine precision. This logic is
        taken directly from IRAF's fp_equald function."""
     # Check the easy answers first
-    if INDEF in (x,y): return INDEF
+    if INDEF in (x, y): return INDEF
     if x==y: return True
 
     # We can't normalize zero, so handle the zero operand cases first.
@@ -1703,13 +1703,13 @@ def boolean(value):
     Accepts integer/float values 0,1 or string 'no','yes'
     Also allows INDEF as value, or existing IRAF boolean type.
     """
-    if value in [0,1]:
+    if value in [0, 1]:
         return value
     elif value in (no, yes):
         return int(value)
     elif value in [INDEF, "", None]:
         return INDEF
-    if isinstance(value, (str,unicode)):
+    if isinstance(value, (str, unicode)):
         v2 = _irafutils.stripQuotes(value.strip())
         if v2 == "INDEF":
             return INDEF
@@ -1718,7 +1718,7 @@ def boolean(value):
             return 0
         elif ff == "yes":
             return 1
-    elif isinstance(value,float):
+    elif isinstance(value, float):
         # try converting to integer
         try:
             ival = int(value)
@@ -1764,7 +1764,7 @@ def fscan(theLocals, line, *namelist, **kw):
         _nscan = 0
         return EOF
     f = line.split()
-    n = min(len(f),len(namelist))
+    n = min(len(f), len(namelist))
     # a tricky thing -- null input is OK if the first variable is
     # a struct
     if n==0 and namelist and _isStruct(theLocals, namelist[0]):
@@ -1844,7 +1844,7 @@ def fscanf(theLocals, line, format, *namelist, **kw):
     if sscanf == None:
         raise RuntimeError("fscanf is not supported on this platform")
     f = sscanf.sscanf(line, format)
-    n = min(len(f),len(namelist))
+    n = min(len(f), len(namelist))
     # if list is null, add a null string
     # ugly but should be right most of the time
     if n==0 and namelist:
@@ -2005,7 +2005,7 @@ def set(*args, **kw):
         #
         # Flag any other syntax as an error.
         if len(args) != 1 or len(kw) != 0 or \
-           (not isinstance(args[0],(str,unicode))) or args[0][:1] != '@':
+           (not isinstance(args[0], (str, unicode))) or args[0][:1] != '@':
             raise SyntaxError("set requires name=value pairs")
 
 # currently do not distinguish set from reset
@@ -2121,17 +2121,17 @@ def stty(terminal=None, **kw):
         dftNlin = '24'
         try:
            if _sys.stdout.isatty():
-               nlines,ncols = _wutil.getTermWindowSize()
+               nlines, ncols = _wutil.getTermWindowSize()
                dftNcol = str(ncols)
                dftNlin = str(nlines)
         except: pass # No error message here - may not always be available
         # no args: print terminal type and size
-        print('%s ncols=%s nlines=%s' % (envget('terminal','undefined'),
-                envget('ttyncols',dftNcol), envget('ttynlines',dftNlin)))
+        print('%s ncols=%s nlines=%s' % (envget('terminal', 'undefined'),
+                envget('ttyncols', dftNcol), envget('ttynlines', dftNlin)))
     elif expkw['resize'] or expkw['terminal'] == "resize":
         # resize: sets CL env parameters giving screen size; show errors
         if _sys.stdout.isatty():
-            nlines,ncols = _wutil.getTermWindowSize()
+            nlines, ncols = _wutil.getTermWindowSize()
             set(ttyncols=str(ncols), ttynlines=str(nlines))
     elif expkw['terminal']:
         set(terminal=expkw['terminal'])
@@ -2140,7 +2140,7 @@ def stty(terminal=None, **kw):
         if ('nlines' not in kw) and ('ncols' not in kw) and \
            _sys.stdout.isatty():
             try:
-                nlines,ncols = _wutil.getTermWindowSize()
+                nlines, ncols = _wutil.getTermWindowSize()
                 set(ttyncols=str(ncols), ttynlines=str(nlines))
             except: pass # No error msg here - may not always be available
     elif expkw['playback'] is not None:
@@ -2384,7 +2384,7 @@ def history(n=20):
     try:
         n = abs(int(n))
         __main__._pycmdline.printHistory(n)
-    except (NameError,AttributeError):
+    except (NameError, AttributeError):
         pass
 
 @handleRedirAndSaveKwds
@@ -2495,19 +2495,19 @@ def clProcedure(input=None, mode="", DOLLARnargs=0, **kw):
     if 'stdin' in redirKW:
         stdin = redirKW['stdin']
         del redirKW['stdin']
-        if hasattr(stdin,'name'):
+        if hasattr(stdin, 'name'):
             filename = stdin.name.split('.')[0]
         else:
             filename = 'tmp'
     elif input is not None:
-        if isinstance(input,(str,unicode)):
+        if isinstance(input, (str, unicode)):
             # input is a string -- stick it in a StringIO buffer
             stdin = _StringIO.StringIO(input)
             filename = input
-        elif hasattr(input,'read'):
+        elif hasattr(input, 'read'):
             # input is a filehandle
             stdin = input
-            if hasattr(stdin,'name'):
+            if hasattr(stdin, 'name'):
                 filename = stdin.name.split('.')[0]
             else:
                 filename = 'tmp'
@@ -2599,8 +2599,8 @@ def task(*args, **kw):
         # of view but it can't much be helped.  verify later is it unique
         orig_tmpCl = tmpCl
         tmpClPath, tmpClFname = _os.path.split(tmpCl)
-        tmpClFname = tmpClFname.replace('-','_')
-        tmpClFname = tmpClFname.replace('+','_')
+        tmpClFname = tmpClFname.replace('-', '_')
+        tmpClFname = tmpClFname.replace('+', '_')
         tmpCl = _os.path.join(tmpClPath, tmpClFname)
         assert tmpCl == orig_tmpCl or not _os.path.exists(tmpCl), \
                'Abused mkstemp usage in some way; fname: '+tmpCl
@@ -2627,8 +2627,8 @@ def task(*args, **kw):
         name = mtl.group('taskname')
         prefix = mtl.group('taskprefix')
         suffix = mtl.group('tasksuffix')
-        newtask = IrafTaskFactory(prefix,name,suffix,value,
-                        pkgname,pkgbinary,redefine=redefine)
+        newtask = IrafTaskFactory(prefix, name, suffix, value,
+                        pkgname, pkgbinary, redefine=redefine)
 
 def redefine(*args, **kw):
     """Redefine an existing task"""
@@ -2679,7 +2679,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
             pkg = getPkg(pkgname, found=1)
             if pkg is None:
                 pkg = getTask(pkgname, found=1)
-                if pkg is None or not isinstance(pkg,_iraftask.IrafCLTask) or \
+                if pkg is None or not isinstance(pkg, _iraftask.IrafCLTask) or \
                                 pkg.getName() != pkgname:
                     raise KeyError("Package `%s' not defined" % pkgname)
                 # Hack city -- there is a CL task with the package name, but it was
@@ -2879,7 +2879,7 @@ def chdir(directory=None):
     if directory is None:
         # use startup directory as home if argument is omitted
         directory = userWorkingHome
-    if not isinstance(directory, (str,unicode)):
+    if not isinstance(directory, (str, unicode)):
         raise IrafError("Illegal non-string value for directory:"+ \
               +repr(directory))
     if Verbose > 2:
@@ -2965,7 +2965,7 @@ def clCompatibilityMode(verbose=0, _save=0):
     print('Entering CL-compatibility%s mode...' % vmode)
 
     # logging may be active if Monty is in use
-    if hasattr(__main__,'_pycmdline'):
+    if hasattr(__main__, '_pycmdline'):
         logfile = __main__._pycmdline.logfile
     else:
         logfile = None
@@ -3073,10 +3073,10 @@ def clExecute(s, locals=None, mode="proc",
 #       DBG('pycode for task,script='+str((taskname,scriptname,))+':\n'+code)
 #       DBG('*'*80)
         # force compile to inherit future division so we don't rely on 2.x div.
-        codeObject = compile(code,scriptname,'exec',0,0)
+        codeObject = compile(code, scriptname, 'exec', 0, 0)
         # add this script to linecache
         codeLines = code.split('\n')
-        _linecache.cache[scriptname] = (0,0,codeLines,taskname)
+        _linecache.cache[scriptname] = (0, 0, codeLines, taskname)
         if locals is None: locals = {}
         exec(codeObject, locals)
         if pycode.vars.proc_name:
@@ -3143,7 +3143,7 @@ def _expand1(instring, noerror):
     mm = __re_var_paren.search(instring)
     while mm is not None:
         # remove embedded dollar signs from name
-        varname = mm.group('varname').replace('$','')
+        varname = mm.group('varname').replace('$', '')
         if defvar(varname):
             varname = envget(varname)
         elif noerror:
@@ -3206,12 +3206,12 @@ def IrafTaskFactory(prefix='', taskname=None, suffix='', value=None,
         taskname = staskname
 
     if suffix == '.pkg':
-        return IrafPkgFactory(prefix,taskname,suffix,value,pkgname,pkgbinary,
+        return IrafPkgFactory(prefix, taskname, suffix, value, pkgname, pkgbinary,
                 redefine=redefine)
 
     root, ext = _os.path.splitext(value)
     if ext == '.par' and function is None:
-        return IrafPsetFactory(prefix,taskname,suffix,value,pkgname,pkgbinary,
+        return IrafPsetFactory(prefix, taskname, suffix, value, pkgname, pkgbinary,
                 redefine=redefine)
 
     # normal task definition
@@ -3223,17 +3223,17 @@ def IrafTaskFactory(prefix='', taskname=None, suffix='', value=None,
         _writeError("Warning: `%s' is not a defined task" % taskname)
 
     if function is not None:
-        newtask = module.IrafPythonTask(prefix,taskname,suffix,value,
-                                pkgname,pkgbinary,function=function)
+        newtask = module.IrafPythonTask(prefix, taskname, suffix, value,
+                                pkgname, pkgbinary, function=function)
     elif ext == '.cl':
-        newtask = module.IrafCLTask(prefix,taskname,suffix,value,
-                                        pkgname,pkgbinary)
+        newtask = module.IrafCLTask(prefix, taskname, suffix, value,
+                                        pkgname, pkgbinary)
     elif value[:1] == '$':
-        newtask = module.IrafForeignTask(prefix,taskname,suffix,value,
-                                        pkgname,pkgbinary)
+        newtask = module.IrafForeignTask(prefix, taskname, suffix, value,
+                                        pkgname, pkgbinary)
     else:
-        newtask = module.IrafTask(prefix,taskname,suffix,value,
-                                        pkgname,pkgbinary)
+        newtask = module.IrafTask(prefix, taskname, suffix, value,
+                                        pkgname, pkgbinary)
     if task is not None:
         # check for consistency of definition by comparing to the
         # new object
@@ -3246,7 +3246,7 @@ def IrafTaskFactory(prefix='', taskname=None, suffix='', value=None,
             # new task is consistent with old task, so return old task
             if task.getPkgbinary() != newtask.getPkgbinary():
                 # package binary differs -- add it to search path
-                if Verbose>1: print('Adding',pkgbinary,'to',task,'path')
+                if Verbose>1: print('Adding', pkgbinary, 'to', task, 'path')
                 task.addPkgbinary(pkgbinary)
             return task
     # add it to the task list
@@ -3274,7 +3274,7 @@ def IrafPsetFactory(prefix,taskname,suffix,value,pkgname,pkgbinary,redefine=0):
     if task is None and redefine:
         _writeError("Warning: `%s' is not a defined task" % taskname)
 
-    newtask = module.IrafPset(prefix,taskname,suffix,value,pkgname,pkgbinary)
+    newtask = module.IrafPset(prefix, taskname, suffix, value, pkgname, pkgbinary)
     if task is not None:
         # check for consistency of definition by comparing to the new
         # object (which will be discarded)
@@ -3316,7 +3316,7 @@ def IrafPkgFactory(prefix,taskname,suffix,value,pkgname,pkgbinary,redefine=0):
     pkg = _pkgs.get_exact_key(taskname)
     if pkg is None and redefine:
         _writeError("Warning: `%s' is not a defined task" % taskname)
-    newpkg = module.IrafPkg(prefix,taskname,suffix,value,pkgname,pkgbinary)
+    newpkg = module.IrafPkg(prefix, taskname, suffix, value, pkgname, pkgbinary)
     if pkg is not None:
         if pkg.getFilename() != newpkg.getFilename() or \
            pkg.hasParfile()  != newpkg.hasParfile():
@@ -3332,11 +3332,11 @@ def IrafPkgFactory(prefix,taskname,suffix,value,pkgname,pkgbinary,redefine=0):
                 return newpkg
         if pkg.getPkgbinary() != newpkg.getPkgbinary():
             # only package binary differs -- add it to search path
-            if Verbose>1: print('Adding',pkgbinary,'to',pkg,'path')
+            if Verbose>1: print('Adding', pkgbinary, 'to', pkg, 'path')
             pkg.addPkgbinary(pkgbinary)
         if pkgname != pkg.getPkgname():
             # add existing task as an item in the new package
-            _addTask(pkg,pkgname=pkgname)
+            _addTask(pkg, pkgname=pkgname)
         return pkg
     _addPkg(newpkg)
     return newpkg
@@ -3408,7 +3408,7 @@ def redirProcess(kw):
                             else:
                                 value = '/dev/null'
                         elif "w" in openArgs and \
-                          envget("clobber","") != yes and \
+                          envget("clobber", "") != yes and \
                           _os.path.exists(value):
                             # don't overwrite unless clobber is set
                             raise IOError("Output file `%s' already exists" %
@@ -3437,7 +3437,7 @@ def redirProcess(kw):
                         # wrap it in a tuple to make it easy to recognize
                         closeFHList.append((PipeOut,))
                     fh = PipeOut
-            elif isinstance(value, (list,tuple)):
+            elif isinstance(value, (list, tuple)):
                 # list/tuple of strings is OK for input
                 if outputFlag:
                     raise IrafError("%s redirection must "
@@ -3492,8 +3492,8 @@ def redirApply(redirKW):
     resetList = []
     for key, value in redirKW.items():
         if key in sysDict:
-            resetList.append((key, getattr(_sys,key)))
-            setattr(_sys,key,value)
+            resetList.append((key, getattr(_sys, key)))
+            setattr(_sys, key, value)
         elif key == 'stdgraph':
             resetList.append((key, gki.kernel))
             gki.kernel = gki.GkiRedirection(value)
@@ -3519,7 +3519,7 @@ def redirReset(resetList, closeFHList):
         if key == 'stdgraph':
             gki.kernel = value
         else:
-            setattr(_sys,key,value)
+            setattr(_sys, key, value)
     if PipeOut is not None:
         # unfortunately cStringIO.StringIO has no readlines method:
         # PipeOut.seek(0)

--- a/lib/pyraf/irafgwcs.py
+++ b/lib/pyraf/irafgwcs.py
@@ -7,7 +7,7 @@ only commit the change when it appears to really be applicable.
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import struct, numpy, math
 from stsci.tools.for2to3 import ndarr2bytes, tobytes, BNULLSTR, PY3K

--- a/lib/pyraf/irafgwcs.py
+++ b/lib/pyraf/irafgwcs.py
@@ -136,18 +136,18 @@ class IrafGWcs:
         for i in range(WCS_SLOTS):
             record = wcsStruct[_WCS_RECORD_SIZE*i:_WCS_RECORD_SIZE*(i+1)]
             # read 8 4-byte floats from beginning of record
-            fvals = numpy.fromstring(ndarr2bytes(record[:8*SZ]),numpy.float32)
+            fvals = numpy.fromstring(ndarr2bytes(record[:8*SZ]), numpy.float32)
             if _IRAF64BIT:
                 # seems to send an extra 0-valued int32 after each 4 bytes
-                fvalsView = fvals.reshape(-1,2).transpose()
+                fvalsView = fvals.reshape(-1, 2).transpose()
                 if fvalsView[1].sum() != 0:
                     raise IrafError("Assumed WCS float padding is non-zero")
                 fvals = fvalsView[0]
             # read 3 4-byte ints after that
-            ivals = numpy.fromstring(ndarr2bytes(record[8*SZ:11*SZ]),numpy.int32)
+            ivals = numpy.fromstring(ndarr2bytes(record[8*SZ:11*SZ]), numpy.int32)
             if _IRAF64BIT:
                 # seems to send an extra 0-valued int32 after each 4 bytes
-                ivalsView = ivals.reshape(-1,2).transpose()
+                ivalsView = ivals.reshape(-1, 2).transpose()
                 if ivalsView[1].sum() != 0:
                     raise IrafError("Assumed WCS int padding is non-zero")
                 ivals = ivalsView[0]
@@ -168,20 +168,20 @@ class IrafGWcs:
             pad = tobytes('\x00\x00\x00\x00\x00\x00\x00\x00')
         for i in range(WCS_SLOTS):
             x = self.wcs[i]
-            farr = numpy.array(x[:8],numpy.float32)
-            iarr = numpy.array(x[8:11],numpy.int32)
+            farr = numpy.array(x[:8], numpy.float32)
+            iarr = numpy.array(x[8:11], numpy.int32)
             if _IRAF64BIT:
                 # see notes in set(); adding 0-padding after every data point
                 lenf = len(farr) # should be 8
-                farr_rs = farr.reshape(lenf,1) # turn array into single column
+                farr_rs = farr.reshape(lenf, 1) # turn array into single column
                 farr = numpy.append(farr_rs,
-                                    numpy.zeros((lenf,1), numpy.float32),
+                                    numpy.zeros((lenf, 1), numpy.float32),
                                     axis=1)
                 farr = farr.flatten()
                 leni = len(iarr) # should be 3
-                iarr_rs = iarr.reshape(leni,1) # turn array into single column
+                iarr_rs = iarr.reshape(leni, 1) # turn array into single column
                 iarr = numpy.append(iarr_rs,
-                                    numpy.zeros((leni,1), numpy.int32),
+                                    numpy.zeros((leni, 1), numpy.int32),
                                     axis=1)
                 iarr = iarr.flatten()
             # end-pad?
@@ -212,8 +212,8 @@ class IrafGWcs:
         # ranging from 10 to 10,000 will have wx1,wx2 = (10,10000),
         # not (1,4)
 
-        return (self.transform1d(coord=x,dimension='x',wcsID=wcsID),
-                        self.transform1d(coord=y,dimension='y',wcsID=wcsID),
+        return (self.transform1d(coord=x, dimension='x', wcsID=wcsID),
+                        self.transform1d(coord=y, dimension='y', wcsID=wcsID),
                         wcsID)
 
     def transform1d(self, coord, dimension, wcsID):
@@ -221,9 +221,9 @@ class IrafGWcs:
         wx1, wx2, wy1, wy2, sx1, sx2, sy1, sy2, xt, yt, flag = \
                  self.wcs[wcsID-1]
         if dimension == 'x':
-            w1,w2,s1,s2,type = wx1,wx2,sx1,sx2,xt
+            w1, w2, s1, s2, type = wx1, wx2, sx1, sx2, xt
         elif dimension == 'y':
-            w1,w2,s1,s2,type = wy1,wy2,sy1,sy2,yt
+            w1, w2, s1, s2, type = wy1, wy2, sy1, sy2, yt
         if (s2-s1) == 0.:
             raise IrafError("IRAF graphics WCS is singular!")
         fract = (coord-s1)/(s2-s1)
@@ -274,8 +274,8 @@ class IrafGWcs:
 
         self.commit()
         if wcsID is None:
-            wcsID = self._getWCS(x,y)
-        return self.transform(x,y,wcsID)
+            wcsID = self._getWCS(x, y)
+        return self.transform(x, y, wcsID)
 
     def _getWCS(self, x, y):
 
@@ -307,7 +307,7 @@ class IrafGWcs:
         # look for viewports x,y is contained in
         newindexlist = []
         for i in indexlist:
-            x1,x2,y1,y2 = self.wcs[i][4:8]
+            x1, x2, y1, y2 = self.wcs[i][4:8]
             if (x1 <= x <= x2) and (y1 <= y <= y2):
                 newindexlist.append(i)
         # handle 3 cases
@@ -319,7 +319,7 @@ class IrafGWcs:
         if len(newindexlist) > 1:
             # multiple, find one with closest center
             for i in newindexlist:
-                x1,x2,y1,y2 = self.wcs[i][4:8]
+                x1, x2, y1, y2 = self.wcs[i][4:8]
                 xcen = (x1+x2)/2
                 ycen = (y1+y2)/2
                 dist.append((xcen-x)**2 + (ycen-y)**2)
@@ -327,9 +327,9 @@ class IrafGWcs:
             # none, now look for closest border
             newindexlist = indexlist
             for i in newindexlist:
-                x1,x2,y1,y2 = self.wcs[i][4:8]
-                xdelt = min([abs(x-x1),abs(x-x2)])
-                ydelt = min([abs(y-y1),abs(y-y2)])
+                x1, x2, y1, y2 = self.wcs[i][4:8]
+                xdelt = min([abs(x-x1), abs(x-x2)])
+                ydelt = min([abs(y-y1), abs(y-y2)])
                 if x1 <= x <= x2:
                     dist.append(ydelt**2)
                 elif y1 <= y <= y2:
@@ -347,9 +347,9 @@ class IrafGWcs:
 def _setWCSDefault():
     """Define default WCS for STDGRAPH plotting area."""
     # set 8 4 byte floats
-    farr = numpy.array([0.,1.,0.,1.,0.,1.,0.,1.],numpy.float32)
+    farr = numpy.array([0., 1., 0., 1., 0., 1., 0., 1.], numpy.float32)
     # set 3 4 byte ints
-    iarr = numpy.array([LINEAR,LINEAR,CLIP+NEWFORMAT],numpy.int32)
+    iarr = numpy.array([LINEAR, LINEAR, CLIP+NEWFORMAT], numpy.int32)
     wcsarr = tuple(farr)+tuple(iarr)
 
     wcs = []

--- a/lib/pyraf/irafgwcs.py
+++ b/lib/pyraf/irafgwcs.py
@@ -133,7 +133,7 @@ class IrafGWcs:
         SZ = 2
         if _IRAF64BIT: SZ = 4
         self.pending = [None]*WCS_SLOTS
-        for i in xrange(WCS_SLOTS):
+        for i in range(WCS_SLOTS):
             record = wcsStruct[_WCS_RECORD_SIZE*i:_WCS_RECORD_SIZE*(i+1)]
             # read 8 4-byte floats from beginning of record
             fvals = numpy.fromstring(ndarr2bytes(record[:8*SZ]),numpy.float32)
@@ -166,7 +166,7 @@ class IrafGWcs:
         pad = tobytes('\x00\x00\x00\x00')
         if _IRAF64BIT:
             pad = tobytes('\x00\x00\x00\x00\x00\x00\x00\x00')
-        for i in xrange(WCS_SLOTS):
+        for i in range(WCS_SLOTS):
             x = self.wcs[i]
             farr = numpy.array(x[:8],numpy.float32)
             iarr = numpy.array(x[8:11],numpy.int32)
@@ -296,7 +296,7 @@ class IrafGWcs:
 
         indexlist = []
         # select subset of those wcs slots which are defined
-        for i in xrange(len(self.wcs)):
+        for i in range(len(self.wcs)):
             if self._isWcsDefined(i):
                 indexlist.append(i)
         # if 0 or 1 found, we're done!
@@ -353,7 +353,7 @@ def _setWCSDefault():
     wcsarr = tuple(farr)+tuple(iarr)
 
     wcs = []
-    for i in xrange(WCS_SLOTS):
+    for i in range(WCS_SLOTS):
         wcs.append(wcsarr)
 
     return wcs

--- a/lib/pyraf/irafgwcs.py
+++ b/lib/pyraf/irafgwcs.py
@@ -98,7 +98,7 @@ class IrafGWcs:
     def clearPending(self):
         self.pending = None
 
-    def __nonzero__(self):
+    def __bool__(self):
         self.commit()
         return self.wcs is not None
 

--- a/lib/pyraf/irafgwcs.py
+++ b/lib/pyraf/irafgwcs.py
@@ -50,8 +50,8 @@ def init_wcs_sizes(forceResetTo=None):
 
     # Given a value for _WCS_RECORD_SIZE ?
     if forceResetTo:
-        if not forceResetTo in \
-        (WCSRCSZ_vOLD_32BIT, WCSRCSZ_v215_32BIT, WCSRCSZ_v215_64BIT):
+        if forceResetTo not in (
+                WCSRCSZ_vOLD_32BIT, WCSRCSZ_v215_32BIT, WCSRCSZ_v215_64BIT):
             raise IrafError("Unexpected value for wcs record size: "+\
                             str(forceResetTo))
         _WCS_RECORD_SIZE = forceResetTo

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -36,7 +36,7 @@ $Id$
 
 R. White, 1999 September 23
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import __main__, re, os, sys, types
 try:
@@ -232,9 +232,9 @@ def _help(an_obj, variables, functions, modules,
 
     if modules and modulelist:
         # modules get listed in simple column format
-        print "Modules:"
+        print("Modules:")
         irafutils.printCols(map(lambda x: x[0], modulelist))
-        print
+        print()
 
     if functions and functionlist:
         _printValueList(functionlist, hidden, padchars)
@@ -247,14 +247,14 @@ def _help(an_obj, variables, functions, modules,
 
     # IRAF packages and tasks get listed in simple column format
     if packages and pkglist:
-        print "IRAF Packages:"
+        print("IRAF Packages:")
         irafutils.printCols(pkglist)
-        print
+        print()
 
     if tasks and tasklist:
-        print "IRAF Tasks:"
+        print("IRAF Tasks:")
         irafutils.printCols(tasklist)
-        print
+        print()
 
     if _isinstancetype(an_obj) and functions:
         # for instances, call recursively to list class methods
@@ -284,10 +284,10 @@ def _valueHelp(an_obj, padchars):
         name = ''
     name = name + (padchars-len(name))*" "
     if name and len(name.strip()) > 0:
-        print name, ":", vstr
+        print(name, ":", vstr)
     else:
         # omit the colon if name is null
-        print vstr
+        print(vstr)
 
 def _getContents(vlist, regexp, an_obj):
     # Make one pass through names getting the type and sort order
@@ -350,7 +350,7 @@ def _printValueList(varlist, hidden, padchars):
             # pad name to padchars chars if shorter
             if len(vname) < padchars:
                 vname = vname + (padchars-len(vname))*" "
-            print vname, ":", vstr
+            print(vname, ":", vstr)
 
 
 
@@ -429,7 +429,7 @@ def _irafHelp(taskname, irafkw):
         pyraf.iraf.system.help(taskname, **irafkw)
         return 1
     except IrafError as e:
-        print str(e)
+        print(str(e))
         return 0
 
 _HelpURL = "http://stsdas.stsci.edu/cgi-bin/gethelp.cgi?task="

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -372,16 +372,16 @@ def _valueString(value,verbose=0):
     vstr = t.__name__
     if issubclass(t, str):
         if len(value)>42:
-            vstr = vstr + ", value = "+ `value[:39]` + '...'
+            vstr = vstr + ", value = "+ repr(value[:39]) + '...'
         else:
-            vstr = vstr + ", value = "+ `value`
+            vstr = vstr + ", value = "+ repr(value)
     elif issubclass(t, _listTypes):
         return "%s [%d entries]" % (vstr, len(value))
     elif (PY3K and issubclass(t, io.IOBase)) or \
          (not PY3K and issubclass(t, file)):
-        vstr = vstr + ", "+ `value`
+        vstr = vstr + ", "+ repr(value)
     elif issubclass(t, _numericTypes):
-        vstr = vstr + ", value = "+ `value`
+        vstr = vstr + ", value = "+ repr(value)
     elif _isinstancetype(value):
         cls = value.__class__
         if cls.__module__ == '__main__':
@@ -404,9 +404,9 @@ def _valueString(value,verbose=0):
         vstr = vstr + " " + str(value.dtype) + "["
         for k in range(len(value.shape)):
             if k:
-                vstr = vstr + "," + `value.shape[k]`
+                vstr = vstr + "," + repr(value.shape[k])
             else:
-                vstr = vstr + `value.shape[k]`
+                vstr = vstr + repr(value.shape[k])
         vstr = vstr + "]"
     else:
         # default -- just return the type

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -91,7 +91,7 @@ _allSingleTypes = _functionTypes + _methodTypes + _listTypes + _numericTypes
 kwnames = ( 'variables', 'functions', 'modules',
                 'tasks', 'packages', 'hidden', 'padchars', 'regexp', 'html' )
 _kwdict = minmatch.MinMatchDict()
-for key in kwnames: _kwdict.add(key,key)
+for key in kwnames: _kwdict.add(key, key)
 del kwnames, key
 
 # additional keywords for IRAF help task
@@ -101,7 +101,7 @@ irafkwnames = ( 'file_template', 'all',
                 'rmargin', 'curpack', 'device', 'helpdb', 'mode' )
 _irafkwdict = {}
 for key in irafkwnames:
-    _kwdict.add(key,key)
+    _kwdict.add(key, key)
     _irafkwdict[key] = 1
 del irafkwnames, key
 
@@ -185,10 +185,10 @@ def _help(an_obj, variables, functions, modules,
     # on it too (XXX this is a bit risky, but I suppose people will not
     # often be asking for help with simple strings as an argument...)
 
-    if isinstance(an_obj,IrafTask):
+    if isinstance(an_obj, IrafTask):
         if _printIrafHelp(an_obj, html, irafkw): return
 
-    if isinstance(an_obj,str):
+    if isinstance(an_obj, str):
         # Python task names
         if an_obj in sys.modules: # e.g. help drizzlepac
             theMod = sys.modules[an_obj]
@@ -205,8 +205,8 @@ def _help(an_obj, variables, functions, modules,
                     theMod.help()
                     return
         # IRAF task names
-        if re.match(r'[A-Za-z_][A-Za-z0-9_.]*$',an_obj) or \
-          (re.match(r'[^\0]*$',an_obj) and \
+        if re.match(r'[A-Za-z_][A-Za-z0-9_.]*$', an_obj) or \
+          (re.match(r'[^\0]*$', an_obj) and \
                     os.path.exists(pyraf.iraf.Expand(an_obj, noerror=1))):
             if _printIrafHelp(an_obj, html, irafkw): return
 
@@ -277,7 +277,7 @@ def _printIrafHelp(an_obj, html, irafkw):
 
 def _valueHelp(an_obj, padchars):
     # just print info on the object itself
-    vstr = _valueString(an_obj,verbose=1)
+    vstr = _valueString(an_obj, verbose=1)
     try:
         name = an_obj.__name__
     except AttributeError:
@@ -312,13 +312,13 @@ def _getContents(vlist, regexp, an_obj):
     for vname in names:
         if (regexp is None) or re_check.match(vname):
             value = vlist[vname]
-            if isinstance(value,IrafPkg):
+            if isinstance(value, IrafPkg):
                 pkglist.append(vname + '/')
-            elif isinstance(value,IrafTask):
+            elif isinstance(value, IrafTask):
                 tasklist.append(vname)
             else:
                 vorder = _sortOrder(type(value))
-                sortlist[vorder].append((vname,value))
+                sortlist[vorder].append((vname, value))
                 namedict[vname] = 1
     # add methods from base classes if this is a class
     if (not PY3K and isinstance(an_obj, types.ClassType)) or \
@@ -330,7 +330,7 @@ def _getContents(vlist, regexp, an_obj):
                 if vname not in namedict and (
                         (regexp is None) or re_check.match(vname)):
                     vorder = _sortOrder(type(value))
-                    sortlist[vorder].append((vname,value))
+                    sortlist[vorder].append((vname, value))
                     namedict[vname] = 1
     # sort into alphabetical order by name
     tasklist.sort()
@@ -419,11 +419,11 @@ def _irafHelp(taskname, irafkw):
     Task can be either a name or an IrafTask object.
     Returns 1 on success or 0 on failure."""
 
-    if isinstance(taskname,IrafTask):
+    if isinstance(taskname, IrafTask):
         taskname = taskname.getName()
     else:
         # expand IRAF variables in case this is name of a help file
-        taskname = pyraf.iraf.Expand(taskname,noerror=1)
+        taskname = pyraf.iraf.Expand(taskname, noerror=1)
     try:
         if 'page' not in irafkw:
             irafkw['page'] = 1
@@ -440,7 +440,7 @@ def _htmlHelp(taskname):
     """Display HTML help for given IRAF task in a browser.
     Task can be either a name or an IrafTask object. """
 
-    if isinstance(taskname,IrafTask):
+    if isinstance(taskname, IrafTask):
         taskname = taskname.getName()
     url = _HelpURL + taskname
 

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -233,7 +233,7 @@ def _help(an_obj, variables, functions, modules,
     if modules and modulelist:
         # modules get listed in simple column format
         print("Modules:")
-        irafutils.printCols(map(lambda x: x[0], modulelist))
+        irafutils.printCols([x[0] for x in modulelist])
         print()
 
     if functions and functionlist:

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -327,8 +327,8 @@ def _getContents(vlist, regexp, an_obj):
         for c in classlist:
             classlist.extend(list(c.__bases__))
             for vname, value in vars(c).items():
-                if not vname in namedict and \
-                  ((regexp is None) or re_check.match(vname)):
+                if vname not in namedict and (
+                        (regexp is None) or re_check.match(vname)):
                     vorder = _sortOrder(type(value))
                     sortlist[vorder].append((vname,value))
                     namedict[vname] = 1
@@ -425,7 +425,8 @@ def _irafHelp(taskname, irafkw):
         # expand IRAF variables in case this is name of a help file
         taskname = pyraf.iraf.Expand(taskname,noerror=1)
     try:
-        if not 'page' in irafkw: irafkw['page'] = 1
+        if 'page' not in irafkw:
+            irafkw['page'] = 1
         pyraf.iraf.system.help(taskname, **irafkw)
         return 1
     except IrafError as e:

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -322,7 +322,7 @@ def _getContents(vlist, regexp, an_obj):
                 namedict[vname] = 1
     # add methods from base classes if this is a class
     if (not PY3K and isinstance(an_obj, types.ClassType)) or \
-       (PY3K and type(an_obj)==type(object)): # i.e. "<class 'type'>"
+       (PY3K and isinstance(an_obj, type(object))): # i.e. "<class 'type'>"
         classlist = list(an_obj.__bases__)
         for c in classlist:
             classlist.extend(list(c.__bases__))

--- a/lib/pyraf/irafhelp.py
+++ b/lib/pyraf/irafhelp.py
@@ -163,7 +163,7 @@ Other keywords are passed on to the IRAF help task if it is called.
             else:
                 # this is a Python help function keyword
                 exec(fullkey+' = '+repr(kw[key]))
-        except KeyError, e:
+        except KeyError as e:
             raise e.__class__("Error in keyword "+key+"\n"+str(e))
 
     resetList = pyraf.iraf.redirApply(redirKW)
@@ -428,7 +428,7 @@ def _irafHelp(taskname, irafkw):
         if not 'page' in irafkw: irafkw['page'] = 1
         pyraf.iraf.system.help(taskname, **irafkw)
         return 1
-    except IrafError, e:
+    except IrafError as e:
         print str(e)
         return 0
 

--- a/lib/pyraf/irafimcur.py
+++ b/lib/pyraf/irafimcur.py
@@ -8,7 +8,7 @@ $Id$
 """
 from __future__ import division, print_function
 
-import sys,string
+import sys, string
 from stsci.tools import irafutils
 from stsci.tools.irafglobals import Verbose, IrafError
 import irafdisplay, gwm, iraf
@@ -30,7 +30,7 @@ def _getDevice(displayname=None):
         device = gwm.gki.getGraphcap()[displayname]
         dd = device['DD'].split(',')
         if len(dd)>1 and dd[1] != '':
-            imtdev = 'fifo:%si:%so' % (dd[1],dd[1])
+            imtdev = 'fifo:%si:%so' % (dd[1], dd[1])
         else:
             imtdev = None
         # multiple stdimage/graphcap entries can share the same device

--- a/lib/pyraf/irafimcur.py
+++ b/lib/pyraf/irafimcur.py
@@ -6,7 +6,7 @@ imcur parameter.
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import sys,string
 from stsci.tools import irafutils

--- a/lib/pyraf/irafimcur.py
+++ b/lib/pyraf/irafimcur.py
@@ -72,13 +72,13 @@ def imcur(displayname=None):
             sys.__stdout__.write("%s\n" % (result,))
             sys.__stdout__.flush()
         if result == 'EOF':
-            raise EOFError
+            raise EOFError()
         x, y, wcs, key = result.split()
 
         if key in [r'\004', r'\032']:
             # ctrl-D and ctrl-Z are treated as EOF
             # Should ctrl-C raise a KeyboardInterrupt?
-            raise EOFError
+            raise EOFError()
         elif key == ':':
             sys.stdout.write(": ")
             sys.stdout.flush()

--- a/lib/pyraf/irafimcur.py
+++ b/lib/pyraf/irafimcur.py
@@ -38,7 +38,7 @@ def _getDevice(displayname=None):
             _devices[imtdev] = irafdisplay.ImageDisplayProxy(imtdev)
         device = _devices[displayname] = _devices[imtdev]
         return device
-    except (KeyError, IOError, OSError), error:
+    except (KeyError, IOError, OSError) as error:
         pass
 
     # last gasp is to assume display is an imtdev string
@@ -84,5 +84,5 @@ def imcur(displayname=None):
             sys.stdout.flush()
             result = result + ' ' + irafutils.tkreadline()[:-1]
         return result
-    except IOError, error:
+    except IOError as error:
         raise IrafError(str(error))

--- a/lib/pyraf/irafimcur.py
+++ b/lib/pyraf/irafimcur.py
@@ -34,7 +34,7 @@ def _getDevice(displayname=None):
         else:
             imtdev = None
         # multiple stdimage/graphcap entries can share the same device
-        if not imtdev in _devices:
+        if imtdev not in _devices:
             _devices[imtdev] = irafdisplay.ImageDisplayProxy(imtdev)
         device = _devices[displayname] = _devices[imtdev]
         return device

--- a/lib/pyraf/irafimport.py
+++ b/lib/pyraf/irafimport.py
@@ -179,7 +179,7 @@ class _irafModuleClass:
         """
         if self.module is None: self._moduleInit()
         if taskname == "":
-            matches = self.mmdict.keys()
+            matches = list(self.mmdict.keys())
         else:
             matches = self.mmdict.getallkeys(taskname, [])
         matches.extend(self.module.getAllTasks(taskname))

--- a/lib/pyraf/irafimport.py
+++ b/lib/pyraf/irafimport.py
@@ -12,7 +12,7 @@ $Id$
 
 R. White, 1999 August 17
 """
-from __future__ import absolute_import, division # confidence high
+from __future__ import absolute_import, division, print_function
 
 import __builtin__
 import sys

--- a/lib/pyraf/irafimport.py
+++ b/lib/pyraf/irafimport.py
@@ -54,7 +54,7 @@ def _irafImport(name, globals={}, locals={}, fromlist=[], level=-1):
     # e.g. "from iraf import stsdas, noao" or "from .iraf import noao"
     if fromlist and (name in ["iraf", "pyraf.iraf", ".iraf"]):
         for task in fromlist:
-            pkg = the_iraf_module.getPkg(task,found=1)
+            pkg = the_iraf_module.getPkg(task, found=1)
             if pkg is not None and not pkg.isLoaded():
                 pkg.run(_doprint=0, _hush=1)
         # must return a module for 'from' import

--- a/lib/pyraf/irafimport.py
+++ b/lib/pyraf/irafimport.py
@@ -157,9 +157,9 @@ class _irafModuleClass:
         # if that fails, try getting a task with this name
         try:
             return self.module.getTask(attr)
-        except minmatch.AmbiguousKeyError, e:
+        except minmatch.AmbiguousKeyError as e:
             raise AttributeError(str(e))
-        except KeyError, e:
+        except KeyError as e:
             pass
         # last try is minimum match dictionary of rest of module contents
         try:

--- a/lib/pyraf/irafinst.py
+++ b/lib/pyraf/irafinst.py
@@ -109,9 +109,9 @@ def _writeTmpFile(base_fname, text):
     """ Utility function for writing our tmp files. Return the full fname."""
     global _tmp_dir
     if not _tmp_dir:
-        u = os.environ.get('USER','')
-        if not u: u = os.environ.get('LOGNAME','')
-        _tmp_dir = tempfile.mkdtemp(prefix='pyraf_'+u+'_tmp_',suffix='.no-iraf')
+        u = os.environ.get('USER', '')
+        if not u: u = os.environ.get('LOGNAME', '')
+        _tmp_dir = tempfile.mkdtemp(prefix='pyraf_'+u+'_tmp_', suffix='.no-iraf')
     tmpf = _tmp_dir+os.sep+base_fname
     if os.path.exists(tmpf): os.remove(tmpf)
     f = open(tmpf, 'w')

--- a/lib/pyraf/irafinst.py
+++ b/lib/pyraf/irafinst.py
@@ -8,7 +8,7 @@ non-IRAF situations.
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, shutil, sys, tempfile
 

--- a/lib/pyraf/irafnames.py
+++ b/lib/pyraf/irafnames.py
@@ -35,28 +35,28 @@ def _addName(task, module):
 # Basic namespace strategy class (does nothing)
 
 class IrafNameStrategy:
-    def addTask(self,task):
+    def addTask(self, task):
         pass
-    def addPkg(self,pkg):
+    def addPkg(self, pkg):
         pass
 
 # NameClean implementation puts tasks and packages in iraf module name space
 # Note that since packages are also tasks, we only need to do this for tasks
 
 class IrafNameClean(IrafNameStrategy):
-    def addTask(self,task):
+    def addTask(self, task):
         _addName(task, pyraf.iraf)
 
 # IrafNamePkg also adds packages to __main__ name space
 
 class IrafNamePkg(IrafNameClean):
-    def addPkg(self,pkg):
+    def addPkg(self, pkg):
         _addName(pkg, __main__)
 
 # IrafNameTask puts everything (tasks and packages) in __main__ name space
 
 class IrafNameTask(IrafNameClean):
-    def addTask(self,task):
+    def addTask(self, task):
         _addName(task, pyraf.iraf)
         _addName(task, __main__)
 

--- a/lib/pyraf/irafnames.py
+++ b/lib/pyraf/irafnames.py
@@ -6,7 +6,7 @@ $Id$
 
 R. White, 1999 March 26
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import __main__
 from stsci.tools import irafglobals
@@ -29,8 +29,8 @@ def _addName(task, module):
         setattr(module, name, task)
     else:
         if irafglobals.Verbose>0:
-            print "Warning: " + module.__name__ + "." + \
-                    name + " was not redefined as Iraf Task"
+            print("Warning: " + module.__name__ + "." +
+                  name + " was not redefined as Iraf Task")
 
 # Basic namespace strategy class (does nothing)
 

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -4,7 +4,7 @@ $Id$
 
 R. White, 2000 January 7
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import copy, glob, os, re, sys, types
 from stsci.tools import basicpar, minmatch, irafutils, taskpars
@@ -649,7 +649,7 @@ class IrafParList(taskpars.TaskPars):
         """
         if not isinstance(other, self.__class__):
             if Verbose>0:
-                print 'Comparison list is not a %s' % self.__class__.__name__
+                print('Comparison list is not a %s' % self.__class__.__name__)
             return 0
         # compare minimal set of parameter attributes
         thislist = self._getConsistentList()
@@ -1004,7 +1004,7 @@ class IrafParList(taskpars.TaskPars):
         tpar.tpar(self)
 
     def lParam(self,verbose=0):
-        print self.lParamStr(verbose=verbose)
+        print(self.lParamStr(verbose=verbose))
 
     def lParamStr(self,verbose=0):
         """List the task parameters"""
@@ -1033,8 +1033,8 @@ class IrafParList(taskpars.TaskPars):
         for i in xrange(len(self.__pars)):
             p = self.__pars[i]
             if p.name != '$nargs':
-                print "%s%s" % (taskname,p.dpar(cl=cl))
-        if cl: print "# EOF"
+                print("%s%s" % (taskname,p.dpar(cl=cl)))
+        if cl: print("# EOF")
 
     def saveParList(self, filename=None, comment=None):
         """Write .par file data to filename (string or filehandle)"""
@@ -1046,7 +1046,7 @@ class IrafParList(taskpars.TaskPars):
         writepars = int(pyraf.iraf.envget("writepars", 1))
         if writepars < 1:
             msg = "No parameters written to disk."
-            print msg
+            print(msg)
             return msg
         # ok, go ahead and write 'em - set up file
         if hasattr(filename,'write'):
@@ -1132,12 +1132,12 @@ def _extractDiffInfo(alist):
 def _printHiddenDiff(pd1,hd1,pd2,hd2):
     for key in pd1.keys():
         if key in hd2:
-            print "Parameter `%s' is hidden in list 2 but not list 1" % (key,)
+            print("Parameter `%s' is hidden in list 2 but not list 1" % (key,))
             del pd1[key]
             del hd2[key]
     for key in pd2.keys():
         if key in hd1:
-            print "Parameter `%s' is hidden in list 1 but not list 2" % (key,)
+            print("Parameter `%s' is hidden in list 1 but not list 2" % (key,))
             del pd2[key]
             del hd1[key]
 
@@ -1163,27 +1163,27 @@ def _printDiff(pd1, pd2, label):
             else:
                 # one or both parameters missing
                 if not key1 in pd2:
-                    print "Extra %s parameter `%s' (type `%s') in list 1" % \
-                            (label, key1, pd1[key1][0])
+                    print("Extra %s parameter `%s' (type `%s') in list 1" %
+                          (label, key1, pd1[key1][0]))
                     # delete the extra parameter
                     del pd1[key1]
                     i1 = i1+1
                 if not key2 in pd1:
-                    print "Extra %s parameter `%s' (type `%s') in list 2" % \
-                            (label, key2, pd2[key2][0])
+                    print("Extra %s parameter `%s' (type `%s') in list 2" %
+                          (label, key2, pd2[key2][0]))
                     del pd2[key2]
                     i2 = i2+1
         # other parameters must be missing
         while i1<len(k1):
             key1 = k1[i1]
-            print "Extra %s parameter `%s' (type `%s') in list 1" % \
-                    (label, key1, pd1[key1][0])
+            print("Extra %s parameter `%s' (type `%s') in list 1" %
+                  (label, key1, pd1[key1][0]))
             del pd1[key1]
             i1 = i1+1
         while i2<len(k2):
             key2 = k2[i2]
-            print "Extra %s parameter `%s' (type `%s') in list 2" % \
-                    (label, key2, pd2[key2][0])
+            print("Extra %s parameter `%s' (type `%s') in list 2" %
+                  (label, key2, pd2[key2][0]))
             del pd2[key2]
             i2 = i2+1
     # remaining parameters are in both lists
@@ -1200,7 +1200,7 @@ def _printDiff(pd1, pd2, label):
                 mm.append("order disagreement")
             if type1 != type2:
                 mm.append("type disagreement (`%s' vs. `%s')" % (type1, type2))
-            print "Parameter `%s': %s" % (key, ", ".join(mm))
+            print("Parameter `%s': %s" % (key, ", ".join(mm)))
 
 
 # The dictionary of all special-use par files found on disk.

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -1160,13 +1160,13 @@ def _printDiff(pd1, pd2, label):
                 i2 = i2+1
             else:
                 # one or both parameters missing
-                if not key1 in pd2:
+                if key1 not in pd2:
                     print("Extra %s parameter `%s' (type `%s') in list 1" %
                           (label, key1, pd1[key1][0]))
                     # delete the extra parameter
                     del pd1[key1]
                     i1 = i1+1
-                if not key2 in pd1:
+                if key2 not in pd1:
                     print("Extra %s parameter `%s' (type `%s') in list 2" %
                           (label, key2, pd2[key2][0]))
                     del pd2[key2]
@@ -1302,7 +1302,7 @@ def newSpecialParFile(taskName, pkgName, pathName):
 
     tupKey = (taskName, pkgName)
     if tupKey in _specialUseParFileDict:
-        if not pathName in _specialUseParFileDict[tupKey]:
+        if pathName not in _specialUseParFileDict[tupKey]:
             _specialUseParFileDict[tupKey].append(pathName)
     else:
         _specialUseParFileDict[tupKey] = [pathName,]

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -1466,7 +1466,7 @@ def _readpar(filename,strict=0):
                     g = mm.group('single')
                 else:
                     raise SyntaxError(filename + "\n" + line + "\n" + \
-                            "Huh? mm.groups()="+`mm.groups()`+"\n" + \
+                            "Huh? mm.groups()="+repr(mm.groups())+"\n" + \
                             "Bug: doesn't match single, double or comma??")
                 flist.append(g)
                 # move match pointer

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -831,7 +831,7 @@ class IrafParList(taskpars.TaskPars):
     def getAllMatches(self,param):
         """Return list of all parameter names that may match param"""
         if param == "":
-            return self.__pardict.keys()
+            return list(self.__pardict.keys())
         else:
             return self.__pardict.getallkeys(param, [])
 
@@ -1145,10 +1145,8 @@ def _printDiff(pd1, pd2, label):
     if pd1 == pd2:
         return
     noextra = 1
-    k1 = pd1.keys()
-    k1.sort()
-    k2 = pd2.keys()
-    k2.sort()
+    k1 = sorted(pd1.keys())
+    k2 = sorted(pd2.keys())
     if k1 != k2:
         # parameter name lists differ
         i1 = 0

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -1010,13 +1010,13 @@ class IrafParList(taskpars.TaskPars):
         """List the task parameters"""
         retval = []
         # Do the non-hidden parameters first
-        for i in xrange(len(self.__pars)):
+        for i in range(len(self.__pars)):
             p = self.__pars[i]
             if p.mode != 'h':
                 if Verbose>0 or p.name != '$nargs':
                     retval.append(p.pretty(verbose=verbose or Verbose>0))
         # Now the hidden parameters
-        for i in xrange(len(self.__pars)):
+        for i in range(len(self.__pars)):
             p = self.__pars[i]
             if p.mode == 'h':
                 if Verbose>0 or p.name != '$nargs':
@@ -1030,7 +1030,7 @@ class IrafParList(taskpars.TaskPars):
         false, writes Python executable code instead.
         """
         if taskname and taskname[-1:] != ".": taskname = taskname + "."
-        for i in xrange(len(self.__pars)):
+        for i in range(len(self.__pars)):
             p = self.__pars[i]
             if p.name != '$nargs':
                 print("%s%s" % (taskname,p.dpar(cl=cl)))

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -42,15 +42,15 @@ def IrafParFactory(fields, strict=0):
 
     # Handle special PyRAF/IRAF types, otherwise default to the standard types
     if type in _string_list_types:
-        return IrafParLS(fields,strict)
+        return IrafParLS(fields, strict)
     elif type == "*gcur" or type == "gcur":
-        return IrafParGCur(fields,strict)
+        return IrafParGCur(fields, strict)
     elif type == "*imcur" or type == "imcur":
-        return IrafParImCur(fields,strict)
+        return IrafParImCur(fields, strict)
     elif type == "*ukey" or type == "ukey":
-        return IrafParUKey(fields,strict)
+        return IrafParUKey(fields, strict)
     elif type == "pset":
-        return IrafParPset(fields,strict)
+        return IrafParPset(fields, strict)
     else:
         return basicpar.parFactory(fields, strict)
 
@@ -169,7 +169,7 @@ class IrafParPset(IrafParS):
     """IRAF pset parameter class"""
 
     def __init__(self,fields,strict=0):
-        IrafParS.__init__(self,fields,strict)
+        IrafParS.__init__(self, fields, strict)
         # omitted pset parameters default to null string
         if self.value is None: self.value = ""
 
@@ -218,7 +218,7 @@ class IrafParL(_StringMixin, IrafPar):
     """IRAF list parameter base class"""
 
     def __init__(self,fields,strict=0):
-        IrafPar.__init__(self,fields,strict)
+        IrafPar.__init__(self, fields, strict)
         # filehandle for input file
         self.__dict__['fh'] = None
         # lines used to store input when not reading from a tty
@@ -244,7 +244,7 @@ class IrafParL(_StringMixin, IrafPar):
             raise SyntaxError("Parameter "+self.name+" is not an array")
 
         if field:
-            self._setField(value,field,check=check)
+            self._setField(value, field, check=check)
         else:
             if check:
                 self.value = self.checkValue(value)
@@ -265,7 +265,7 @@ class IrafParL(_StringMixin, IrafPar):
         """Return value of this parameter as a string (or in native format
         if native is non-zero.)"""
 
-        if field: return self._getField(field,native=native,prompt=prompt)
+        if field: return self._getField(field, native=native, prompt=prompt)
         if lpar:
             if self.value is None and native == 0:
                 return ""
@@ -303,7 +303,7 @@ class IrafParL(_StringMixin, IrafPar):
                 if not self.errMsg:
                     warning("Unable to read values for list parameter `%s' "
                             "from file `%s'\n%s" %
-                            (self.name, self.value,str(e)), level=-1)
+                            (self.name, self.value, str(e)), level=-1)
                     # only print message one time
                     self.errMsg = 1
                 # fall back on default behavior if file is not readable
@@ -330,7 +330,7 @@ class IrafParL(_StringMixin, IrafPar):
         """Return a string with next value"""
         raise RuntimeError("Bug: base class IrafParL cannot be used directly")
 
-    def _getPFilename(self,native,prompt):
+    def _getPFilename(self, native, prompt):
         """Get p_filename field for this parameter (returns filename)"""
         #XXX is this OK? should we check for self.value==None?
         return self.value
@@ -375,10 +375,10 @@ class IrafParCursor(IrafParL):
     """Base class for cursor parameters"""
 
     def _coerceOneValue(self,value,strict=0):
-        if isinstance(value,IrafParCursor):
+        if isinstance(value, IrafParCursor):
             return value.p_filename
         else:
-            return IrafParL._coerceOneValue(self,value,strict)
+            return IrafParL._coerceOneValue(self, value, strict)
 
 # -----------------------------------------------------
 # IRAF gcur (graphics cursor) parameter class
@@ -543,7 +543,7 @@ class IrafParList(taskpars.TaskPars):
         """
         if hasattr(filename, 'name') and hasattr(filename, 'read'):
             filename = filename.name
-        if isinstance(filename,str):
+        if isinstance(filename, str):
             root, ext = os.path.splitext(filename)
             if ext != ".par":
                 # Only .par files are used as basis for parameter cache -- see if there
@@ -692,16 +692,16 @@ class IrafParList(taskpars.TaskPars):
 
     # parameters are accessible as attributes
 
-    def __getattr__(self,name):
+    def __getattr__(self, name):
 #       DBG: id(self), len(self.__dict__), "__getattr__ for: "+str(name)
         if name and name[0] == '_':
             raise AttributeError(name)
         try:
-            return self.getValue(name,native=1)
+            return self.getValue(name, native=1)
         except SyntaxError as e:
             raise AttributeError(str(e))
 
-    def __setattr__(self,name,value):
+    def __setattr__(self, name, value):
 #       DBG: id(self), len(self.__dict__), "__setattr__ for: "+str(name)+", value: "+str(value)[0:20]
         # hidden Python parameters go into the standard dictionary
         # (hope there are none of these in IRAF tasks)
@@ -711,13 +711,13 @@ class IrafParList(taskpars.TaskPars):
             else:
                 self.__dict__[name] = value # for old-style classes
         else:
-            self.setParam(name,value)
+            self.setParam(name, value)
 
     def __len__(self): return len(self.__pars)
 
     # public accessor functions for attributes
 
-    def hasPar(self,param):
+    def hasPar(self, param):
         """Test existence of parameter named param"""
         if self.__psets2merge: self.__addPsetParams()
         param = irafutils.untranslateName(param)
@@ -740,7 +740,7 @@ class IrafParList(taskpars.TaskPars):
         if self.__psets2merge: self.__addPsetParams()
         return self.__pardict
 
-    def getParObject(self,param):
+    def getParObject(self, param):
         """ Returns an IrafPar object matching the name given (param).
         This looks only at the "top level" (which includes
         any duplicated PSET pars via __addPsetParams), but does not look
@@ -828,7 +828,7 @@ class IrafParList(taskpars.TaskPars):
                     retval[pset.name] = matching_pars[0]
         return retval
 
-    def getAllMatches(self,param):
+    def getAllMatches(self, param):
         """Return list of all parameter names that may match param"""
         if param == "":
             return list(self.__pardict.keys())
@@ -845,14 +845,14 @@ class IrafParList(taskpars.TaskPars):
         """
         par = self.getParObject(param)
         value = par.get(native=native, mode=mode, prompt=prompt)
-        if isinstance(value,str) and value and value[0] == ")":
+        if isinstance(value, str) and value and value[0] == ")":
             # parameter indirection: ')task.param'
             try:
                 task = pyraf.iraf.getTask(self.__name)
-                value = task.getParam(value[1:],native=native,mode="h")
+                value = task.getParam(value[1:], native=native, mode="h")
             except KeyError:
                 # if task is not known, use generic function to get param
-                value = pyraf.iraf.clParGet(value[1:],native=native,mode="h",
+                value = pyraf.iraf.clParGet(value[1:], native=native, mode="h",
                         prompt=prompt)
         return value
 
@@ -993,7 +993,7 @@ class IrafParList(taskpars.TaskPars):
 
         # Number of arguments on command line, $nargs, is used by some IRAF
         # tasks (e.g. imheader).
-        self.setParam('$nargs',nargs)
+        self.setParam('$nargs', nargs)
 
     def eParam(self):
         import epar
@@ -1033,7 +1033,7 @@ class IrafParList(taskpars.TaskPars):
         for i in range(len(self.__pars)):
             p = self.__pars[i]
             if p.name != '$nargs':
-                print("%s%s" % (taskname,p.dpar(cl=cl)))
+                print("%s%s" % (taskname, p.dpar(cl=cl)))
         if cl: print("# EOF")
 
     def saveParList(self, filename=None, comment=None):
@@ -1049,13 +1049,13 @@ class IrafParList(taskpars.TaskPars):
             print(msg)
             return msg
         # ok, go ahead and write 'em - set up file
-        if hasattr(filename,'write'):
+        if hasattr(filename, 'write'):
             fh = filename
         else:
             absFileName = pyraf.iraf.Expand(filename)
             absDir = os.path.dirname(absFileName)
             if len(absDir) and not os.path.isdir(absDir): os.makedirs(absDir)
-            fh = open(absFileName,'w')
+            fh = open(absFileName, 'w')
         nsave = len(self.__pars)
         if comment:
             fh.write('# '+comment+'\n')
@@ -1114,7 +1114,7 @@ def _printVerboseDiff(list1, list2):
     """Print description of differences between parameter lists"""
     pd1, hd1 = _extractDiffInfo(list1)
     pd2, hd2 = _extractDiffInfo(list2)
-    _printHiddenDiff(pd1,hd1,pd2,hd2)       # look for hidden/positional changes
+    _printHiddenDiff(pd1, hd1, pd2, hd2)       # look for hidden/positional changes
     _printDiff(pd1, pd2, 'positional')      # compare positional parameters
     _printDiff(hd1, hd2, 'hidden')          # compare hidden parameters
 
@@ -1127,9 +1127,9 @@ def _extractDiffInfo(alist):
             hd[key] = value
         else:
             pd[key] = value
-    return (pd,hd)
+    return (pd, hd)
 
-def _printHiddenDiff(pd1,hd1,pd2,hd2):
+def _printHiddenDiff(pd1, hd1, pd2, hd2):
     for key in pd1.keys():
         if key in hd2:
             print("Parameter `%s' is hidden in list 2 but not list 1" % (key,))
@@ -1229,7 +1229,7 @@ def _updateSpecialParFileDict(dirToCheck=None, strict=False):
     # usual places (which calls us recursively).
     if dirToCheck == None:
         # Check the auxilliary par dir
-        uparmAux = pyraf.iraf.envget("uparm_aux","")
+        uparmAux = pyraf.iraf.envget("uparm_aux", "")
         if 'UPARM_AUX' in os.environ: uparmAux = os.environ['UPARM_AUX']
         if len(uparmAux) > 0:
             _updateSpecialParFileDict(dirToCheck=uparmAux, strict=True)
@@ -1386,7 +1386,7 @@ comma = whitespace + r"(?P<comma>$|(?=,)|(?:[^, \t'" + r'"][^,]*))' + optcomma
 # Combined pattern
 
 field = '(?:' + comma + ')|(?:' + double + ')|(?:' + single + ')'
-_re_field = re.compile(field,re.DOTALL)
+_re_field = re.compile(field, re.DOTALL)
 
 # Pattern that matches trailing backslashes at end of line
 _re_bstrail = re.compile(r'\\*$')
@@ -1401,7 +1401,7 @@ def _readpar(filename,strict=0):
 
     param_dict = {}
     param_list = []
-    fh = open(os.path.expanduser(filename),'r')
+    fh = open(os.path.expanduser(filename), 'r')
     lines = fh.readlines()
     fh.close()
     # reverse order of lines so we can use pop method
@@ -1426,7 +1426,7 @@ def _readpar(filename,strict=0):
             flist = []
             i1 = 0
             while len(line) > i1:
-                mm = _re_field.match(line,i1)
+                mm = _re_field.match(line, i1)
                 if mm is None:
                     # Failure occurs only for unmatched leading quote.
                     # Append more lines to get quotes to match.  (Probably
@@ -1441,7 +1441,7 @@ def _readpar(filename,strict=0):
                             raise SyntaxError(filename + ": Unmatched quote\n" +
                                     sline[0])
                         line = line + '\n' + nline.rstrip()
-                        mm = _re_field.match(line,i1)
+                        mm = _re_field.match(line, i1)
                 if mm.group('comma') is not None:
                     g = mm.group('comma')
                     # completely omitted field (,,)

--- a/lib/pyraf/irafpar.py
+++ b/lib/pyraf/irafpar.py
@@ -155,7 +155,7 @@ def makeIrafPar(init_value, datatype=None, name="<anonymous>", mode="h",
             fields[i] = str(fields[i])
     try:
         return IrafParFactory(fields, strict=strict)
-    except ValueError, e:
+    except ValueError as e:
         errmsg = "Bad value for parameter `%s'\n%s" % (name, str(e))
         raise ValueError(errmsg)
 
@@ -299,7 +299,7 @@ class IrafParL(_StringMixin, IrafPar):
                     # EOF -- raise exception
                     raise EOFError("EOF from list parameter `%s'" % self.name)
                 if value[-1:] == "\n": value = value[:-1]
-            except IOError, e:
+            except IOError as e:
                 if not self.errMsg:
                     warning("Unable to read values for list parameter `%s' "
                             "from file `%s'\n%s" %
@@ -698,7 +698,7 @@ class IrafParList(taskpars.TaskPars):
             raise AttributeError(name)
         try:
             return self.getValue(name,native=1)
-        except SyntaxError, e:
+        except SyntaxError as e:
             raise AttributeError(str(e))
 
     def __setattr__(self,name,value):
@@ -750,7 +750,7 @@ class IrafParList(taskpars.TaskPars):
         try:
             param = irafutils.untranslateName(param)
             return self.__pardict[param]
-        except KeyError, e:
+        except KeyError as e:
             raise e.__class__("Error in parameter '" +
                     param + "' for task " + self.__name + "\n" + str(e))
 
@@ -797,7 +797,7 @@ class IrafParList(taskpars.TaskPars):
         try:
             pobj = self.__pardict[param]
             retval[''] = pobj
-        except KeyError, e:
+        except KeyError as e:
             raise e.__class__("Error in parameter '" +
                     param + "' for task " + self.__name + "\n" + str(e))
 
@@ -903,7 +903,7 @@ class IrafParList(taskpars.TaskPars):
                         raise RuntimeError('PSET name non-match; par name: '+ \
                               key+'; got: '+results_dict[psetname].name)
                     dupl_pset_pars.append( (psetname, results_dict[psetname].name, key) )
-            except KeyError, e:
+            except KeyError as e:
                 # Perhaps it is pset.param ? This would occur if the caller
                 # used kwargs like gemcube(..., geofunc.axis1 = 1, ...)
                 # (see help call #3454 for Mark Sim.)
@@ -1477,7 +1477,7 @@ def _readpar(filename,strict=0):
                 par = IrafParFactory(flist, strict=strict)
             except KeyboardInterrupt:
                 raise
-            except Exception, exc:
+            except Exception as exc:
                 #XXX Shouldn't catch all exceptions here -- this could
                 #XXX screw things up
                 if Verbose:

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -250,7 +250,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             paramdict = self.getParDict()
             if paramdict._has(paramname,exact=exact):
                 return paramdict[paramname]
-        except minmatch.AmbiguousKeyError, e:
+        except minmatch.AmbiguousKeyError as e:
             # re-raise the error with a bit more info
             raise IrafError("Cannot get parameter `%s'\n%s" %
                             (paramname, str(e)))
@@ -515,7 +515,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             except KeyError:
                 raise IrafError("Could not find task "+task+
                                 " to get parameter "+qualifiedName)
-            except IrafError, e:
+            except IrafError as e:
                 raise IrafError(str(e)+"\nFailed to set parameter "+
                                 qualifiedName)
 
@@ -589,7 +589,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         except KeyError:
             raise IrafError("Could not find task "+task+
                             " to get parameter "+qualifiedName)
-        except IrafError, e:
+        except IrafError as e:
             raise IrafError(str(e)+"\nFailed to get parameter "+
                             qualifiedName)
 
@@ -602,7 +602,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             if paramdict._has(paramname,exact=exact):
                 return self._getParFromDict(paramdict, paramname, pindex,
                                             field, native, mode=mode, prompt=prompt)
-        except minmatch.AmbiguousKeyError, e:
+        except minmatch.AmbiguousKeyError as e:
             # re-raise the error with a bit more info
             raise IrafError("Cannot get parameter `%s'\n%s" %
                             (paramname, str(e)))
@@ -742,7 +742,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         self.initTask()
         try:
             return self.getParam(name,native=1)
-        except SyntaxError, e:
+        except SyntaxError as e:
             raise AttributeError(str(e))
 
     def __setattr__(self,name,value):
@@ -806,7 +806,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         """
         try:
             irafexecute.IrafExecute(self, pyraf.iraf.getVarDict(), **redirKW)
-        except irafexecute.IrafProcessError, value:
+        except irafexecute.IrafProcessError as value:
             raise IrafError("Error running IRAF task "+self._name+
                             "\n"+str(value))
 
@@ -930,7 +930,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             exename1 = pyraf.iraf.Expand(self._filename)
             # get name of executable file without path
             basedir, basename = os.path.split(exename1)
-        except IrafError, e:
+        except IrafError as e:
             if Verbose>0:
                 print >> sys.stderr, "Error searching for executable for: "+\
                          self._name
@@ -955,7 +955,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             for pbin in self._pkgbinary: # e.g. ['bin$']
                 try:
                     exelist.append(pyraf.iraf.Expand(pbin + basename))
-                except IrafError, e:
+                except IrafError as e:
                     if Verbose>0:
                         print >> sys.stderr, "Error finding executable for: "+\
                                  self._name
@@ -994,7 +994,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             exename1 = pyraf.iraf.Expand(self._filename)
             basedir, basename = os.path.split(exename1)
             if basedir=="": basedir = "."
-        except IrafError, e:
+        except IrafError as e:
             if Verbose>0:
                 print >> sys.stderr, "Error expanding executable name for "+\
                          "task "+self._name+", tried: "+self._filename
@@ -1218,12 +1218,12 @@ class ParDictListSearch:
         # try exact match
         try:
             return self._taskObj.getParam(paramname,native=1,mode="h",exact=1)
-        except IrafError, e:
+        except IrafError as e:
             pass
         # try minimum match
         try:
             p = self._taskObj.getParObject(paramname,alldict=1)
-        except IrafError, e:
+        except IrafError as e:
             # not found at all
             raise AttributeError(str(e))
         # it was found, but we don't allow min-match in CL scripts
@@ -1236,12 +1236,12 @@ class ParDictListSearch:
         # try exact match
         try:
             return self._taskObj.getParObject(paramname,exact=1,alldict=1)
-        except IrafError, e:
+        except IrafError as e:
             pass
         # try minimum match
         try:
             p = self._taskObj.getParObject(paramname,alldict=1)
-        except IrafError, e:
+        except IrafError as e:
             # not found at all
             raise AttributeError(str(e))
         # it was found, but we don't allow min-match in CL scripts
@@ -1257,12 +1257,12 @@ class ParDictListSearch:
         # try exact match
         try:
             return self._taskObj.setParam(paramname,value,exact=1)
-        except IrafError, e:
+        except IrafError as e:
             pass
         # try minimum match
         try:
             p = self._taskObj.getParObject(paramname,alldict=1)
-        except IrafError, e:
+        except IrafError as e:
             # not found at all
             raise AttributeError(str(e))
         # it was found, but we don't allow min-match in CL scripts
@@ -1555,7 +1555,7 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
                     try:
                         matches.extend(p.getAllMatches(name,
                                                 triedpkgs=triedpkgs))
-                    except AttributeError, e:
+                    except AttributeError as e:
                         pass
         return matches
 

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -1163,12 +1163,12 @@ class IrafPythonTask(IrafTask):
         if self._pyFunction is None:
             return self.__dict__
         try:
-            module = self._pyFunction.func_globals['__name__']
+            module = self._pyFunction.__globals__['__name__']
             if module[:6] == 'pyraf.':
                 return self.__dict__
         except KeyError:
             pass
-        file = self._pyFunction.func_code.co_filename
+        file = self._pyFunction.__code__.co_filename
         # oh well, replace _pyFunction in shallow copy of dictionary
         sdict = self.__dict__.copy()
         sdict['_pyFunction'] = None

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -1756,7 +1756,7 @@ class IrafForeignTask(IrafTask):
         # converted to strings, including objects which are not
         # naturally converted to strings.
         #self._args = map(re.escape,map(str,args))
-        self._args = map(self._str_escape, args)
+        self._args = list(map(self._str_escape, args))
 
     #=========================================================
     # private methods
@@ -1833,7 +1833,7 @@ def _splitName(qualifiedName):
     is changed to Python zero-based subscript.
     """
     # name components may have had 'PY' appended if they match Python keywords
-    slist = map(irafutils.untranslateName, qualifiedName.split('.'))
+    slist = list(map(irafutils.untranslateName, qualifiedName.split('.')))
 
     # add field=None if not present
 

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -508,7 +508,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             try:
                 tobj = pyraf.iraf.getTask(task)
                 # reattach the index and/or field
-                if pindex: paramname = paramname + '[' + `pindex+1` + ']'
+                if pindex: paramname = paramname + '[' + repr(pindex+1) + ']'
                 if field: paramname = paramname + '.' + field
                 tobj.setParam(paramname,newvalue,check=check)
                 return
@@ -1698,7 +1698,7 @@ def mutateCLTask2Pkg(o, loaded=1,  klass=IrafPkg):
     if isinstance(o, IrafPkg):
         return
     if not isinstance(o, IrafCLTask):
-        raise TypeError("Cannot turn object `%s' into an IrafPkg" % `o`)
+        raise TypeError("Cannot turn object `%s' into an IrafPkg" % repr(o))
 
     # add the extra attributes used in IrafPkg
     # this is usually called while actually loading the package, so by

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -248,7 +248,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         # most of the time it will be in the active task dictionary
         try:
             paramdict = self.getParDict()
-            if paramdict._has(paramname,exact=exact):
+            if paramdict._has(paramname, exact=exact):
                 return paramdict[paramname]
         except minmatch.AmbiguousKeyError as e:
             # re-raise the error with a bit more info
@@ -261,12 +261,12 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
 
             if self._parDictList is None: self._setParDictList()
             for dictname, paramdict in self._parDictList:
-                if paramdict._has(paramname,exact=exact):
+                if paramdict._has(paramname, exact=exact):
                     return paramdict[paramname]
 
         raise IrafError("Unknown parameter requested: "+paramname)
 
-    def getAllMatches(self,param):
+    def getAllMatches(self, param):
         """Return list of names of all parameters that may match param"""
         self.initTask(force=1)
         plist = self._runningParList or self._currentParList
@@ -286,7 +286,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
 
         if not pkgbinary:
             return
-        elif isinstance(pkgbinary,str):
+        elif isinstance(pkgbinary, str):
             if pkgbinary and (pkgbinary not in self._pkgbinary):
                 self._pkgbinary.append(pkgbinary)
         else:
@@ -375,7 +375,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         Searches up the task, package, cl hierarchy for automatic modes
         """
         if parList is not None:
-            mode = parList.getValue('mode',prompt=0)
+            mode = parList.getValue('mode', prompt=0)
         else:
             pdict = self.getParDict()
             if pdict:
@@ -462,7 +462,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             # set mode of automatic parameters
             mode = self.getMode(newParList)
             for p in newParList.getParList():
-                p.mode = p.mode.replace("a",mode)
+                p.mode = p.mode.replace("a", mode)
         if parList:
             #XXX Set all command-line flags for parameters when a
             #XXX parlist is supplied so that it does not prompt for
@@ -497,8 +497,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                 for dictname, paramdict in self._parDictList:
                     if dictname == task:
                         if paramname in paramdict:
-                            paramdict[paramname].set(newvalue,index=pindex,
-                                    field=field,check=check)
+                            paramdict[paramname].set(newvalue, index=pindex,
+                                    field=field, check=check)
                             return
                         else:
                             raise IrafError("Attempt to set unknown parameter "+
@@ -510,7 +510,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                 # reattach the index and/or field
                 if pindex: paramname = paramname + '[' + repr(pindex+1) + ']'
                 if field: paramname = paramname + '.' + field
-                tobj.setParam(paramname,newvalue,check=check)
+                tobj.setParam(paramname, newvalue, check=check)
                 return
             except KeyError:
                 raise IrafError("Could not find task "+task+
@@ -523,9 +523,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         # most of the time it will be in the active task dictionary
 
         paramdict = self.getParDict()
-        if paramdict._has(paramname,exact=exact):
-            paramdict[paramname].set(newvalue,index=pindex,
-                    field=field,check=check)
+        if paramdict._has(paramname, exact=exact):
+            paramdict[paramname].set(newvalue, index=pindex,
+                    field=field, check=check)
             return
 
         # OK, the easy case didn't work -- now initialize the
@@ -533,9 +533,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
 
         if self._parDictList is None: self._setParDictList()
         for dictname, paramdict in self._parDictList:
-            if paramdict._has(paramname,exact=exact):
-                paramdict[paramname].set(newvalue,index=pindex,
-                        field=field,check=check)
+            if paramdict._has(paramname, exact=exact):
+                paramdict[paramname].set(newvalue, index=pindex,
+                        field=field, check=check)
                 return
         else:
             raise IrafError("Attempt to set unknown lone parameter "+
@@ -599,7 +599,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         # most of the time it will be in the active task dictionary
         paramdict = self.getParDict()
         try:
-            if paramdict._has(paramname,exact=exact):
+            if paramdict._has(paramname, exact=exact):
                 return self._getParFromDict(paramdict, paramname, pindex,
                                             field, native, mode=mode, prompt=prompt)
         except minmatch.AmbiguousKeyError as e:
@@ -611,7 +611,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         # complete parDictList (if necessary) and search them all
         if self._parDictList is None: self._setParDictList()
         for dictname, paramdict in self._parDictList:
-            if paramdict._has(paramname,exact=exact):
+            if paramdict._has(paramname, exact=exact):
                 return self._getParFromDict(paramdict, paramname, pindex,
                                                 field, native, mode="h", prompt=prompt)
         else:
@@ -707,7 +707,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             if self._scrunchParpath and \
               (self._scrunchParpath == self._currentParpath):
                 try:
-                    os.remove(pyraf.iraf.Expand(self._scrunchParpath,noerror=1))
+                    os.remove(pyraf.iraf.Expand(self._scrunchParpath, noerror=1))
                 except OSError:
                     pass
             self._currentParList = copy.deepcopy(self._defaultParList)
@@ -736,16 +736,16 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
 
     # parameters are accessible as attributes
 
-    def __getattr__(self,name):
+    def __getattr__(self, name):
         if name[:1] == '_':
             raise AttributeError(name)
         self.initTask()
         try:
-            return self.getParam(name,native=1)
+            return self.getParam(name, native=1)
         except SyntaxError as e:
             raise AttributeError(str(e))
 
-    def __setattr__(self,name,value):
+    def __setattr__(self, name, value):
         # hidden Python parameters go into the standard dictionary
         # (hope there are none of these in IRAF tasks)
         if name[:1] == '_':
@@ -754,7 +754,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             self.__dict__[name] = value
         else:
             self.initTask()
-            self.setParam(name,value)
+            self.setParam(name, value)
 
     def is_pseudo(self, paramname):
         """Hook enabling ECL pseudos... always returns False"""
@@ -875,19 +875,19 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
 
         # Start with the parameters for the current task
         self.initTask()
-        parDictList = [(self._name,self.getParDict())]
+        parDictList = [(self._name, self.getParDict())]
 
         # Next, parameters from the package to which the current task belongs
         # [Ticket 59: mimic behavior of param.c:lookup_param()]
         task = pyraf.iraf.getTask(self.getPkgname())
         pd = task.getParDict()
         if pd: # do not include null dictionaries
-            parDictList.append( (self.getPkgname(),pd) )
+            parDictList.append( (self.getPkgname(), pd) )
 
         # Lastly, cl parameters
         cl = pyraf.iraf.cl
         if cl is not None:
-            parDictList.append( (cl.getName(),cl.getParDict()) )
+            parDictList.append( (cl.getName(), cl.getParDict()) )
 
         # Done
         self._parDictList = parDictList
@@ -901,9 +901,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         pmode = par.mode[:1]
         if pmode == "a":
             pmode = mode or self.getMode()
-        v = par.get(index=pindex,field=field,
-                    native=native,mode=pmode,prompt=prompt)
-        if isinstance(v,str) and v[:1] == ")":
+        v = par.get(index=pindex, field=field,
+                    native=native, mode=pmode, prompt=prompt)
+        if isinstance(v, str) and v[:1] == ")":
 
             # parameter indirection: call getParam recursively
             # I'm making the assumption that indirection in a
@@ -914,7 +914,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             # ')task.param.p_min' refers to the min or
             # choice string, etc.
 
-            return self.getParam(v[1:],native=native,mode="h",prompt=prompt)
+            return self.getParam(v[1:], native=native, mode="h", prompt=prompt)
         else:
             return v
 
@@ -1003,7 +1003,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             basedir = ""
 
         # default parameters are found with task
-        self._defaultParpath = os.path.join(basedir,self._name + ".par")
+        self._defaultParpath = os.path.join(basedir, self._name + ".par")
         if not os.path.exists(pyraf.iraf.Expand(self._defaultParpath,
                               noerror=1)):
             self._noParFile()
@@ -1047,7 +1047,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                 sys.stderr.flush()
                 #XXX just toss it for now -- later can try to merge new,old
                 try:
-                    os.remove(pyraf.iraf.Expand(self._scrunchParpath,noerror=1))
+                    os.remove(pyraf.iraf.Expand(self._scrunchParpath, noerror=1))
                 except OSError:
                     pass
                 self._currentParpath = self._defaultParpath
@@ -1078,7 +1078,7 @@ class IrafGKITask(IrafTask):
 
     def __init__(self, name, filename):
         """Initialize: only name and executable filename are needed"""
-        IrafTask.__init__(self,'',name,'',filename,'clpackage','bin$')
+        IrafTask.__init__(self, '', name, '', filename, 'clpackage', 'bin$')
         self.setHidden()
         # all graphics kernel  tasks have the same parameters
         pars = irafpar.IrafParList(name)
@@ -1103,7 +1103,7 @@ class IrafPset(IrafTask):
     """IRAF pset class (special case of IRAF task)"""
 
     def __init__(self, prefix, name, suffix, filename, pkgname, pkgbinary):
-        IrafTask.__init__(self,prefix,name,suffix,filename,pkgname,pkgbinary)
+        IrafTask.__init__(self, prefix, name, suffix, filename, pkgname, pkgbinary)
         # check that parameters are consistent with pset:
         # - not a foreign task
         # - has a parameter file
@@ -1134,7 +1134,7 @@ class IrafPythonTask(IrafTask):
     def __init__(self, prefix, name, suffix, filename, pkgname, pkgbinary,
                     function):
         # filename is the .par file for this task
-        IrafTask.__init__(self,prefix,name,suffix,filename,pkgname,pkgbinary)
+        IrafTask.__init__(self, prefix, name, suffix, filename, pkgname, pkgbinary)
         if self.getForeign():
             raise IrafError(
                   "Python task `%s' cannot be foreign (filename=`%s')" %
@@ -1217,12 +1217,12 @@ class ParDictListSearch:
             raise AttributeError(paramname)
         # try exact match
         try:
-            return self._taskObj.getParam(paramname,native=1,mode="h",exact=1)
+            return self._taskObj.getParam(paramname, native=1, mode="h", exact=1)
         except IrafError as e:
             pass
         # try minimum match
         try:
-            p = self._taskObj.getParObject(paramname,alldict=1)
+            p = self._taskObj.getParObject(paramname, alldict=1)
         except IrafError as e:
             # not found at all
             raise AttributeError(str(e))
@@ -1235,12 +1235,12 @@ class ParDictListSearch:
     def getParObject(self, paramname):
         # try exact match
         try:
-            return self._taskObj.getParObject(paramname,exact=1,alldict=1)
+            return self._taskObj.getParObject(paramname, exact=1, alldict=1)
         except IrafError as e:
             pass
         # try minimum match
         try:
-            p = self._taskObj.getParObject(paramname,alldict=1)
+            p = self._taskObj.getParObject(paramname, alldict=1)
         except IrafError as e:
             # not found at all
             raise AttributeError(str(e))
@@ -1256,12 +1256,12 @@ class ParDictListSearch:
         if paramname[:1] == '_': raise AttributeError(paramname)
         # try exact match
         try:
-            return self._taskObj.setParam(paramname,value,exact=1)
+            return self._taskObj.setParam(paramname, value, exact=1)
         except IrafError as e:
             pass
         # try minimum match
         try:
-            p = self._taskObj.getParObject(paramname,alldict=1)
+            p = self._taskObj.getParObject(paramname, alldict=1)
         except IrafError as e:
             # not found at all
             raise AttributeError(str(e))
@@ -1282,18 +1282,18 @@ class IrafCLTask(IrafTask):
 
     def __init__(self, prefix, name, suffix, filename, pkgname, pkgbinary):
         # allow filename to be a filehandle or a filename
-        if isinstance(filename,str):
+        if isinstance(filename, str):
             fh = None
         else:
-            if not hasattr(filename,'read'):
+            if not hasattr(filename, 'read'):
                 raise TypeError(
                         'filename must be either a string or a filehandle')
             fh = filename
-            if hasattr(fh,'name'):
+            if hasattr(fh, 'name'):
                 filename = fh.name
             else:
                 filename = None
-        IrafTask.__init__(self,prefix,name,suffix,filename,pkgname,pkgbinary)
+        IrafTask.__init__(self, prefix, name, suffix, filename, pkgname, pkgbinary)
         if self.getForeign():
             raise IrafError("CL task `%s' cannot be foreign (filename=`%s')" %
                             (self.getName(), filename))
@@ -1392,7 +1392,7 @@ class IrafCLTask(IrafTask):
                 # null pkgname -- just use task in name
                 scriptname = '<CL script %s>' % self._name
             # force compile to inherit future div. so we don't rely on 2.x div.
-            self._codeObject = compile(self._pycode.code,scriptname,'exec',0,0)
+            self._codeObject = compile(self._pycode.code, scriptname, 'exec', 0, 0)
 
 
         if self._clFunction is None:
@@ -1493,7 +1493,7 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
     """IRAF package class (special case of IRAF task)"""
 
     def __init__(self, prefix, name, suffix, filename, pkgname, pkgbinary):
-        IrafCLTask.__init__(self,prefix,name,suffix,filename,pkgname,pkgbinary)
+        IrafCLTask.__init__(self, prefix, name, suffix, filename, pkgname, pkgbinary)
         self._loaded = 0
         self._tasks = minmatch.MinMatchDict()
         self._subtasks = minmatch.MinMatchDict()
@@ -1577,7 +1577,7 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
         # return package parameter if it exists
         plist = self._runningParList or self._currentParList
         if plist and plist.hasPar(name):
-            return plist.getValue(name,native=1,mode=self.getMode())
+            return plist.getValue(name, native=1, mode=self.getMode())
         # else search for task with the given name
         if not self._loaded:
             raise AttributeError("Package " + self.getName() +
@@ -1622,9 +1622,9 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
         for fullname in self._pkgs.values():
             p = getPkg(fullname)
             if p._loaded and (not getTried(id(p))):
-                task = p._getTaskFullname(name,triedpkgs=triedpkgs)
+                task = p._getTaskFullname(name, triedpkgs=triedpkgs)
                 if task:
-                    self._subtasks.add(name,task)
+                    self._subtasks.add(name, task)
                     return task
         return None
 
@@ -1727,7 +1727,7 @@ class IrafForeignTask(IrafTask):
     """IRAF foreign task class"""
 
     def __init__(self, prefix, name, suffix, filename, pkgname, pkgbinary):
-        IrafTask.__init__(self,prefix,name,suffix,filename,pkgname,pkgbinary)
+        IrafTask.__init__(self, prefix, name, suffix, filename, pkgname, pkgbinary)
         # check that parameters are consistent with foreign task:
         # - foreign flag set
         # - no parameter file
@@ -1776,7 +1776,7 @@ class IrafForeignTask(IrafTask):
         args = self._args
         self._nsub = 0
         # create command line
-        cmdline = _re_foreign_par.sub(self._parSub,self._filename)
+        cmdline = _re_foreign_par.sub(self._parSub, self._filename)
         if self._nsub==0 and args:
             # no argument substitution, just append all args
             cmdline = cmdline + ' ' + ' '.join(args)
@@ -1815,7 +1815,7 @@ class IrafForeignTask(IrafTask):
         n = mo.group('allparen')
         if n is not None:
             # $(*) -- append all arguments with virtual filenames converted
-            return ' '.join(map(pyraf.iraf.Expand,self._args))
+            return ' '.join(map(pyraf.iraf.Expand, self._args))
         raise IrafError("Cannot handle foreign string `%s' "
                         "for task %s" % (self._filename, self._name))
 

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -1541,7 +1541,7 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
         if self._loaded:
             # tasks in this package
             if name == "":
-                matches.extend(self._tasks.keys())
+                matches.extend(list(self._tasks.keys()))
             else:
                 matches.extend(self._tasks.getallkeys(name, []))
             # tasks in subpackages
@@ -1750,7 +1750,7 @@ class IrafForeignTask(IrafTask):
             del kw['_setMode']
         if len(kw)>0:
             raise ValueError('Illegal keyword parameters %s for task %s' %
-                    (kw.keys(), self._name,))
+                    (list(kw.keys()), self._name,))
         #self._args = args
         # Insure that all arguments passed to ForeignTasks are
         # converted to strings, including objects which are not

--- a/lib/pyraf/iraftask.py
+++ b/lib/pyraf/iraftask.py
@@ -9,7 +9,7 @@ the creation of IRAF ECL.  irafecl is closely related and derived from
 iraftask,  providing drop-in replacements for the Task classes defined
 here which also support ECL syntax like "iferr" and $errno.
 """
-from __future__ import division
+from __future__ import division, print_function
 
 import fnmatch, os, sys, copy, re
 from stsci.tools import basicpar, minmatch, irafutils, irafglobals, taskpars
@@ -112,12 +112,12 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         objdict.update(_IrafTask_attr_dict)
         sname = name.replace('.', '_')
         if sname != name:
-            print "Warning: '.' illegal in task name, changing", name, \
-                    "to", sname
+            print("Warning: '.' illegal in task name, changing", name,
+                  "to", sname)
         spkgname = pkgname.replace('.', '_')
         if spkgname != pkgname:
-            print "Warning: '.' illegal in pkgname, changing", pkgname, \
-                    "to", spkgname
+            print("Warning: '.' illegal in pkgname, changing", pkgname,
+                  "to", spkgname)
         objdict['_name'] = sname
         objdict['_pkgname'] = spkgname
         objdict['_pkgbinary'] = []
@@ -172,7 +172,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         else:
             self._filename = irafinst.NO_IRAF_PFX+base # to be built on the fly
         if Verbose>1:
-            print 'Task "'+self._name+'" needed "'+orig+'" got: '+self._filename
+            print('Task "'+self._name+'" needed "'+orig+'" got: '+self._filename)
 
 
     #=========================================================
@@ -342,8 +342,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         self.setParList(*args, **kw)
 
         if Verbose>1:
-            print >> sys.stderr, "run %s (%s: %s)" % (self._name,
-                     self.__class__.__name__, self._fullpath)
+            print("run %s (%s: %s)" % (self._name,
+                     self.__class__.__name__, self._fullpath), file=sys.stderr)
             if self._runningParList:
                 self._runningParList.lParam()
 
@@ -359,7 +359,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             self._run(redirKW, specialKW)
             self._updateParList(save)
             if Verbose>1:
-                print >> sys.stderr, 'Successful task termination'
+                print('Successful task termination', file=sys.stderr)
         finally:
             rv = self._resetRedir(resetList, closeFHList)
             self._deleteRunningParList()
@@ -690,7 +690,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                 status = "Unable to save parameters for task %s" % \
                         (self._name,)
                 if Verbose>0:
-                    print >> sys.stderr, status
+                    print(status, file=sys.stderr)
                 return status
         rv = self._currentParList.saveParList(filename, comment)
         return rv
@@ -846,7 +846,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         if changed:
             rv = self.saveParList()
             if Verbose>1:
-                print >> sys.stderr, rv
+                print(rv, file=sys.stderr)
 
     def _deleteRunningParList(self):
         """Delete the _runningParList parameter list for this and psets"""
@@ -932,9 +932,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             basedir, basename = os.path.split(exename1)
         except IrafError as e:
             if Verbose>0:
-                print >> sys.stderr, "Error searching for executable for: "+\
-                         self._name
-                print >> sys.stderr, str(e)
+                print("Error searching for executable for: " + self._name,
+                      file=sys.stderr)
+                print(str(e), file=sys.stderr)
             exename1 = ""
             # make our best guess that the basename is what follows the
             # last '$' in _filename
@@ -957,9 +957,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                     exelist.append(pyraf.iraf.Expand(pbin + basename))
                 except IrafError as e:
                     if Verbose>0:
-                        print >> sys.stderr, "Error finding executable for: "+\
-                                 self._name
-                        print >> sys.stderr, str(e)
+                        print("Error finding executable for: " + self._name,
+                              file=sys.stderr)
+                        print(str(e), file=sys.stderr)
             for exename2 in exelist:
                 if os.path.exists(exename2):
                     self._fullpath = exename2
@@ -996,9 +996,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             if basedir=="": basedir = "."
         except IrafError as e:
             if Verbose>0:
-                print >> sys.stderr, "Error expanding executable name for "+\
-                         "task "+self._name+", tried: "+self._filename
-                print >> sys.stderr, str(e)
+                print("Error expanding executable name for task " + self._name
+                      + ", tried: "+self._filename, file=sys.stderr)
+                print(str(e), file=sys.stderr)
             exename1 = ""
             basedir = ""
 
@@ -1358,7 +1358,7 @@ class IrafCLTask(IrafTask):
         if not irafinst.EXISTS and fcopy.startswith(irafinst.NO_IRAF_PFX):
             # translate code to python
             if Verbose>0:
-                print >> sys.stderr, "Compiling No-IRAF CL task: "+self._name
+                print("Compiling No-IRAF CL task: "+self._name, file=sys.stderr)
             fcopy = os.path.basename(fcopy)
             self._codeObject = None
             self._pycode = cl2py.cl2py(None,
@@ -1371,12 +1371,12 @@ class IrafCLTask(IrafTask):
             # File has changed, force recompilation
             self._pycode = None
             if Verbose>1:
-                print >> sys.stderr, "Cached version out-of-date: "+self._name
+                print("Cached version out-of-date: "+self._name, file=sys.stderr)
 
         if self._pycode is None:
             # translate code to python
             if Verbose>1:
-                print >> sys.stderr, "Compiling CL task ", self._name, id(self)
+                print("Compiling CL task ", self._name, id(self), file=sys.stderr)
             self._codeObject = None
             self._pycode = cl2py.cl2py(filehandle,
                     parlist=self._defaultParList, parfile=self._defaultParpath)
@@ -1659,8 +1659,8 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
             self._loaded = 1
             pyraf.iraf.addLoaded(self)
             if Verbose>1:
-                print >> sys.stderr, "Loading pkg: "+self.getName()+"("+\
-                         self.getFullpath()+")"
+                print("Loading pkg: " + self.getName()
+                      + "(" + self.getFullpath() + ")", file=sys.stderr)
             menus = pyraf.iraf.cl.menus
             try:
                 pyraf.iraf.cl.menus = 0
@@ -1736,8 +1736,8 @@ class IrafForeignTask(IrafTask):
                             (self.getName(), filename))
         if self.hasParfile():
             if Verbose>0:
-                print >> sys.stderr, "Foreign task "+self.getName()+\
-                        " cannot have a parameter file"
+                print("Foreign task " + self.getName()
+                      + " cannot have a parameter file", file=sys.stderr)
             self._hasparfile = 0
 
     def setParList(self, *args, **kw):
@@ -1781,7 +1781,7 @@ class IrafForeignTask(IrafTask):
             # no argument substitution, just append all args
             cmdline = cmdline + ' ' + ' '.join(args)
         if Verbose>1:
-            print >> sys.stderr, "Running foreign task: "+cmdline
+            print("Running foreign task: "+cmdline, file=sys.stderr)
         # create and run the sub-process
         subproc.subshellRedir(cmdline)
 
@@ -1895,11 +1895,11 @@ def printable_task_def(x) :
 def showtasklong(name, level=0) :
     l = gettask(name)
     if len(l) < 1 :
-        print ("    "*level)+'%s : NOT FOUND'%name
+        print(("    "*level)+'%s : NOT FOUND'%name)
     else :
         l.sort()
         for x in l :
-            print ("    "*level)+printable_task_def(x)
+            print(("    "*level)+printable_task_def(x))
             next_name = x._pkgname
             if (next_name == name) or ( level > 15 ) :
                 pass

--- a/lib/pyraf/irafukey.py
+++ b/lib/pyraf/irafukey.py
@@ -62,10 +62,10 @@ def ukey():
 
     if not char:
         # on control-C, raise KeyboardInterrupt
-        raise KeyboardInterrupt
+        raise KeyboardInterrupt()
     elif char == '\004':
         # on control-D, raise EOF
-        raise EOFError
+        raise EOFError()
     elif ord(char) <= ord(' '):
         # convert to octal ascii representation
         returnStr = '\\'+"%03o" % ord(char)

--- a/lib/pyraf/irafukey.py
+++ b/lib/pyraf/irafukey.py
@@ -3,7 +3,7 @@ implement IRAF ukey functionality
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, string, sys
 import wutil

--- a/lib/pyraf/msgiobuffer.py
+++ b/lib/pyraf/msgiobuffer.py
@@ -6,7 +6,7 @@
 M.D. De La Pena, 2000 June 28
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 # System level modules
 from Tkinter import * # requires 2to3

--- a/lib/pyraf/msgiowidget.py
+++ b/lib/pyraf/msgiowidget.py
@@ -4,7 +4,7 @@
    it turns into a single-line text widget.
    $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 # System level modules
 import Tkinter as TKNTR # requires 2to3

--- a/lib/pyraf/newWindowHack.py
+++ b/lib/pyraf/newWindowHack.py
@@ -15,7 +15,7 @@ tkSimpleDialog.askstring("window title", "question?")
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import tkSimpleDialog
 from Tkinter import * # requires 2to3

--- a/lib/pyraf/pseteparoption.py
+++ b/lib/pyraf/pseteparoption.py
@@ -4,7 +4,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 # local modules
 from stsci.tools import eparoption

--- a/lib/pyraf/pycmdline.py
+++ b/lib/pyraf/pycmdline.py
@@ -269,7 +269,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         wutil.closeGraphics()
 
         # leave
-        raise SystemExit
+        raise SystemExit()
 
     def do_logfile(self, line='', i=0):
         """Start or stop logging commands"""

--- a/lib/pyraf/pycmdline.py
+++ b/lib/pyraf/pycmdline.py
@@ -86,7 +86,7 @@ class CmdConsole(code.InteractiveConsole):
         neofs = 0
         # flag indicating whether terminal ID needs to be set
         needtermid = 1
-        while 1:
+        while True:
             try:
                 if not sys.stdin.isatty():
                     prompt = ""

--- a/lib/pyraf/pycmdline.py
+++ b/lib/pyraf/pycmdline.py
@@ -40,7 +40,7 @@ class CmdConsole(code.InteractiveConsole):
 
     def __init__(self, locals=None, filename="<console>",
                     cmddict=None, prompt1=">>> ", prompt2="... ",
-                    cmdchars=("a-zA-Z_.","0-9")):
+                    cmdchars=("a-zA-Z_.", "0-9")):
         code.InteractiveConsole.__init__(self, locals=locals, filename=filename)
         self.ps1 = prompt1
         self.ps2 = prompt2
@@ -68,7 +68,7 @@ class CmdConsole(code.InteractiveConsole):
 
     def printHistory(self, n=20):
         """Print last n lines of history"""
-        for i in range(-min(n, self.nhistory),0):
+        for i in range(-min(n, self.nhistory), 0):
             print(self.history[self.nhistory+i])
 
     def interact(self, banner=None):
@@ -141,7 +141,7 @@ class CmdConsole(code.InteractiveConsole):
             method_name = self.cmddict.get(cmd)
         if method_name is None:
             # no method, but have a look at it anyway
-            return self.default(cmd,line,i)
+            return self.default(cmd, line, i)
         else:
             # if in cmddict, there must be a method by this name
             f = getattr(self, method_name)
@@ -179,9 +179,9 @@ class PyCmdLine(CmdConsole):
         self.logfile = None
         self.lasttrace = None
         if logfile is not None:
-            if hasattr(logfile,'write'):
+            if hasattr(logfile, 'write'):
                 self.logfile = logfile
-            elif isinstance(logfile,str):
+            elif isinstance(logfile, str):
                 self.do_logfile(logfile)
             else:
                 self.write('logfile ignored -- not string or filehandle\n')
@@ -248,7 +248,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         if self.debug>1: self.write('do_exit: %s\n' % line[i:])
 
         # write out history - ignore write errors
-        hfile = os.getenv('HOME','.')+os.sep+'.pyraf_history'
+        hfile = os.getenv('HOME', '.')+os.sep+'.pyraf_history'
         hlen = 1000 # High default.  Note this setting itself may cause
                     # confusion between this history and the IRAF history cmd.
         try:
@@ -296,10 +296,10 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
                         " ".join(args))
             try:
                 oldlogfile = self.logfile
-                self.logfile = open(filename,oflag)
+                self.logfile = open(filename, oflag)
                 if oldlogfile: oldlogfile.close()
             except IOError as e:
-                self.write("error opening logfile %s\n%s\n" % (filename,str(e)))
+                self.write("error opening logfile %s\n%s\n" % (filename, str(e)))
         return ""
 
     def do_clemulate(self, line='', i=0):
@@ -357,7 +357,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         line = full line (including cmd, preceding blanks, etc.)
         i = index in line of first non-blank character following cmd
         """
-        if self.debug>1: self.write('default: %s - %s\n' % (cmd,line[i:]))
+        if self.debug>1: self.write('default: %s - %s\n' % (cmd, line[i:]))
         if len(cmd)==0:
             if line[i:i+1] == '!':
                 # '!' is shell escape
@@ -379,7 +379,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         elif line[i:i+1] != "" and line[i] in '=,[':
             # don't even try if it doesn't look like a procedure call
             return line
-        elif not hasattr(iraf,cmd):
+        elif not hasattr(iraf, cmd):
             # not an IRAF command
             #XXX Eventually want to improve error message for
             #XXX case where user intended to use IRAF syntax but
@@ -397,7 +397,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
                 return line
             # check for some Python operator keywords
             mm = self.reword.match(line[i:])
-            if mm.group() in ["is","in","and","or","not"]:
+            if mm.group() in ["is", "in", "and", "or", "not"]:
                 return line
         elif line[i:i+1] == '(':
             if cmd in ['type', 'dir', 'set']:
@@ -414,7 +414,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
                 #XXX this find() may be improved with latest Python readline features
                 j = line.find(cmd)
                 return line[:j] + 'iraf.' + line[j:]
-        elif not callable(getattr(iraf,cmd)):
+        elif not callable(getattr(iraf, cmd)):
             # variable from iraf module is not callable task (e.g.,
             # yes, no, INDEF, etc.) -- add 'iraf.' so it can be used
             # as a variable and execute as Python

--- a/lib/pyraf/pycmdline.py
+++ b/lib/pyraf/pycmdline.py
@@ -298,7 +298,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
                 oldlogfile = self.logfile
                 self.logfile = open(filename,oflag)
                 if oldlogfile: oldlogfile.close()
-            except IOError, e:
+            except IOError as e:
                 self.write("error opening logfile %s\n%s\n" % (filename,str(e)))
         return ""
 
@@ -309,7 +309,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         if line[i:] != "":
             try:
                 self.clemulate = int(line[i:])
-            except ValueError, e:
+            except ValueError as e:
                 if self.debug: self.write(str(e)+'\n')
                 pass
         return ""
@@ -321,7 +321,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         if line[i:] != "":
             try:
                 self.complete = int(line[i:])
-            except ValueError, e:
+            except ValueError as e:
                 if self.debug: self.write(str(e)+'\n')
                 pass
         if self.complete:
@@ -339,7 +339,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         if line[i:] != "":
             try:
                 self.debug = int(line[i:])
-            except ValueError, e:
+            except ValueError as e:
                 if self.debug: self.write(str(e)+'\n')
                 pass
         return ""

--- a/lib/pyraf/pycmdline.py
+++ b/lib/pyraf/pycmdline.py
@@ -24,7 +24,7 @@ $Id$
 
 R. White, 2000 February 20
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import string, re, os, sys, code, keyword, traceback, linecache
 from stsci.tools import capable, minmatch
@@ -69,7 +69,7 @@ class CmdConsole(code.InteractiveConsole):
     def printHistory(self, n=20):
         """Print last n lines of history"""
         for i in range(-min(n, self.nhistory),0):
-            print self.history[self.nhistory+i]
+            print(self.history[self.nhistory+i])
 
     def interact(self, banner=None):
         """Emulate the interactive Python console, with extra commands.

--- a/lib/pyraf/pyrafTk.py
+++ b/lib/pyraf/pyrafTk.py
@@ -4,7 +4,7 @@ $Id$
 
 R. L. White, 2000 November 17
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import sys
 import Tkinter as TKNTR # requires 2to3

--- a/lib/pyraf/pyrafglobals.py
+++ b/lib/pyraf/pyrafglobals.py
@@ -9,7 +9,7 @@ $Id$
 
 Broken out from irafglobals.py which was signed "R. White, 2000 January 5"
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, sys
 _os = os

--- a/lib/pyraf/splash.py
+++ b/lib/pyraf/splash.py
@@ -5,7 +5,7 @@ $Id$
 R. White, 2001 Dec 15
 """
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os
 import sys

--- a/lib/pyraf/splash.py
+++ b/lib/pyraf/splash.py
@@ -71,7 +71,7 @@ class PyrafSplash(SplashScreen):
     def __init__(self, filename=logo, text=None, textcolor="blue", **kw):
         # look for file in both local directory and this script's directory
         if not os.path.exists(filename):
-            tfilename = os.path.join(os.path.dirname(__file__),filename)
+            tfilename = os.path.join(os.path.dirname(__file__), filename)
             if not os.path.exists(tfilename):
                 raise ValueError("Splash image `%s' not found" % filename)
             filename = tfilename

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -427,7 +427,7 @@ class Subprocess:
             os.kill(self.pid, signal.SIGSTOP)
         except os.error:
             if verbose:
-                print("Stop failed for '%s' - '%s'" % (self.cmd, sys.exc_value))
+                print("Stop failed for '%s' - '%s'" % (self.cmd, sys.exc_info()[1]))
             return 0
         if verbose:
             print("Stopped '%s'" % self.cmd)
@@ -441,7 +441,7 @@ class Subprocess:
         except os.error:
             if verbose:
                 print("Continue failed for '%s' - '%s'" %
-                      (self.cmd, sys.exc_value))
+                      (self.cmd, sys.exc_info()[1]))
             return 0
         if verbose: print("Continued '%s'" % self.cmd)
         return 'continued'

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -158,10 +158,10 @@ class Subprocess:
                 self.toChild_fdlist.append(pWc)
                 self.toChild = pWc
             if self.control_stderr:
-                self.errbuf = ReadBuf(pRe,self.maxChunkSize)
+                self.errbuf = ReadBuf(pRe, self.maxChunkSize)
                 self.fromChild_fdlist.append(pRe)
             if self.control_stdout:
-                self.readbuf = ReadBuf(pRc,self.maxChunkSize)
+                self.readbuf = ReadBuf(pRc, self.maxChunkSize)
                 self.fromChild_fdlist.append(pRc)
             # close child ends of pipes
             for i in childPipes: os.close(i)
@@ -226,7 +226,7 @@ class Subprocess:
             while totalwait <= timeout:
                 ## if totalwait: print "waiting for subprocess..."
                 totalwait = totalwait + printtime
-                if select.select([],self.toChild_fdlist,[],printtime)[1]:
+                if select.select([], self.toChild_fdlist, [], printtime)[1]:
                     if bytes_write(self.toChild, strval) != len(strval):
                         raise SubprocessError("Write error to %s" % self)
                     return                                              # ===>
@@ -234,7 +234,7 @@ class Subprocess:
         except select.error as e:
             raise SubprocessError(
                     "Select error for %s: file descriptors %s\n%s" %
-                    (self,self.toChild_fdlist,str(e)))
+                    (self, self.toChild_fdlist, str(e)))
 
     def writeline(self, line=''):
         """Write STRING, with added newline termination, to subprocess."""
@@ -400,7 +400,7 @@ class Subprocess:
         self.control_stdout = 0
         self.control_stderr = 0
 
-    def _noisy_print(self,err):
+    def _noisy_print(self, err):
         sig = err & 0xff
         rc = (err & 0xff00) >> 8
         if sig == 0:
@@ -781,7 +781,7 @@ class RedirProcess(Subprocess):
                 # this should not happen -- raise an exception
                 raise SubprocessError(
                         "Select error for %s: file descriptors %s\n%s" %
-                        (self,self.toChild_fdlist+self.fromChild_fdlist,str(e)))
+                        (self, self.toChild_fdlist+self.fromChild_fdlist, str(e)))
             if readable:
                 # stderr is first in fromChild_fdlist (if present)
                 if doErr and (self.fromChild_fdlist[0] in readable):

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -17,7 +17,7 @@ Subprocess class features:
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 __version__ = "Revision: 1.7r "
 
@@ -427,9 +427,10 @@ class Subprocess:
             os.kill(self.pid, signal.SIGSTOP)
         except os.error:
             if verbose:
-                print "Stop failed for '%s' - '%s'" % (self.cmd, sys.exc_value)
+                print("Stop failed for '%s' - '%s'" % (self.cmd, sys.exc_value))
             return 0
-        if verbose: print "Stopped '%s'" % self.cmd
+        if verbose:
+            print("Stopped '%s'" % self.cmd)
         return 'stopped'
 
     def cont(self, verbose=False):
@@ -439,10 +440,10 @@ class Subprocess:
             os.kill(self.pid, signal.SIGCONT)
         except os.error:
             if verbose:
-                print ("Continue failed for '%s' - '%s'" %
-                           (self.cmd, sys.exc_value))
+                print("Continue failed for '%s' - '%s'" %
+                      (self.cmd, sys.exc_value))
             return 0
-        if verbose: print "Continued '%s'" % self.cmd
+        if verbose: print("Continued '%s'" % self.cmd)
         return 'continued'
 
     def die(self):
@@ -630,7 +631,7 @@ class ReadBuf:
                     self.eof = 1
                     return got
             else:
-                print 'Select returned without input?'
+                print('Select returned without input?')
 
 
 #############################################################################

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -696,7 +696,7 @@ def record_trial(s):
     c.write(s)
     c.seek(0)
     r = c.read()
-    show = " start:\t %s\n end:\t %s\n" % (`s`, `r`)
+    show = " start:\t %s\n end:\t %s\n" % (repr(s), repr(r))
     if r != s:
         raise IOError("String distorted:\n%s" % show)
 

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -143,7 +143,7 @@ class Subprocess:
                 os.execvp(cmd[0], cmd)
                 os._exit(1)                                     # Shouldn't get here
 
-            except os.error, e:
+            except os.error as e:
                 if self.control_stderr:
                     os.dup2(parentErr, 2)           # Reconnect to parent's stderr
                 sys.stderr.write("**execvp failed, '%s'**\n" % str(e))
@@ -168,7 +168,8 @@ class Subprocess:
             try:
                 # this is useless since the child may not have erred yet
                 pid, err = os.waitpid(self.pid, os.WNOHANG)
-            except os.error, (errnum, msg):
+            except os.error as xxx_todo_changeme1:
+                (errnum, msg) = xxx_todo_changeme1.args
                 if errnum == 10:
                     raise SubprocessError("Subprocess '%s' failed." % self.cmd)
                 else:
@@ -230,7 +231,7 @@ class Subprocess:
                         raise SubprocessError("Write error to %s" % self)
                     return                                              # ===>
             raise SubprocessError("Write to %s blocked" % self)
-        except select.error, e:
+        except select.error as e:
             raise SubprocessError(
                     "Select error for %s: file descriptors %s\n%s" %
                     (self,self.toChild_fdlist,str(e)))
@@ -774,7 +775,7 @@ class RedirProcess(Subprocess):
             try:
                 readable, writable, errors = select.select(self.fromChild_fdlist,
                                         self.toChild_fdlist, [], timeout)
-            except select.error, e:
+            except select.error as e:
                 # select error occurs if a file descriptor has been closed
                 # this should not happen -- raise an exception
                 raise SubprocessError(
@@ -820,7 +821,10 @@ class RedirProcess(Subprocess):
                     if s:
                         try:
                             self.write(s) # inside, converts PY3K str to bytes
-                        except IOError, (errnum, msg):
+                        except IOError as xxx_todo_changeme:
+                            # broken pipe may be OK
+                            # just call it an EOF and see what happens
+                            (errnum, msg) = xxx_todo_changeme.args
                             # broken pipe may be OK
                             # just call it an EOF and see what happens
                             if errnum == errno.EPIPE:

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -567,7 +567,7 @@ class ReadBuf:
         else:
             # don't wait at all
             waittime = 0
-        while 1:                        # (we'll only loop if block set)
+        while True:                        # (we'll only loop if block set)
             try:
                 sel = select.select(fdlist, [], fdlist, waittime)
             except select.error:
@@ -612,7 +612,7 @@ class ReadBuf:
             got = BNULLSTR
 
         fdlist = [self.fd]
-        while 1:
+        while True:
             try:
                 sel = select.select(fdlist, [], fdlist)
             except select.error:

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -130,7 +130,7 @@ class Subprocess:
             fdmax = max(256, parentErr)
             if self.parentPipes:
                 fdmax = max(fdmax, max(self.parentPipes))
-            rclose = range(fdmax+1)
+            rclose = list(range(fdmax+1))
             excludes = [self.in_fd, self.out_fd, self.err_fd, parentErr]
             for i in excludes+self.parentPipes:
                 rclose.remove(i)

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -828,9 +828,9 @@ class RedirProcess(Subprocess):
                             # broken pipe may be OK
                             # just call it an EOF and see what happens
                             if errnum == errno.EPIPE:
-                                raise EOFError
+                                raise EOFError()
                             else:
-                                raise (errnum, msg)
+                                raise
                     else:
                         # EOF if readline returns null
                         os.close(self.toChild)

--- a/lib/pyraf/subproc.py
+++ b/lib/pyraf/subproc.py
@@ -472,7 +472,7 @@ class Subprocess:
         # Only got here if subprocess is not gone:
         raise SubprocessError(
                         "Failed kill of subproc %d, '%s', with signals %s" %
-                        (self.pid, self.cmd, map(lambda(x): x[0], sigs)))
+                        (self.pid, self.cmd, [x[0] for x in sigs]))
 
     def __del__(self):
         """Terminate the subprocess"""

--- a/lib/pyraf/textattrib.py
+++ b/lib/pyraf/textattrib.py
@@ -21,7 +21,7 @@ From experiments, these are some properties of IRAF text:
 This implementation will allow some of these properties to be overriden
 by a system-wide configuration state. See gkiopengl.py
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import fontdata
 

--- a/lib/pyraf/tkplottext.py
+++ b/lib/pyraf/tkplottext.py
@@ -121,7 +121,7 @@ def softText(win,x,y,textstr):
     for char in textstr:
         # draw character with origin at bottom left corner of character box
         charstrokes = ta.font[ord(char)-ord(' ')]
-        for i in xrange(len(charstrokes[0])):
+        for i in range(len(charstrokes[0])):
             vertex = numpy.zeros((len(charstrokes[0][i]),2),numpy.float64)
             xf = size * charstrokes[0][i]/27. -fsize*hsize/2.
             yf = size * charstrokes[1][i]*fontAspect/27. - fsize*vsize/2.

--- a/lib/pyraf/tkplottext.py
+++ b/lib/pyraf/tkplottext.py
@@ -21,7 +21,7 @@ From experiments, these are some properties of IRAF text:
 This implementation will allow some of these properties to be overriden
 by a system-wide configuration state. See gkiopengl.py
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import fontdata
 import numpy

--- a/lib/pyraf/tkplottext.py
+++ b/lib/pyraf/tkplottext.py
@@ -28,7 +28,7 @@ import numpy
 import math
 from textattrib import *
 
-def softText(win,x,y,textstr):
+def softText(win, x, y, textstr):
 
     # Generate text using software generated stroked fonts
     # except for the input x,y, all coordinates are in units of pixels
@@ -40,7 +40,7 @@ def softText(win,x,y,textstr):
     # get current size in unit font units (!)
     fsize = ta.charSize
     # We draw the line at fontSizes less than 1/2! Get real.
-    fsize = max(fsize,0.5)
+    fsize = max(fsize, 0.5)
     # Character spacing depends on whether text is 'vertical' or 'horizontal'
     #  (relative to character orientation). Figure out what the character
     #  delta offset is in the coordinate system where charUp is the y axis.
@@ -56,17 +56,17 @@ def softText(win,x,y,textstr):
         dy = -vspace
         if ta.textPath == CHARPATH_UP: dy = -dy
     # Figure out 'path' size of the text string for use in justification
-    xpath,ypath = (dx*(len(textstr)-1),dy*(len(textstr)-1))
+    xpath, ypath = (dx*(len(textstr)-1), dy*(len(textstr)-1))
     charUp = math.fmod(ta.charUp, 360.)
     if charUp < 0: charUp = charUp + 360.
     if ta.textPath == CHARPATH_RIGHT:
-        textdir = math.fmod(charUp+270,360.)
+        textdir = math.fmod(charUp+270, 360.)
     elif ta.textPath == CHARPATH_LEFT:
-        textdir = math.fmod(charUp+90,360.)
+        textdir = math.fmod(charUp+90, 360.)
     elif ta.textPath ==     CHARPATH_UP:
         textdir = charUp
     elif ta.textPath ==     CHARPATH_DOWN:
-        textdir = math.fmod(charUp+180,360.)
+        textdir = math.fmod(charUp+180, 360.)
     # IRAF definition of justification is a bit weird, justification is
     # for the text string relative to the window. So a rotated string will
     # be justified relative to the window horizontal and vertical, not the
@@ -77,7 +77,7 @@ def softText(win,x,y,textstr):
     deg2rad = math.pi/180.
     cosv = math.cos((charUp-90.)*deg2rad)
     sinv = math.sin((charUp-90.)*deg2rad)
-    xpathwin, ypathwin = (cosv*xpath-sinv*ypath,sinv*xpath+cosv*ypath)
+    xpathwin, ypathwin = (cosv*xpath-sinv*ypath, sinv*xpath+cosv*ypath)
     xcharsize = fsize * max(abs(cosv*hsize+sinv*vsize),
                                             abs(cosv*hsize-sinv*vsize))
     ycharsize = fsize * max(abs(-sinv*hsize+cosv*vsize),
@@ -89,7 +89,7 @@ def softText(win,x,y,textstr):
     elif ta.textHorizontalJust == JUSTIFIED_RIGHT:
         if not left: xoffset = -xpathwin
         xcharoff = -xcharsize/2.
-    elif ta.textHorizontalJust in (JUSTIFIED_LEFT,JUSTIFIED_NORMAL):
+    elif ta.textHorizontalJust in (JUSTIFIED_LEFT, JUSTIFIED_NORMAL):
         if left: xoffset = xpathwin
         xcharoff = xcharsize/2.
     if ta.textVerticalJust == JUSTIFIED_CENTER:
@@ -122,12 +122,12 @@ def softText(win,x,y,textstr):
         # draw character with origin at bottom left corner of character box
         charstrokes = ta.font[ord(char)-ord(' ')]
         for i in range(len(charstrokes[0])):
-            vertex = numpy.zeros((len(charstrokes[0][i]),2),numpy.float64)
+            vertex = numpy.zeros((len(charstrokes[0][i]), 2), numpy.float64)
             xf = size * charstrokes[0][i]/27. -fsize*hsize/2.
             yf = size * charstrokes[1][i]*fontAspect/27. - fsize*vsize/2.
-            vertex[:,0]=      cosrot*(xf + nchar*dx) \
+            vertex[:, 0]=      cosrot*(xf + nchar*dx) \
                             - sinrot*(yf + nchar*dy) + xNetOffset + xwin*x
-            vertex[:,1]=ywin-(sinrot*(xf + nchar*dx) \
+            vertex[:, 1]=ywin-(sinrot*(xf + nchar*dx) \
                             + cosrot*(yf + nchar*dy) + yNetOffset + ywin*y)
             gw.create_line(*(tuple(vertex.ravel().astype(numpy.int32))),
                            **options)

--- a/lib/pyraf/tpar.py
+++ b/lib/pyraf/tpar.py
@@ -573,7 +573,7 @@ class NumberTparOption(StringTparOption):
                 self.paramInfo.set(v)
             self.paramInfo.set(self._previousValue)
             return True
-        except ValueError, e:
+        except ValueError as e:
             self.set_candidate("")
             self.inform(str(e))
             return False
@@ -984,7 +984,7 @@ class TparDisplay(Binder):
                 return
             try:
                 f(file, emph)
-            except Exception, e:
+            except Exception as e:
                 self.inform("command '%s' failed with exception '%s'" % (cmd, e))
 
     def save_as(self):

--- a/lib/pyraf/tpar.py
+++ b/lib/pyraf/tpar.py
@@ -283,7 +283,7 @@ class PyrafEdit(urwid.Edit):
         self.reset_del_buffers()
         urwid.Edit.__init__(self, *args, **keys)
         EDIT_BINDINGS  = {  # single field bindings
-                           "delete" : self.DEL_CHAR,
+                           "delete": self.DEL_CHAR,
                            "del_line": self.DEL_LINE,
                            "del_word": self.DEL_WORD,
 
@@ -457,10 +457,10 @@ class StringTparOption(urwid.Columns):
         self._edit.verify = self.verify
         self._value = urwid.Text( "%10s" % value, align="right" )
         self._help = urwid.Text( "%-30s" % help )
-        urwid.Columns.__init__( self, [('weight',0.20, self._name),
-                                       ('weight',0.20, self._edit),
-                                       ('weight',0.20, self._value),
-                                       ('weight',0.40, self._help)],
+        urwid.Columns.__init__( self, [('weight', 0.20, self._name),
+                                       ('weight', 0.20, self._edit),
+                                       ('weight', 0.20, self._value),
+                                       ('weight', 0.40, self._help)],
                                 0, 1, 1)
 
     def keypress(self, pos, key):
@@ -562,7 +562,7 @@ class StringTparOption(urwid.Columns):
 
 class NumberTparOption(StringTparOption):
     def normalize(self, v):
-        if v in ["INDEF","Indef","indef"]:
+        if v in ["INDEF", "Indef", "indef"]:
             return "INDEF"
         else:
             return v
@@ -584,7 +584,7 @@ class NumberTparOption(StringTparOption):
 class BooleanTparOption(StringTparOption):
     def __init__(self, *args, **keys):
         StringTparOption.__init__(self, *args, **keys)
-        self._binder.bind(" ","space")
+        self._binder.bind(" ", "space")
         self._binder.bind("space", self.TOGGLE)
         self._binder.bind("right", self.TOGGLE)
         self._binder.bind("left", self.TOGGLE)
@@ -596,16 +596,16 @@ class BooleanTparOption(StringTparOption):
             self.set_result("yes")
 
     def normalize(self, v):
-        if v in ["n","N"]:
+        if v in ["n", "N"]:
             return "no"
-        elif v in ["y","Y"]:
+        elif v in ["y", "Y"]:
             return "yes"
         else:
             return v
 
     def verify(self, v):
         v = self.normalize(v)
-        if v in ["yes","no"]:
+        if v in ["yes", "no"]:
             self.inform("")
             return True
         else:
@@ -618,7 +618,7 @@ class BooleanTparOption(StringTparOption):
 class EnumTparOption(StringTparOption):
     def __init__(self, *args, **keys):
         StringTparOption.__init__(self, *args, **keys)
-        self._binder.bind(" ","space")
+        self._binder.bind(" ", "space")
         self._binder.bind("space", self.SPACE)
         self._binder.bind("right", self.SPACE)
         self._binder.bind("left", self.LEFT)
@@ -667,17 +667,17 @@ class TparHeader(urwid.Pile):
 
 class TparDisplay(Binder):
     palette = [
-                ('body','default','default', 'standout'),
+                ('body', 'default', 'default', 'standout'),
                 ('header', 'default', 'default', ('standout', 'underline')),
-                ('help','black','light gray'),
-                ('reverse','light gray','black'),
-                ('important','dark blue','light gray',('standout','underline')),
-                ('editfc','white', 'dark blue', 'bold'),
-                ('editbx','light gray', 'dark blue'),
-                ('editcp','black','light gray', 'standout'),
-                ('bright','dark gray','light gray', ('bold','standout')),
-                ('buttn','black','dark cyan'),
-                ('buttnf','white','dark blue','bold'),
+                ('help', 'black', 'light gray'),
+                ('reverse', 'light gray', 'black'),
+                ('important', 'dark blue', 'light gray', ('standout', 'underline')),
+                ('editfc', 'white', 'dark blue', 'bold'),
+                ('editbx', 'light gray', 'dark blue'),
+                ('editcp', 'black', 'light gray', 'standout'),
+                ('bright', 'dark gray', 'light gray', ('bold', 'standout')),
+                ('buttn', 'black', 'dark cyan'),
+                ('buttnf', 'white', 'dark blue', 'bold'),
                ]
 
     def __init__(self,  taskName):
@@ -689,11 +689,11 @@ class TparDisplay(Binder):
                         "ctrl t", "ctrl T"]
 
         TPAR_BINDINGS = {  # Page level bindings
-                          "quit"   : self.QUIT,
-                          "exit "  : self.EXIT,
-                          "help"   : self.HELP,
-                          "end" : self.MOVE_END,
-                          "home" : self.MOVE_START,
+                          "quit": self.QUIT,
+                          "exit ": self.EXIT,
+                          "help": self.HELP,
+                          "end": self.MOVE_END,
+                          "home": self.MOVE_START,
                          }
 
         # Get the Iraftask object
@@ -761,24 +761,24 @@ class TparDisplay(Binder):
         isPset = isinstance(self.taskObject, iraftask.IrafPset)
 
         self.help_button = urwid.Padding(
-            urwid.Button("Help",self.HELP),
+            urwid.Button("Help", self.HELP),
             align="center",    width=('fixed', 8))
         self.cancel_button = urwid.Padding(
-            urwid.Button("Cancel",self.QUIT),
+            urwid.Button("Cancel", self.QUIT),
             align="center",    width=('fixed', 10))
         if not isPset:
             self.save_as_button = urwid.Padding(
-                urwid.Button("Save As",self.SAVEAS),
+                urwid.Button("Save As", self.SAVEAS),
                 align="center",    width=('fixed', 11))
         self.save_button = urwid.Padding(
-            urwid.Button("Save",self.EXIT),
+            urwid.Button("Save", self.EXIT),
             align="center",    width=('fixed', 8))
         self.exec_button = urwid.Padding(
-            urwid.Button("Exec",self.go),
+            urwid.Button("Exec", self.go),
             align="center",    width=('fixed', 8))
         if self.__areAnyToLoad:
             self.open_button = urwid.Padding(
-                urwid.Button("Open",self.PFOPEN),
+                urwid.Button("Open", self.PFOPEN),
                 align="center",    width=('fixed', 8))
 
         # GUI button layout - weightings
@@ -812,20 +812,20 @@ class TparDisplay(Binder):
         isPset = isinstance(self.taskObject, iraftask.IrafPset)
 
         self.help_button = urwid.Padding(
-            urwid.Button("Help",self.HELP), align="center", width=8, right=4,
+            urwid.Button("Help", self.HELP), align="center", width=8, right=4,
                                                                      left=5)
         self.cancel_button = urwid.Padding(
-            urwid.Button("Cancel",self.QUIT), align="center", width=10)
+            urwid.Button("Cancel", self.QUIT), align="center", width=10)
         if not isPset:
             self.save_as_button = urwid.Padding(
-                urwid.Button("Save As",self.SAVEAS), align="center", width=11)
+                urwid.Button("Save As", self.SAVEAS), align="center", width=11)
         self.save_button = urwid.Padding(
-            urwid.Button("Save",self.EXIT), align="center", width=8)
+            urwid.Button("Save", self.EXIT), align="center", width=8)
         self.exec_button = urwid.Padding(
-            urwid.Button("Exec",self.go), align="center", width=8)
+            urwid.Button("Exec", self.go), align="center", width=8)
         if self.__areAnyToLoad:
             self.open_button = urwid.Padding(
-                urwid.Button("Open",self.PFOPEN), align="center", width=8)
+                urwid.Button("Open", self.PFOPEN), align="center", width=8)
 
         # GUI button layout - weightings
         if isPset: # show no Open nor Save As buttons
@@ -1000,7 +1000,7 @@ class TparDisplay(Binder):
         if fname == None:
             msg = "Parameters NOT saved to a file."
             okdlg = urwutil.DialogDisplay(msg, 8, 0)
-            okdlg.add_buttons([ ("OK",0) ])
+            okdlg.add_buttons([ ("OK", 0) ])
             okdlg.main()
             return
 
@@ -1020,7 +1020,7 @@ class TparDisplay(Binder):
                   '\n\n"'+fname+'"'
             # title='PSET Save-As Not Yet Supported
             okdlg = urwutil.DialogDisplay(msg, 0, 0)
-            okdlg.add_buttons([ ("OK",0) ])
+            okdlg.add_buttons([ ("OK", 0) ])
             okdlg.main()
 
         # Verify all the entries (without save), keeping track of the invalid
@@ -1046,7 +1046,7 @@ class TparDisplay(Binder):
         # Let them know what they just did
         msg = 'Saved to: "'+fname+'"'
         okdlg = urwutil.DialogDisplay(msg, 8, 0)
-        okdlg.add_buttons([ ("OK",0) ])
+        okdlg.add_buttons([ ("OK", 0) ])
         okdlg.main()
 
         # Notify irafpar that there is a new special-purpose file on the scene
@@ -1062,7 +1062,7 @@ class TparDisplay(Binder):
         if len(flist) <= 0:
             msg = "No special-purpose parameter files found for "+self.taskName
             okdlg = urwutil.DialogDisplay(msg, 8, 0)
-            okdlg.add_buttons([ ("OK",0) ])
+            okdlg.add_buttons([ ("OK", 0) ])
             okdlg.main()
             return
 
@@ -1085,7 +1085,7 @@ class TparDisplay(Binder):
             selectdlg = urwutil.ListDialogDisplay("Select from these:",
                                 len(flist)+7, 75,
                                 menuItemConstr, tuple(chcs), False)
-            selectdlg.add_buttons([ ("Cancel",1), ])
+            selectdlg.add_buttons([ ("Cancel", 1), ])
             rv, ans = selectdlg.main()
             if rv == 0: fname = flist[int(ans)]
 

--- a/lib/pyraf/tpar.py
+++ b/lib/pyraf/tpar.py
@@ -11,7 +11,7 @@ $Id$
 
 Todd Miller, 2006 May 30  derived from epar.py and IRAF CL epar.
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 # XXXX Debugging tip:  uncomment self.inform() in the debug() method below
 
@@ -1162,7 +1162,7 @@ class TparDisplay(Binder):
         """Executes the task."""
         self.save(emph)
         def go_continue():
-            print "\nTask %s is running...\n" % self.taskName
+            print("\nTask %s is running...\n" % self.taskName)
             self.run_task()
         self.done = go_continue
 
@@ -1383,9 +1383,9 @@ class TparDisplay(Binder):
 
 def tpar(taskName):
     if isinstance(urwid, FakeModule):
-        print >>sys.stderr, "The urwid package isn't found on your Python system so tpar can't be used."
-        print >>sys.stderr, '    (the error given: "'+urwid.the_error+'")'
-        print >>sys.stderr, "Please install urwid version >= 0.9.7 or use epar instead."
+        print("The urwid package isn't found on your Python system so tpar can't be used.", file=sys.stderr)
+        print('    (the error given: "'+urwid.the_error+'")', file=sys.stderr)
+        print("Please install urwid version >= 0.9.7 or use epar instead.", file=sys.stderr)
         return
     TparDisplay(taskName).main()
 

--- a/lib/pyraf/urwfiledlg.py
+++ b/lib/pyraf/urwfiledlg.py
@@ -12,7 +12,7 @@ versions of urwid.  Many thanks to author Rebecca Breu.
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from urwid import *
 from urwid import WidgetWrap
@@ -340,4 +340,4 @@ def run():
 if __name__ == "__main__":
     import urwid
     import urwid.curses_display
-    print main()
+    print(main())

--- a/lib/pyraf/urwutil.py
+++ b/lib/pyraf/urwutil.py
@@ -240,12 +240,12 @@ class MenuItem(urwid.Text):
         if key == "enter" or \
            key == "ctrl m" or key == " ": # is ctrl-m on OSX; also allow space
             self.state = True
-            raise DialogExit, 0
+            raise DialogExit(0)
         return key
     def mouse_event(self,size,event,button,col,row,focus):
         if event=='mouse release':
             self.state = True
-            raise DialogExit, 0
+            raise DialogExit(0)
         return False
     def get_state(self):
         return self.state

--- a/lib/pyraf/urwutil.py
+++ b/lib/pyraf/urwutil.py
@@ -26,7 +26,7 @@ include this file until it comes with urwid.  This is slightly modified.
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import sys
 import urwid

--- a/lib/pyraf/urwutil.py
+++ b/lib/pyraf/urwutil.py
@@ -39,12 +39,12 @@ class DialogExit(Exception):
 
 class DialogDisplay:
     palette = [
-        ('body','black','light gray', 'standout'),
-        ('border','black','dark blue'),
-        ('shadow','white','black'),
-        ('selectable','black', 'dark cyan'),
-        ('focus','white','dark blue','bold'),
-        ('focustext','light gray','dark blue'),
+        ('body', 'black', 'light gray', 'standout'),
+        ('border', 'black', 'dark blue'),
+        ('shadow', 'white', 'black'),
+        ('selectable', 'black', 'dark cyan'),
+        ('focus', 'white', 'dark blue', 'bold'),
+        ('focustext', 'light gray', 'dark blue'),
         ]
 
     def __init__(self, text, height, width, body=None):
@@ -58,7 +58,7 @@ class DialogDisplay:
         self.body = body
         if body is None:
             # fill space with nothing
-            body = urwid.Filler(urwid.Divider(),'top')
+            body = urwid.Filler(urwid.Divider(), 'top')
 
         self.frame = urwid.Frame( body, focus_part='footer')
         if text is not None:
@@ -67,16 +67,16 @@ class DialogDisplay:
         w = self.frame
 
         # pad area around listbox
-        w = urwid.Padding(w, ('fixed left',2), ('fixed right',2))
-        w = urwid.Filler(w, ('fixed top',1), ('fixed bottom',1))
+        w = urwid.Padding(w, ('fixed left', 2), ('fixed right', 2))
+        w = urwid.Filler(w, ('fixed top', 1), ('fixed bottom', 1))
         w = urwid.AttrWrap(w, 'body')
 
         # "shadow" effect
-        w = urwid.Columns( [w,('fixed', 2, urwid.AttrWrap(
-            urwid.Filler(urwid.Text(('border','  ')), "top")
-            ,'shadow'))])
+        w = urwid.Columns( [w, ('fixed', 2, urwid.AttrWrap(
+            urwid.Filler(urwid.Text(('border', '  ')), "top")
+            , 'shadow'))])
         w = urwid.Frame( w, footer =
-            urwid.AttrWrap(urwid.Text(('border','  ')),'shadow'))
+            urwid.AttrWrap(urwid.Text(('border', '  ')), 'shadow'))
 
         # outermost border area
         w = urwid.Padding(w, 'center', width )
@@ -91,7 +91,7 @@ class DialogDisplay:
         for name, exitcode in buttons:
             b = urwid.Button( name, self.button_press )
             b.exitcode = exitcode
-            b = urwid.AttrWrap( b, 'selectable','focus' )
+            b = urwid.AttrWrap( b, 'selectable', 'focus' )
             l.append( b )
         self.buttons = urwid.GridFlow(l, 10, 3, 1, 'center')
         self.frame.footer = urwid.Pile( [ urwid.Divider(),
@@ -141,16 +141,16 @@ class InputDialogDisplay(DialogDisplay):
     def __init__(self, text, height, width):
         self.edit = urwid.Edit()
         body = urwid.ListBox([self.edit])
-        body = urwid.AttrWrap(body, 'selectable','focustext')
+        body = urwid.AttrWrap(body, 'selectable', 'focustext')
 
         DialogDisplay.__init__(self, text, height, width, body)
 
         self.frame.set_focus('body')
 
     def unhandled_key(self, size, k):
-        if k in ('up','page up'):
+        if k in ('up', 'page up'):
             self.frame.set_focus('body')
-        if k in ('down','page down'):
+        if k in ('down', 'page down'):
             self.frame.set_focus('footer')
         if k == 'enter' or k == 'ctrl m': # STScI change ! add ctrl-m for OSX
             # pass enter to the "ok" button
@@ -196,7 +196,7 @@ class ListDialogDisplay(DialogDisplay):
             self.items.append(w)
             w = urwid.Columns( [('fixed', 12, w),
                 urwid.Text(item)], 2 )
-            w = urwid.AttrWrap(w, 'selectable','focus')
+            w = urwid.AttrWrap(w, 'selectable', 'focus')
             l.append(w)
 
         lb = urwid.ListBox(l)
@@ -206,9 +206,9 @@ class ListDialogDisplay(DialogDisplay):
         self.frame.set_focus('body')
 
     def unhandled_key(self, size, k):
-        if k in ('up','page up'):
+        if k in ('up', 'page up'):
             self.frame.set_focus('body')
-        if k in ('down','page down'):
+        if k in ('down', 'page down'):
             self.frame.set_focus('footer')
         if k == 'enter':
             # pass enter to the "ok" button
@@ -236,13 +236,13 @@ class MenuItem(urwid.Text):
     def selectable(self):
         return True
     # The change below (in the if) was made by STScI !
-    def keypress(self,size,key):
+    def keypress(self, size, key):
         if key == "enter" or \
            key == "ctrl m" or key == " ": # is ctrl-m on OSX; also allow space
             self.state = True
             raise DialogExit(0)
         return key
-    def mouse_event(self,size,event,button,col,row,focus):
+    def mouse_event(self, size, event, button, col, row, focus):
         if event=='mouse release':
             self.state = True
             raise DialogExit(0)
@@ -276,7 +276,7 @@ if __name__=="__main__":
     # Create a DialogDisplay instance
     d = InputDialogDisplay(sys.argv[1], sys.argv[2], sys.argv[3])
     # for simple yes/no dialog:  d = DialogDisplay(text, height, width)
-    d.add_buttons([ ("OK",0), ("Cancel",1) ])
+    d.add_buttons([ ("OK", 0), ("Cancel", 1) ])
 
     # Run it
     exitcode, exitstring = d.main()

--- a/lib/pyraf/urwutil.py
+++ b/lib/pyraf/urwutil.py
@@ -127,7 +127,7 @@ class DialogDisplay:
 
                     if k:
                         self.unhandled_key( size, k)
-        except DialogExit, e:
+        except DialogExit as e:
             return self.on_exit( e.args[0] )
 
     def on_exit(self, exitcode):

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -6,7 +6,7 @@ If the c versions do not exist, then these routines will do nothing
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import struct, sys, os
 try:
@@ -93,7 +93,7 @@ try:
                 _has_aqutil = 1
             except:
                 _has_aqutil = 0
-                print "Could not import aqutil"
+                print("Could not import aqutil")
 
 except ImportError:
     _has_xutil = 0 # Unsuccessful init of XWindow
@@ -582,7 +582,7 @@ def dumpspecs(outstream = None, skip_volatiles = False):
     if outstream:
         outstream.write(out+'\n')
     else:
-        print out
+        print(out)
 
 
 
@@ -596,11 +596,11 @@ if _skipDisplay:
        '-s' not in sys.argv and '--silent' not in sys.argv:
         # Warn, but be specific about why
         if 'PYRAF_NO_DISPLAY' in os.environ:
-            print "No graphics/display intended for this session."
+            print("No graphics/display intended for this session.")
         else:
-            print "No graphics/display possible for this session."
+            print("No graphics/display possible for this session.")
             if hasattr(capable, 'TKINTER_IMPORT_FAILED'):
-                print "tkinter import failed."
+                print("tkinter import failed.")
 else:
     if _has_xutil or _has_aqutil:
         hasGraphics = focusController.hasGraphics
@@ -611,20 +611,20 @@ else:
         if hasGraphics:
             try: # the try/except handling here will be unneccessary after stsci.tools 3.4.2
                 if capable.which_darwin_linkage() == 'aqua':
-                    print "\nLimited graphics available on OSX (aqutil not loaded)\n"
+                    print("\nLimited graphics available on OSX (aqutil not loaded)\n")
                 else:
-                    print "\nLimited graphics available on OSX (xutil not loaded)\n"
+                    print("\nLimited graphics available on OSX (xutil not loaded)\n")
             except Exception:
-                print "\nLimited graphics available on OSX (library not loaded)\n"
+                print("\nLimited graphics available on OSX (library not loaded)\n")
     elif WUTIL_ON_WIN:
         hasGraphics = 1 # try this, tho VERY limited (epar only I guess)
-        print "\nLimited graphics available on win32 platform\n"
+        print("\nLimited graphics available on win32 platform\n")
 
     if not hasGraphics:
-        print ""
-        print "No graphics display available for this session."
-        print "Graphics tasks that attempt to plot to an interactive " + \
-                          "screen will fail."
-        print 'For help, search "PyRAF FAQ 5.13" or visit the STScI help site, ' \
-              'https://hsthelp.stsci.edu.'
-        print ""
+        print("")
+        print("No graphics display available for this session.")
+        print("Graphics tasks that attempt to plot to an interactive "
+              "screen will fail.")
+        print('For help, search "PyRAF FAQ 5.13" or visit the STScI help site, '
+              'https://hsthelp.stsci.edu.')
+        print("")

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -70,7 +70,7 @@ try:
         # ONLY if an XWindow was successfully initialized.
         #  WJH (10June2004)
         if xutil.getFocalWindowID() == -1:
-            raise EnvironmentError
+            raise EnvironmentError()
 
         # Successful intialization. Reset dummy methods with
         # those from 'xutil' now.

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -199,13 +199,13 @@ def getTermWindowSize():
     tstruct = ' '*20 # that should be more than enough memory
     try:
         rstruct = fcntl.ioctl(sys.stdout.fileno(), magicConstant, tstruct)
-        ysize, xsize = struct.unpack('hh',rstruct[0:4])
+        ysize, xsize = struct.unpack('hh', rstruct[0:4])
         # handle bug in konsole (and maybe other bad cases)
         if ysize <= 0: ysize = 24
         if xsize <= 0: xsize = 80
         return ysize, xsize
     except (IOError, AttributeError):
-        return (24,80) # assume generic size
+        return (24, 80) # assume generic size
 
 
 class FocusEntity:
@@ -340,7 +340,7 @@ class TerminalFocusEntity(FocusEntity):
         tstruct = ' '*20 # that should be more than enough memory
         # xxx exception handling needed (but what exception to catch?)
         rstruct = fcntl.ioctl(sys.stdout.fileno(), magicConstant, tstruct)
-        xsize, ysize = struct.unpack('hh',rstruct[0:4])
+        xsize, ysize = struct.unpack('hh', rstruct[0:4])
         return xsize, ysize
 
 
@@ -414,7 +414,7 @@ class FocusController:
             return None, None
         currentFocusWinID = getFocalWindowID()
         currentTopID = getTopID(currentFocusWinID)
-        for name,focusEntity in self.focusEntities.items():
+        for name, focusEntity in self.focusEntities.items():
             if getTopID(focusEntity.getWindowID()) == currentTopID:
                 return name, focusEntity
         else:

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -158,7 +158,7 @@ def getTopID(WindowID):
         return topIDmap[wid]
     try:
         oid = wid
-        while 1:
+        while True:
             pid = getParentID(wid)
             if (not pid) or (pid==wid):
                 topIDmap[oid] = wid
@@ -373,7 +373,7 @@ class FocusController:
             entity = self.focusEntities[focusEntityName]
             del self.focusEntities[focusEntityName]
             try:
-                while 1:
+                while True:
                     self.focusStack.remove(entity)
             except ValueError:
                 pass

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -258,7 +258,7 @@ class TerminalFocusEntity(FocusEntity):
                 scrnPosDict = aqutil.getPointerGlobalPosition()
                 self.lastScreenX = scrnPosDict['x']
                 self.lastScreenY = scrnPosDict['y']
-        except EnvironmentError, e:
+        except EnvironmentError as e:
             self.windowID = None
         self.lastX = 30
         self.lastY = 30

--- a/lib/pyraf/wutil.py
+++ b/lib/pyraf/wutil.py
@@ -444,7 +444,7 @@ class FocusController:
                 focusTarget.gwidget.focus_set()
 
         current = self.focusStack[-1]
-        if type(focusTarget) == type(""):
+        if isinstance(focusTarget, type("")):
             next = self.focusEntities[focusTarget]
         else:
             next = focusTarget

--- a/tests/test_clcache.py
+++ b/tests/test_clcache.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 

--- a/tests/test_core_nongraphics.py
+++ b/tests/test_core_nongraphics.py
@@ -1,5 +1,5 @@
 """These were tests under core/irafparlist and core/subproc in pandokia."""
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import time
 import uuid

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -19,7 +19,7 @@ def test_desc():
     bar = lambda a: 0  # noqa
 
     # from Duncan Booth
-#    def baz(a, (b, c) = ('foo','bar'), (d, e, f) = (None, None, None), g = None):  # noqa
+#    def baz(a, (b, c) = ('foo', 'bar'), (d, e, f) = (None, None, None), g = None):  # noqa
 #        pass
 
     assert describeParams(foo) == ['a', ('b', 1), '*c', '**d']

--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -1,5 +1,5 @@
 """These were tests under core/graphics_checks in pandokia."""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import six
 
 import glob

--- a/tools/cachecompare.py
+++ b/tools/cachecompare.py
@@ -24,11 +24,11 @@ ok2 = 0
 diff1 = 0
 diff2 = 0
 for key in dbnew.keys():
-    if dbold1.has_key(key):
+    if key in dbold1:
         oldcode = dbold1[key]
         found1 += 1
         select = 1
-    elif dbold2.has_key(key):
+    elif key in dbold2:
         oldcode = dbold2[key]
         found2 += 1
         select = 2

--- a/tools/cachecompare.py
+++ b/tools/cachecompare.py
@@ -9,12 +9,12 @@ import os
 import pyraf
 
 newname = os.path.expanduser('~/iraf/pyraf/clcache')
-oldname1 = os.path.join(pyraf.irafglobals.pyrafDir,'clcache.old')
+oldname1 = os.path.join(pyraf.irafglobals.pyrafDir, 'clcache.old')
 oldname2 = os.path.expanduser('~/iraf/pyraf/clcache.old')
 
-dbnew = pyraf.dirshelve.open(newname,'r')
-dbold1 = pyraf.dirshelve.open(oldname1,'r')
-dbold2 = pyraf.dirshelve.open(oldname2,'r')
+dbnew = pyraf.dirshelve.open(newname, 'r')
+dbold1 = pyraf.dirshelve.open(oldname1, 'r')
+dbold2 = pyraf.dirshelve.open(oldname2, 'r')
 
 notfound = 0
 found1 = 0
@@ -46,16 +46,16 @@ for key in dbnew.keys():
             diff1 += 1
         else:
             diff2 += 1
-        print(select,"Different", newcode.vars.proc_name)
+        print(select, "Different", newcode.vars.proc_name)
 
 dbnew.close()
 dbold1.close()
 dbold2.close()
-print("Checked",notfound+ok1+ok2+diff1+diff2,"entries from new cache")
-print(notfound,"not found in old cache")
-print(found1,"found in old cache 1",oldname1)
-print(ok1,"same")
-print(diff1,"different")
-print(found2,"found in old cache 2",oldname2)
-print(ok2,"same")
-print(diff2,"different")
+print("Checked", notfound+ok1+ok2+diff1+diff2, "entries from new cache")
+print(notfound, "not found in old cache")
+print(found1, "found in old cache 1", oldname1)
+print(ok1, "same")
+print(diff1, "different")
+print(found2, "found in old cache 2", oldname2)
+print(ok2, "same")
+print(diff2, "different")

--- a/tools/cachecompare.py
+++ b/tools/cachecompare.py
@@ -3,7 +3,7 @@
 """cachecompare.py: Compare contents of new CL to old cache
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os
 import pyraf
@@ -46,16 +46,16 @@ for key in dbnew.keys():
             diff1 += 1
         else:
             diff2 += 1
-        print select,"Different", newcode.vars.proc_name
+        print(select,"Different", newcode.vars.proc_name)
 
 dbnew.close()
 dbold1.close()
 dbold2.close()
-print "Checked",notfound+ok1+ok2+diff1+diff2,"entries from new cache"
-print notfound,"not found in old cache"
-print found1,"found in old cache 1",oldname1
-print ok1,"same"
-print diff1,"different"
-print found2,"found in old cache 2",oldname2
-print ok2,"same"
-print diff2,"different"
+print("Checked",notfound+ok1+ok2+diff1+diff2,"entries from new cache")
+print(notfound,"not found in old cache")
+print(found1,"found in old cache 1",oldname1)
+print(ok1,"same")
+print(diff1,"different")
+print(found2,"found in old cache 2",oldname2)
+print(ok2,"same")
+print(diff2,"different")

--- a/tools/cachesearch.py
+++ b/tools/cachesearch.py
@@ -27,9 +27,9 @@ def search(pattern):
     nomatch = 0
     pmatch = []
     for key in keydict.keys():
-        if db1.has_key(key):
+        if key in db1:
             pycode = db1[key]
-        elif db2.has_key(key):
+        elif key in db2:
             pycode = db2[key]
         else:
             raise Exception("Error: not in cache on second pass??")

--- a/tools/cachesearch.py
+++ b/tools/cachesearch.py
@@ -17,8 +17,8 @@ def search(pattern):
     db1 = pyraf.dirshelve.open(cachename1,'r')
     db2 = pyraf.dirshelve.open(cachename2,'r')
 
-    keys1 = db1.keys()
-    keys2 = db2.keys()
+    keys1 = list(db1.keys())
+    keys2 = list(db2.keys())
     keydict = {}
     for key in db1.keys(): keydict[key] = 1
     for key in db2.keys(): keydict[key] = 1

--- a/tools/cachesearch.py
+++ b/tools/cachesearch.py
@@ -3,7 +3,7 @@
 """cachesearch.py: Check all entries in CL cache for a particular string
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, re
 import pyraf
@@ -38,7 +38,7 @@ def search(pattern):
         mm = pattern.search(pycode.code)
         if mm:
             match += 1
-            print '%d: %s' % (match, pycode.vars.proc_name)
+            print('%d: %s' % (match, pycode.vars.proc_name))
             pmatch.append(pycode.vars.proc_name)
             # print matching lines
             lines = pycode.code.split('\n')
@@ -50,17 +50,17 @@ def search(pattern):
                     i = i+1
                     sum = sum+len(lines[i])+1
                 if ilast != i:
-                    print lines[i]
+                    print(lines[i])
                     ilast = i
                 mm = pattern.search(pycode.code, mm.end())
         else:
             nomatch += 1
         if match+nomatch == 1:
-            print dir(pycode)
-            print dir(pycode.vars)
+            print(dir(pycode))
+            print(dir(pycode.vars))
     db1.close()
     db2.close()
-    print "Checked",match+nomatch,"entries from caches"
-    print nomatch,"did not match pattern"
-    print match,"did match pattern"
+    print("Checked",match+nomatch,"entries from caches")
+    print(nomatch,"did not match pattern")
+    print(match,"did match pattern")
     return pmatch

--- a/tools/cachesearch.py
+++ b/tools/cachesearch.py
@@ -12,10 +12,10 @@ def search(pattern):
     if isinstance(pattern, str):
         pattern = re.compile(pattern)
     cachename1 = os.path.expanduser('~/iraf/pyraf/clcache')
-    cachename2 = os.path.join(pyraf.irafglobals.pyrafDir,'clcache')
+    cachename2 = os.path.join(pyraf.irafglobals.pyrafDir, 'clcache')
 
-    db1 = pyraf.dirshelve.open(cachename1,'r')
-    db2 = pyraf.dirshelve.open(cachename2,'r')
+    db1 = pyraf.dirshelve.open(cachename1, 'r')
+    db2 = pyraf.dirshelve.open(cachename2, 'r')
 
     keys1 = list(db1.keys())
     keys2 = list(db2.keys())
@@ -33,7 +33,7 @@ def search(pattern):
             pycode = db2[key]
         else:
             raise Exception("Error: not in cache on second pass??")
-        if not hasattr(pycode,'code'):
+        if not hasattr(pycode, 'code'):
             continue
         mm = pattern.search(pycode.code)
         if mm:
@@ -60,7 +60,7 @@ def search(pattern):
             print(dir(pycode.vars))
     db1.close()
     db2.close()
-    print("Checked",match+nomatch,"entries from caches")
-    print(nomatch,"did not match pattern")
-    print(match,"did match pattern")
+    print("Checked", match+nomatch, "entries from caches")
+    print(nomatch, "did not match pattern")
+    print(match, "did match pattern")
     return pmatch

--- a/tools/checkcompileall.py
+++ b/tools/checkcompileall.py
@@ -4,7 +4,7 @@
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 import re, sys
 
 taskpat = re.compile(r'\d')
@@ -19,38 +19,38 @@ expectTask = True
 inError = False
 for line in lines:
     if line.startswith("====="):
-        print line
+        print(line)
         expectTask = True
         if inError:
             inError = False
-            print
+            print()
     elif line.startswith("-----"):
         cpackage = line
         expectTask = False
         if inError:
             inError = False
-            print
+            print()
     elif taskpat.match(line):
         ctask = line
         expectTask = True
         if inError:
             inError = False
-            print
+            print()
     elif line == "...continuing...":
         expectTask = True
-        print
+        print()
         inError = False
     elif not line:
         if inError:
             inError = False
-            print
+            print()
     elif expectTask:
         # Some sort of unexpected output, so print it
         if cpackage:
-            print cpackage
+            print(cpackage)
             cpackage = None
         if ctask:
-            print ctask
+            print(ctask)
             ctask = None
-        print line
+        print(line)
         inError = True

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -11,14 +11,14 @@ and move the user cache so that everything gets compiled from scratch.)
 
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import os, sys, traceback, time
 
 def printcenter(s, length=70, char="-"):
     l1 = (length-len(s))//2
     l2 = length-l1-len(s)
-    print l1*char, s, l2*char
+    print(l1*char, s, l2*char)
     sys.stdout.flush()
 
 def compileall():
@@ -42,9 +42,9 @@ def compileall():
     if not os.path.exists(userCacheDir):
         try:
             os.mkdir(userCacheDir)
-            print 'Created directory %s for cache' % userCacheDir
+            print('Created directory %s for cache' % userCacheDir)
         except OSError:
-            print 'Could not create directory %s' % userCacheDir
+            print('Could not create directory %s' % userCacheDir)
     dbfile = 'clcache'
     clcache.codeCache = clcache._CodeCache([ os.path.join(userCacheDir,dbfile) ])
     cl2py.codeCache = clcache.codeCache
@@ -76,10 +76,10 @@ def compileall():
                 npkg_new = npkg_new+1
                 printcenter(pkg)
                 if pkg in ["newimred","digiphotx"]:
-                    print """
+                    print("""
 Working around bugs in newimred, digiphotx.
 They screw up subsequent loading of imred/digiphot tasks.
-(It happens in IRAF too.)"""
+(It happens in IRAF too.)""")
                     sys.stdout.flush()
                 else:
                     try:
@@ -88,7 +88,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                         # going)
                         iraf.load(pkg,kw={'Stdin': 'dev$null'})
                     except KeyboardInterrupt:
-                        print 'Interrupt'
+                        print('Interrupt')
                         sys.stdout.flush()
                         keepGoing = 0
                         break
@@ -98,7 +98,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                         if isinstance(e,MemoryError):
                             keepGoing = 0
                             break
-                        print "...continuing...\n"
+                        print("...continuing...\n")
                         sys.stdout.flush()
                 # load tasks after each package
                 task_list = iraf.getTaskList()
@@ -110,12 +110,12 @@ They screw up subsequent loading of imred/digiphot tasks.
                         if isinstance(taskobj, IrafCLTask) and \
                                         not isinstance(taskobj,IrafPkg):
                             ntask_total = ntask_total+1
-                            print "%d: %s" % (ntask_total, taskname)
+                            print("%d: %s" % (ntask_total, taskname))
                             sys.stdout.flush()
                             try:
                                 taskobj.initTask()
                             except KeyboardInterrupt:
-                                print 'Interrupt'
+                                print('Interrupt')
                                 sys.stdout.flush()
                                 keepGoing = 0
                                 break
@@ -125,7 +125,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                                 if isinstance(e,MemoryError):
                                     keepGoing = 0
                                     break
-                                print "...continuing...\n"
+                                print("...continuing...\n")
                                 sys.stdout.flush()
                                 ntask_failed = ntask_failed+1
                 if not keepGoing: break
@@ -136,17 +136,17 @@ They screw up subsequent loading of imred/digiphot tasks.
         pkg_list = iraf.getPkgList()
 
     t1 = time.time()
-    print "Finished package and task loading (%f seconds)" % (t1-t0,)
-    print "Compiled %d CL tasks -- %d failed" % (ntask_total, ntask_failed)
+    print("Finished package and task loading (%f seconds)" % (t1-t0,))
+    print("Compiled %d CL tasks -- %d failed" % (ntask_total, ntask_failed))
     sys.stdout.flush()
 
 
 def usage():
-    print """Usage: %s [-r] [-h]
+    print("""Usage: %s [-r] [-h]
             -r recompiles only out-of-date routines.  Default is to
                     force recompilation of all CL scripts and packages.
             -h prints this message.
-"""
+""")
     sys.stdout.flush()
     sys.exit()
 
@@ -157,10 +157,10 @@ if __name__ == '__main__':
     try:
         optlist, args = getopt.getopt(sys.argv[1:], "rh")
         if len(args) > 0:
-            print "Error: no positional arguments accepted"
+            print("Error: no positional arguments accepted")
             usage()
     except getopt.error as e:
-        print str(e)
+        print(str(e))
         usage()
     clearcache = 1
     for opt, value in optlist:
@@ -169,7 +169,7 @@ if __name__ == '__main__':
         elif opt == "-h":
             usage()
         else:
-            print "Program bug, unknown option", opt
+            print("Program bug, unknown option", opt)
             raise SystemExit()
 
     # find pyraf directory
@@ -186,8 +186,8 @@ if __name__ == '__main__':
         # move the old user cache
         if os.path.exists(usrCache):
             os.rename(usrCache, usrCache + '.old')
-            print "Pyraf user cache %s renamed to %s.old" % (usrCache, usrCache)
+            print("Pyraf user cache %s renamed to %s.old" % (usrCache, usrCache))
         else:
-            print "Warning: pyraf user cache %s was not found" % usrCache
+            print("Warning: pyraf user cache %s was not found" % usrCache)
 
     compileall()

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -71,7 +71,7 @@ def compileall():
         printcenter("pass %d: %d packages (%d new)" %
                 (npass,len(pkg_list),len(pkg_list)-npkg_total), char="=")
         for pkg in pkg_list:
-            if not pkgs_tried.has_key(pkg):
+            if pkg not in pkgs_tried:
                 pkgs_tried[pkg] = 1
                 npkg_new = npkg_new+1
                 printcenter(pkg)
@@ -103,7 +103,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                 # load tasks after each package
                 task_list = sorted(iraf.getTaskList())
                 for taskname in task_list:
-                    if not tasks_tried.has_key(taskname):
+                    if taskname not in tasks_tried:
                         tasks_tried[taskname] = 1
                         taskobj = iraf.getTask(taskname)
                         if isinstance(taskobj, IrafCLTask) and \

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -92,7 +92,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                         sys.stdout.flush()
                         keepGoing = 0
                         break
-                    except Exception, e:
+                    except Exception as e:
                         sys.stdout.flush()
                         traceback.print_exc()
                         if isinstance(e,MemoryError):
@@ -119,7 +119,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                                 sys.stdout.flush()
                                 keepGoing = 0
                                 break
-                            except Exception, e:
+                            except Exception as e:
                                 sys.stdout.flush()
                                 traceback.print_exc(10)
                                 if isinstance(e,MemoryError):
@@ -159,7 +159,7 @@ if __name__ == '__main__':
         if len(args) > 0:
             print "Error: no positional arguments accepted"
             usage()
-    except getopt.error, e:
+    except getopt.error as e:
         print str(e)
         usage()
     clearcache = 1

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -38,7 +38,7 @@ def compileall():
     cl2py.codeCache.close()
     del clcache.codeCache
 
-    userCacheDir = os.path.join(irafglobals.userIrafHome,'pyraf')
+    userCacheDir = os.path.join(irafglobals.userIrafHome, 'pyraf')
     if not os.path.exists(userCacheDir):
         try:
             os.mkdir(userCacheDir)
@@ -46,7 +46,7 @@ def compileall():
         except OSError:
             print('Could not create directory %s' % userCacheDir)
     dbfile = 'clcache'
-    clcache.codeCache = clcache._CodeCache([ os.path.join(userCacheDir,dbfile) ])
+    clcache.codeCache = clcache._CodeCache([ os.path.join(userCacheDir, dbfile) ])
     cl2py.codeCache = clcache.codeCache
 
     iraf.setVerbose()
@@ -69,13 +69,13 @@ def compileall():
         pkg_list.sort()
         npkg_new = 0
         printcenter("pass %d: %d packages (%d new)" %
-                (npass,len(pkg_list),len(pkg_list)-npkg_total), char="=")
+                (npass, len(pkg_list), len(pkg_list)-npkg_total), char="=")
         for pkg in pkg_list:
             if pkg not in pkgs_tried:
                 pkgs_tried[pkg] = 1
                 npkg_new = npkg_new+1
                 printcenter(pkg)
-                if pkg in ["newimred","digiphotx"]:
+                if pkg in ["newimred", "digiphotx"]:
                     print("""
 Working around bugs in newimred, digiphotx.
 They screw up subsequent loading of imred/digiphot tasks.
@@ -86,7 +86,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                         # redirect stdin in case the package tries to
                         # prompt for parameters (this aborts but keeps
                         # going)
-                        iraf.load(pkg,kw={'Stdin': 'dev$null'})
+                        iraf.load(pkg, kw={'Stdin': 'dev$null'})
                     except KeyboardInterrupt:
                         print('Interrupt')
                         sys.stdout.flush()
@@ -95,7 +95,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                     except Exception as e:
                         sys.stdout.flush()
                         traceback.print_exc()
-                        if isinstance(e,MemoryError):
+                        if isinstance(e, MemoryError):
                             keepGoing = 0
                             break
                         print("...continuing...\n")
@@ -107,7 +107,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                         tasks_tried[taskname] = 1
                         taskobj = iraf.getTask(taskname)
                         if isinstance(taskobj, IrafCLTask) and \
-                                        not isinstance(taskobj,IrafPkg):
+                                        not isinstance(taskobj, IrafPkg):
                             ntask_total = ntask_total+1
                             print("%d: %s" % (ntask_total, taskname))
                             sys.stdout.flush()
@@ -121,7 +121,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                             except Exception as e:
                                 sys.stdout.flush()
                                 traceback.print_exc(10)
-                                if isinstance(e,MemoryError):
+                                if isinstance(e, MemoryError):
                                     keepGoing = 0
                                     break
                                 print("...continuing...\n")
@@ -173,8 +173,8 @@ if __name__ == '__main__':
 
     # find pyraf directory
     for p in sys.path:
-        absPyrafDir = os.path.join(p,'pyraf')
-        if os.path.exists(os.path.join(absPyrafDir,'__init__.py')):
+        absPyrafDir = os.path.join(p, 'pyraf')
+        if os.path.exists(os.path.join(absPyrafDir, '__init__.py')):
             break
     else:
         raise Exception('pyraf module not found')

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -101,8 +101,7 @@ They screw up subsequent loading of imred/digiphot tasks.
                         print("...continuing...\n")
                         sys.stdout.flush()
                 # load tasks after each package
-                task_list = iraf.getTaskList()
-                task_list.sort()
+                task_list = sorted(iraf.getTaskList())
                 for taskname in task_list:
                     if not tasks_tried.has_key(taskname):
                         tasks_tried[taskname] = 1

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -170,7 +170,7 @@ if __name__ == '__main__':
             usage()
         else:
             print "Program bug, unknown option", opt
-            raise SystemExit
+            raise SystemExit()
 
     # find pyraf directory
     for p in sys.path:

--- a/tools/fixcache.py
+++ b/tools/fixcache.py
@@ -3,7 +3,7 @@
 # $Id$
 #
 
-from __future__ import division # confidence high
+from __future__ import division, print_function
 import os
 
 def fixit(trylist, verbose=0):
@@ -23,7 +23,7 @@ def fixit(trylist, verbose=0):
             fpath = os.path.join(cachedir,file)
             os.rename(fpath, fpath+"==")
     if verbose:
-        print "Renamed %d of %d files in %s" % (rcount, fcount, cachedir)
+        print("Renamed %d of %d files in %s" % (rcount, fcount, cachedir))
 
 if __name__ == "__main__":
     # looks in ~/iraf/pyraf/clcache, ./clcache, and ./pyraf/clcache

--- a/tools/fixcache.py
+++ b/tools/fixcache.py
@@ -20,7 +20,7 @@ def fixit(trylist, verbose=0):
         fcount = fcount+1
         if file[-2:] != "==":
             rcount = rcount+1
-            fpath = os.path.join(cachedir,file)
+            fpath = os.path.join(cachedir, file)
             os.rename(fpath, fpath+"==")
     if verbose:
         print("Renamed %d of %d files in %s" % (rcount, fcount, cachedir))

--- a/tools/loadall.py
+++ b/tools/loadall.py
@@ -45,7 +45,7 @@ while keepGoing and (ntotal<len(plist)):
                     print 'Interrupt'
                     keepGoing = 0
                     break
-                except Exception, e:
+                except Exception as e:
                     sys.stdout.flush()
                     traceback.print_exc()
                     if e.__class__ == MemoryError:

--- a/tools/loadall.py
+++ b/tools/loadall.py
@@ -24,8 +24,8 @@ while keepGoing and (ntotal<len(plist)):
     plist.sort()
     nnew = 0
     npass = npass + 1
-    printcenter("pass "+`npass` + " trying " +
-            `len(plist)`, char="=")
+    printcenter("pass " + repr(npass) + " trying " + repr(len(plist)),
+                char="=")
     for pkg in plist:
         if pkg not in ptried:
             ptried[pkg] = 1
@@ -53,7 +53,7 @@ while keepGoing and (ntotal<len(plist)):
                         break
                     print("...continuing...\n")
     ntotal = ntotal + nnew
-    printcenter("Finished pass "+`npass` +
-            " new pkgs " + `nnew` +
-            " total pkgs " + `ntotal`, char="=")
+    printcenter("Finished pass " + repr(npass) +
+                " new pkgs " + repr(nnew) +
+                " total pkgs " + repr(ntotal), char="=")
     plist = iraf.getPkgList()

--- a/tools/loadall.py
+++ b/tools/loadall.py
@@ -3,7 +3,7 @@
 """loadall.py: Load all the main packages in IRAF with verbose turned on
 $Id$
 """
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 import sys, traceback
 from pyraf import iraf
@@ -13,7 +13,7 @@ iraf.setVerbose()
 def printcenter(s, length=70, char="-"):
     l1 = (length-len(s))//2
     l2 = length-l1-len(s)
-    print l1*char, s, l2*char
+    print(l1*char, s, l2*char)
 
 ptried = {}
 npass = 0
@@ -34,15 +34,15 @@ while keepGoing and (ntotal<len(plist)):
             l2 = 70-l1-len(pkg)
             printcenter(pkg)
             if pkg == "digiphotx":
-                print """
+                print("""
                         Working around bug in digiphotx.
                         It screws up subsequent loading of digiphot tasks.
-                        (It happens in IRAF too.)"""
+                        (It happens in IRAF too.)""")
             else:
                 try:
                     iraf.load(pkg)
                 except KeyboardInterrupt:
-                    print 'Interrupt'
+                    print('Interrupt')
                     keepGoing = 0
                     break
                 except Exception as e:
@@ -51,7 +51,7 @@ while keepGoing and (ntotal<len(plist)):
                     if e.__class__ == MemoryError:
                         keepGoing = 0
                         break
-                    print "...continuing...\n"
+                    print("...continuing...\n")
     ntotal = ntotal + nnew
     printcenter("Finished pass "+`npass` +
             " new pkgs " + `nnew` +

--- a/tools/loadall.py
+++ b/tools/loadall.py
@@ -27,7 +27,7 @@ while keepGoing and (ntotal<len(plist)):
     printcenter("pass "+`npass` + " trying " +
             `len(plist)`, char="=")
     for pkg in plist:
-        if not ptried.has_key(pkg):
+        if pkg not in ptried:
             ptried[pkg] = 1
             nnew = nnew+1
             l1 = (70-len(pkg))//2

--- a/tools/plotbench.py
+++ b/tools/plotbench.py
@@ -9,7 +9,7 @@
 #
 # $Id$
 #
-from __future__ import division # confidence high
+from __future__ import division, print_function
 
 from pyraf import iraf, gki
 import os, time, random
@@ -68,7 +68,7 @@ def runAllCases(suiteName, resDict):
 
    # we reset gki to pick up the current graphics kernel of choice
    # we also close the graphics window and then throw away the first plot
-   print ("\n"+suiteName+":")
+   print("\n" + suiteName + ":")
    gki._resetGraphicsKernel()
 
    for mo in ('graph','prow','surface','contour'):

--- a/tools/plotbench.py
+++ b/tools/plotbench.py
@@ -82,7 +82,7 @@ def runAllCases(suiteName, resDict):
             print(case+': '+"%.5g" %secs+' secs')
             # add case name to results dict
             if 'case names' in resDict:
-               if not case in resDict['case names']:
+               if case not in resDict['case names']:
                   resDict['case names'].append(case)
             else:
                resDict['case names'] = [case]

--- a/tools/plotbench.py
+++ b/tools/plotbench.py
@@ -22,9 +22,9 @@ CASES=(None, 'point', 'box', 'plus', 'cross', 'circle')
 def manyPoints(task, pkind):
    """ Plot a bunch of points, return the time it took (s). """
 
-   assert task in ('prow','graph','surface','contour'), \
+   assert task in ('prow', 'graph', 'surface', 'contour'), \
           "Unexpected task: "+str(task)
-   assert pkind in (None, 'point','box','plus','cross','circle'), \
+   assert pkind in (None, 'point', 'box', 'plus', 'cross', 'circle'), \
           'Unknown: '+str(pkind)
 
    # plot 10 rows.  in dev$pix this is 5120 pts
@@ -71,7 +71,7 @@ def runAllCases(suiteName, resDict):
    print("\n" + suiteName + ":")
    gki._resetGraphicsKernel()
 
-   for mo in ('graph','prow','surface','contour'):
+   for mo in ('graph', 'prow', 'surface', 'contour'):
       did = 0
       # duplicate the first plot since it will be tossed.
       for test in CASES[:1]+CASES:
@@ -92,7 +92,7 @@ def runAllCases(suiteName, resDict):
             else:
                resDict[case] = [secs]
             # only do one plot for surface or contour (not varied cases)
-            if mo in ('surface','contour'):
+            if mo in ('surface', 'contour'):
                break
          did = 1
 

--- a/tools/subproc_Ph.py
+++ b/tools/subproc_Ph.py
@@ -19,7 +19,7 @@ class Ph:
             self.proc = Subprocess("ph", expire_noisily=1)
         except:
             raise SubprocessError("failure starting ph: %s" %
-                                  str(sys.exc_value))
+                                  str(sys.exc_info()[1]))
 
     def query(self, q):
         """Send a query and return a list of dicts for responses.

--- a/tools/subproc_Ph.py
+++ b/tools/subproc_Ph.py
@@ -30,7 +30,7 @@ class Ph:
 
         self.proc.writeline('query ' + q)
         got = []; it = {}
-        while 1:
+        while True:
             response = self.getreply()      # Should get null on new prompt.
             errs = self.proc.readPendingErrChars()
             if errs:


### PR DESCRIPTION
Currentl, the code is Python3 compatible only after washing with 2to3, which changes a lot of the code. This is not really nice, since first 2to3 isn't perfect, but also the development is more difficult. And Python 2 is abandoned since 2020.

Therefore the ultimate goal is to switch the code completely to Pythhon 3. This will happen in three steps:

 1. Bring the code as close to Python 3 as possible, still keeping compatibility to Python 2.7.  This is the goal of this PR.
 2. Improve code style by applying PEP-8 (flake8)
 3. Remove Python 2.7 compatibility and allow new Python features where possible

This way, we can create an Python2 compatibility branch after step 2 and be able to backport fixes if a Python 2 version would really still required. And we also can streamline the code by supporting only the actual Python versions (as do all other Python packages).

**This is open for discussion; please drop your opinion here.**

The changes done here are mainly created with 2to3, and then reviewed manually.