### PR TITLE
Remove Python 2 support and improve Python 3 style

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -8,18 +8,16 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
-      PYTHON: ${{ matrix.python }}
+      tmp: /tmp/
+      iraf: /usr/lib/iraf/
+      IRAFARCH: generic
+      TERM: dumb
 
     strategy:
       matrix:
         include:
           - name: Ubuntu 20.04 (Focal) Python-3.8.2
             os: ubuntu-20.04
-            python: python3
-
-          - name: Ubuntu 18.04 (Bionic) Python-2.7.17
-            os: ubuntu-18.04
-            python: python
 
     steps:
       - name: Checkout repository
@@ -29,18 +27,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends iraf iraf-noao iraf-dev build-essential libx11-dev
-          sudo apt-get install --no-install-recommends ${PYTHON}-all-dev ${PYTHON}-astropy ${PYTHON}-numpy-dev ${PYTHON}-setuptools ${PYTHON}-setuptools-scm ${PYTHON}-stsci.tools ${PYTHON}-tk ${PYTHON}-pytest ${PYTHON}-pytest-cov i${PYTHON}
+          sudo apt-get install --no-install-recommends python3-all-dev python3-astropy python3-numpy-dev python3-setuptools python3-setuptools-scm python3-stsci.tools python3-tk python3-pytest python3-pytest-cov ipython3
 
       - name: Build Pyraf
         run: |
-           ${PYTHON} setup.py build
+           python3 setup.py build
 
       - name: Run tests
         run: |
           TEST_BASE=$(ls -d $(pwd)/build/lib.*/)
           export PATH=$(ls -d $(pwd)/build/scripts-*/):${PATH}
-          export tmp=/tmp/
-          export iraf=/usr/lib/iraf/
-          export IRAFARCH=generic
-          export TERM=dumb
-          cd ${TEST_BASE} && ${PYTHON} -m pytest --cov=pyraf
+          cd ${TEST_BASE} && python3 -m pytest --cov=pyraf

--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -31,10 +31,9 @@ jobs:
 
       - name: Build Pyraf
         run: |
-           python3 setup.py build
+           python3 setup.py build_ext -i
 
       - name: Run tests
         run: |
-          TEST_BASE=$(ls -d $(pwd)/build/lib.*/)
-          export PATH=$(ls -d $(pwd)/build/scripts-*/):${PATH}
-          cd ${TEST_BASE} && python3 -m pytest --cov=pyraf
+          export PATH=$(pwd)/scripts:${PATH}
+          python3 -m pytest --cov=pyraf

--- a/pyraf/GkiMpl.py
+++ b/pyraf/GkiMpl.py
@@ -12,7 +12,6 @@ import matplotlib
 from matplotlib.lines import Line2D
 from matplotlib.figure import Figure
 from matplotlib.patches import Rectangle
-from stsci.tools.for2to3 import ndarr2str
 
 from . import gki
 from . import gkitkbase
@@ -477,7 +476,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         # add the text
         x = gki.ndc(arg[0])
         y = gki.ndc(arg[1])
-        text = ndarr2str(arg[3:].astype(numpy.int8))
+        text = arg[3:].astype(numpy.int8).tobytes().encode('ascii')
         ta = self.textAttributes
 
         # For now, force this to be non-bold for decent looking plots.  It

--- a/pyraf/GkiMpl.py
+++ b/pyraf/GkiMpl.py
@@ -733,4 +733,4 @@ class tkColorManager:
         red = int(255 * color[0])
         green = int(255 * color[1])
         blue = int(255 * color[2])
-        return "#%02x%02x%02x" % (red, green, blue)
+        return "#{:02x}{:02x}{:02x}".format(red, green, blue)

--- a/pyraf/GkiMpl.py
+++ b/pyraf/GkiMpl.py
@@ -14,12 +14,12 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Rectangle
 from stsci.tools.for2to3 import ndarr2str
 
-import gki
-import gkitkbase
-import textattrib
-import gkigcur
-import MplCanvasAdapter as mca
-from wutil import moveCursorTo
+from . import gki
+from . import gkitkbase
+from . import textattrib
+from . import gkigcur
+from . import MplCanvasAdapter as mca
+from .wutil import moveCursorTo
 try:
     import readline
 except ImportError:

--- a/pyraf/GkiMpl.py
+++ b/pyraf/GkiMpl.py
@@ -2,7 +2,7 @@
 matplotlib implementation of the gki kernel class
 """
 
-from __future__ import division, print_function
+
 
 import math
 import numpy

--- a/pyraf/GkiMpl.py
+++ b/pyraf/GkiMpl.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function
 
 import math
 import numpy
-import Tkinter as TKNTR
+import tkinter
 import matplotlib
 # (done in mca file) matplotlib.use('TkAgg') # set backend
 from matplotlib.lines import Line2D
@@ -64,8 +64,8 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
 
     def makeGWidget(self, width=600, height=420):
         """Make the graphics widget.  Also perform some self init."""
-        self.__pf = TKNTR.Frame(self.top)
-        self.__pf.pack(side=TKNTR.TOP, fill=TKNTR.BOTH, expand=1)
+        self.__pf = tkinter.Frame(self.top)
+        self.__pf.pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
         self.__xsz = width
         self.__ysz = height
 
@@ -76,7 +76,7 @@ class GkiMplKernel(gkitkbase.GkiInteractiveTkBase):
         self.__fig.set_facecolor('k')  # default to black
 
         self.__mca = mca.MplCanvasAdapter(self, self.__fig, master=self.__pf)
-        self.__mca.pack(side=TKNTR.TOP, fill=TKNTR.BOTH, expand=1)
+        self.__mca.pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
         self.__mca.gwidgetize(width, height)  # Add attrs to the gwidget
         self.gwidget = self.__mca.get_tk_widget()
 

--- a/pyraf/MplCanvasAdapter.py
+++ b/pyraf/MplCanvasAdapter.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-
-
-
 import matplotlib
 matplotlib.use('TkAgg')  # set backend
 import matplotlib.backends.backend_tkagg as tkagg

--- a/pyraf/MplCanvasAdapter.py
+++ b/pyraf/MplCanvasAdapter.py
@@ -5,10 +5,10 @@ from __future__ import division, print_function
 import matplotlib
 matplotlib.use('TkAgg')  # set backend
 import matplotlib.backends.backend_tkagg as tkagg
-from Ptkplot import hideTkCursor
-from Ptkplot import FullWindowCursor
+from .Ptkplot import hideTkCursor
+from .Ptkplot import FullWindowCursor
 import tk
-from wutil import moveCursorTo, WUTIL_USING_X
+from .wutil import moveCursorTo, WUTIL_USING_X
 
 
 class MplCanvasAdapter(tkagg.FigureCanvasTkAgg):

--- a/pyraf/MplCanvasAdapter.py
+++ b/pyraf/MplCanvasAdapter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import division, print_function
+
 
 import matplotlib
 matplotlib.use('TkAgg')  # set backend

--- a/pyraf/Ptkplot.py
+++ b/pyraf/Ptkplot.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function
 import os
 from tkinter import _default_root
 from tkinter import TclError, Canvas
-import wutil
+from . import wutil
 
 # XBM file for cursor is in same directory as this module
 _blankcursor = 'blankcursor.xbm'

--- a/pyraf/Ptkplot.py
+++ b/pyraf/Ptkplot.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-
-
-
 import os
 from tkinter import _default_root
 from tkinter import TclError, Canvas

--- a/pyraf/Ptkplot.py
+++ b/pyraf/Ptkplot.py
@@ -3,8 +3,8 @@
 from __future__ import division, print_function
 
 import os
-from Tkinter import _default_root  # requires 2to3
-from Tkinter import TclError, Canvas
+from tkinter import _default_root
+from tkinter import TclError, Canvas
 import wutil
 
 # XBM file for cursor is in same directory as this module
@@ -30,14 +30,14 @@ if _default_root is None:
 
 def cleanup():
     try:
-        from Tkinter import _default_root, TclError  # requires 2to3
-        import Tkinter as TKNTR
+        from tkinter import _default_root, TclError
+        import tkinter
         try:
             if _default_root:
                 _default_root.destroy()
         except TclError:
             pass
-        TKNTR._default_root = None
+        tkinter._default_root = None
     except SystemError:
         # If cleanup() is called before pyraf fully loads, we will
         # see: "SystemError: Parent module 'pyraf' not loaded".  In that case,

--- a/pyraf/Ptkplot.py
+++ b/pyraf/Ptkplot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import division, print_function
+
 
 import os
 from tkinter import _default_root

--- a/pyraf/__init__.py
+++ b/pyraf/__init__.py
@@ -38,13 +38,8 @@ def usage():
     # to be run at this point - else we'd see run-time import warnings
     os._exit(0)
 
-
-# set search path to include current directory
-if "." not in sys.path:
-    sys.path.insert(0, ".")
-
 # Grab the terminal window's id at the earliest possible moment
-import wutil
+from . import wutil
 
 # Since numpy as absolutely required for any PyRAF use, go ahead and
 # import it now, just to check it
@@ -64,14 +59,14 @@ if _verbosity_ > 0:
 # convenient for the iraf module
 if _verbosity_ > 0:
     print("pyraf: importing irafimport")
-import irafimport
+from . import irafimport
 if _verbosity_ > 0:
     print("pyraf: imported irafimport")
 
 # this gives more useful tracebacks for CL scripts
-import cllinecache
+from . import cllinecache
 
-import irafnames
+from . import irafnames
 
 # initialization is silent unless program name is 'pyraf' or
 # silent flag is set on command line
@@ -86,8 +81,8 @@ _pyrafMain = os.path.split(executable)[1] in ('pyraf', 'runpyraf.py')
 del executable
 
 runCmd = None
-import irafexecute
-import clcache
+from . import irafexecute
+from . import clcache
 from stsci.tools import capable
 
 if _verbosity_ > 0:
@@ -119,7 +114,7 @@ if not _pyrafMain:
     # quietly load initial iraf symbols and packages
     if _verbosity_ > 0:
         print("pyraf: initializing IRAF")
-    import iraf
+    from . import iraf
     if _verbosity_ > 0:
         print("pyraf: imported iraf")
 
@@ -147,7 +142,7 @@ else:
     # special initialization when this is the main program
 
     # command-line options
-    import pyrafglobals as _pyrafglobals
+    from . import pyrafglobals as _pyrafglobals
     import getopt
     try:
         optlist, args = getopt.getopt(sys.argv[1:], "imc:vhsney", [
@@ -205,7 +200,7 @@ else:
     if _verbosity_ > 0:
         print("pyraf: finished arg parsing")
 
-    import iraf
+    from . import iraf
     if _verbosity_ > 0:
         print("pyraf: imported iraf")
     iraf.setVerbose(verbose)
@@ -218,7 +213,7 @@ else:
     else:
         _initkw = {}
         if _dosplash:
-            import splash
+            from . import splash
             _splash = splash.splash('PyRAF ' + __version__)
         else:
             _splash = None

--- a/pyraf/__init__.py
+++ b/pyraf/__init__.py
@@ -6,7 +6,7 @@ is done verbosely or quietly.
 
 R. White, 2000 February 18
 """
-from __future__ import division, print_function
+
 
 from .version import version as __version__
 

--- a/pyraf/aqutil.py
+++ b/pyraf/aqutil.py
@@ -3,7 +3,7 @@ not possible in tkinter.  In general, an attempt is made to use the Pyobjc
 bridging package so that compiling another C extension is not needed.
 """
 
-from __future__ import division, print_function
+
 
 import os
 import struct

--- a/pyraf/aqutil.py
+++ b/pyraf/aqutil.py
@@ -10,7 +10,6 @@ import struct
 import time
 import objc
 import AppKit
-from stsci.tools.for2to3 import tobytes
 
 # Arbitrary module constants for term vs. gui.  0 and negative numbers have
 # special meanings when queried elsewhere (e.g. wutil).  It is assumed that
@@ -183,12 +182,12 @@ def __doPyobjcWinInit():
     #
     OSErr = objc._C_SHT
     CGErr = objc._C_INT
-    INPSN = tobytes('n^{ProcessSerialNumber=LL}')
-    OUTPSN = tobytes('o^{ProcessSerialNumber=LL}')
-    #   OUTPID = tobytes('o^_C_ULNG') # invalid as of objc v3.2
-    WARPSIG = tobytes('v{CGPoint=ff}')
+    INPSN = b'n^{ProcessSerialNumber=LL}'
+    OUTPSN = b'o^{ProcessSerialNumber=LL}'
+    #   OUTPID = b'o^_C_ULNG'  # invalid as of objc v3.2
+    WARPSIG = b'v{CGPoint=ff}'
     if struct.calcsize("l") > 4:  # is 64-bit python
-        WARPSIG = tobytes('v{CGPoint=dd}')
+        WARPSIG = b'v{CGPoint=dd}'
 
     FUNCTIONS = [
         # These are public API
@@ -238,7 +237,7 @@ def __doPyobjcWinInit():
         raise Exception("GetCurrentProcess: " + str(err))
 
     # Set Proc name
-    err = CPSSetProcessName(__thisPSN, tobytes('PyRAF'))
+    err = CPSSetProcessName(__thisPSN, b'PyRAF')
     if err:
         raise Exception("CPSSetProcessName: " + str(err))
     # Make us a FG app (need to be in order to use SetFrontProcess on us)

--- a/pyraf/aqutil.py
+++ b/pyraf/aqutil.py
@@ -192,23 +192,23 @@ def __doPyobjcWinInit():
 
     FUNCTIONS = [
         # These are public API
-        (u'GetCurrentProcess', OSErr + OUTPSN),
-        (u'GetFrontProcess', OSErr + OUTPSN),
+        ('GetCurrentProcess', OSErr + OUTPSN),
+        ('GetFrontProcess', OSErr + OUTPSN),
         #        ( u'GetProcessPID', OSStat+INPSN+OUTPID), # see OUTPID note
-        (u'SetFrontProcess', OSErr + INPSN),
-        (u'CGWarpMouseCursorPosition', WARPSIG),
-        (u'CGMainDisplayID', objc._C_PTR + objc._C_VOID),
-        (u'CGDisplayPixelsHigh', objc._C_ULNG + objc._C_ULNG),
-        (u'CGDisplayHideCursor', CGErr + objc._C_ULNG),
-        (u'CGDisplayShowCursor', CGErr + objc._C_ULNG),
+        ('SetFrontProcess', OSErr + INPSN),
+        ('CGWarpMouseCursorPosition', WARPSIG),
+        ('CGMainDisplayID', objc._C_PTR + objc._C_VOID),
+        ('CGDisplayPixelsHigh', objc._C_ULNG + objc._C_ULNG),
+        ('CGDisplayHideCursor', CGErr + objc._C_ULNG),
+        ('CGDisplayShowCursor', CGErr + objc._C_ULNG),
         # This is undocumented API
-        (u'CPSSetProcessName', OSErr + INPSN + objc._C_CHARPTR),
-        (u'CPSEnableForegroundOperation', OSErr + INPSN),
+        ('CPSSetProcessName', OSErr + INPSN + objc._C_CHARPTR),
+        ('CPSEnableForegroundOperation', OSErr + INPSN),
     ]
 
     bndl = AppKit.NSBundle.bundleWithPath_(
         objc.pathForFramework(
-            u'/System/Library/Frameworks/ApplicationServices.framework'))
+            '/System/Library/Frameworks/ApplicationServices.framework'))
     if bndl is None:
         raise Exception("Error in aqutil with bundleWithPath_")
 

--- a/pyraf/cgeneric.py
+++ b/pyraf/cgeneric.py
@@ -17,7 +17,7 @@ I also added the re match object as an argument to the action function.
 
 Created 1999 September 10 by R. White
 """
-from __future__ import division, print_function
+
 
 
 class ContextSensitiveScanner:

--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -16,7 +16,6 @@ from . import clparse
 from .clcache import codeCache, DISABLE_CLCACHING
 
 from stsci.tools.irafglobals import Verbose
-from stsci.tools.for2to3 import PY3K
 from stsci.tools import basicpar, minmatch, irafutils
 from . import irafpar
 from . import pyrafglobals
@@ -74,7 +73,7 @@ def cl2py(filename=None,
 
     global _parser, codeCache
 
-    if PY3K or DISABLE_CLCACHING:
+    if True or DISABLE_CLCACHING:
         usecache = False  # ! turn caching off until it is fully tested/worked
         # when this is turned on, see corresponding PY3K note in clcache.py!
 
@@ -2241,7 +2240,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
     def n_inspect_stmt(self, node):
         # The following will create/call print as a statement, but is a function
         # However, there may not be a valid use case to worry about here.
-        if PY3K:
+        if True:
             raise RuntimeError("Error - this code is incorrect in PY3K")
         self.write("print ")
         if node[0].type == "=":

--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -81,7 +81,7 @@ def cl2py(filename=None,
         _parser = clparse.getParser()
 
     if mode not in ["proc", "single"]:
-        raise ValueError("Mode = `%s', must be `proc' or `single'" % (mode,))
+        raise ValueError("Mode = `{}', must be `proc' or `single'".format(mode))
 
     if filename not in (None, ''):
         if isinstance(filename, str):
@@ -239,8 +239,8 @@ def _checkVars(vars, parlist, parfile):
         if Verbose > 0:
             sys.stdout.flush()
             sys.stderr.write("Parameters from CL code inconsistent "
-                             "with .par file for task %s\n" %
-                             vars.getProcName())
+                             "with .par file for task {}\n"
+                             .format(vars.getProcName()))
             sys.stderr.flush()
 
     # create copies of the list and dictionary
@@ -299,7 +299,7 @@ class ErrorTracker:
 
         if not hasattr(self, 'errlist'):
             self._error_init()
-        self.warnlist.append((self.getlineno(node), "Warning: %s" % msg))
+        self.warnlist.append((self.getlineno(node), "Warning: {}".format(msg)))
 
     def comment(self, msg):
         """Add comments to the list - to be helpful to the debugging soul"""
@@ -335,12 +335,12 @@ class ErrorTracker:
             self.errlist.extend(self.warnlist)
             self.errlist.sort()
             try:
-                errmsg = ["Error in CL script %s" % self.filename]
+                errmsg = ["Error in CL script {}".format(self.filename)]
             except AttributeError:
                 errmsg = ["Error in CL script"]
             for lineno, msg in self.errlist:
                 if lineno:
-                    errmsg.append("%s (line %d)" % (msg, lineno))
+                    errmsg.append("{} (line {:d})".format(msg, lineno))
                 else:
                     errmsg.append(msg)
             for comment in self.comments:
@@ -349,12 +349,12 @@ class ErrorTracker:
         elif self.warnlist:
             self.warnlist.sort()
             try:
-                warnmsg = ["Warning in CL script %s" % self.filename]
+                warnmsg = ["Warning in CL script {}".format(self.filename)]
             except AttributeError:
                 warnmsg = ["Warning in CL script"]
             for lineno, msg in self.warnlist:
                 if lineno:
-                    warnmsg.append("%s (line %d)" % (msg, lineno))
+                    warnmsg.append("{} (line {:d})".format(msg, lineno))
                 else:
                     warnmsg.append(msg)
             for comment in self.comments:
@@ -577,7 +577,8 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
             shape = None
         if name in self.var_dict:
             if self.var_dict[name]:
-                self.error("Variable `%s' is multiply declared" % name, node)
+                self.error("Variable `{}' is multiply declared".format(name),
+                           node)
                 self.prune()
             else:
                 # existing but undefined entry comes from procedure line
@@ -606,9 +607,9 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
         # begin list of initial values
         if self.current_var.init_value is not None:
             # oops, looks like this was already initialized
-            errmsg = \
-                "%s: Variable `%s' has more than one set of initial values" % \
-                (self.filename, self.current_var.name,)
+            errmsg = (
+                "{}: Variable `{}' has more than one set of initial values"
+                .format(self.filename, self.current_var.name))
             self.error(errmsg, node)
         else:
             self.current_var.init_value = []
@@ -623,7 +624,7 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
                 v.init_value = _convFunc(v, ilist[0])
             except ValueError as e:
                 self.error(
-                    "Bad initial value for variable `%s': %s" % (v.name, e),
+                    "Bad initial value for variable `{}': {}".format(v.name, e),
                     node)
         else:
             # it is an array, set size or pad initial values
@@ -634,7 +635,7 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
                     v.init_value.append(None)
             elif len(v) < len(ilist):
                 self.error(
-                    "Variable `%s' has too many initial values" % (v.name,),
+                    "Variable `{}' has too many initial values".format(v.name),
                     node)
             else:
                 try:
@@ -642,8 +643,8 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
                         v.init_value[i] = _convFunc(v, v.init_value[i])
                 except ValueError as e:
                     self.error(
-                        "Bad initial value for array variable `%s': %s" %
-                        (v.name, e), node)
+                        "Bad initial value for array variable `{}': {}"
+                        .format(v.name, e), node)
 
     def n_decl_init_value(self, node):
         # initial value is token with value
@@ -671,7 +672,7 @@ class ExtractDeclInfo(GenericASTTraversal, ErrorTracker):
                 optvalue = vnode[1].get()
         optdict = self.current_var.options
         if optname not in optdict:
-            errmsg = "Unknown option `%s' for variable `%s'" % (
+            errmsg = "Unknown option `{}' for variable `{}'".format(
                 optname, self.current_var.name)
             self.error(errmsg, node)
         else:
@@ -768,13 +769,12 @@ class VarList(GenericASTTraversal, ErrorTracker):
         # names with embedded dots are allow by the CL but should be illegal
         pdot = proc_name.find('.')
         if pdot == 0:
-            self.error(
-                "Illegal procedure name `%s' starts with `.'" % proc_name,
-                node)
+            self.error("Illegal procedure name `{}' starts with `.'"
+                       .format(proc_name), node)
         if pdot >= 0:
             self.warning(
-                "Bad procedure name `%s' truncated after dot to `%s'" %
-                (proc_name, proc_name[:pdot]), node)
+                "Bad procedure name `{}' truncated after dot to `{}'"
+                .format(proc_name, proc_name[:pdot]), node)
             proc_name = proc_name[:pdot]
         # Procedure name is stored in translated form ('PY' added
         # to Python keywords, etc.)
@@ -819,12 +819,12 @@ class VarList(GenericASTTraversal, ErrorTracker):
     def checkLocalConflict(self):
         """Check for local variables that conflict with parameters"""
 
-        errlist = ["Error in procedure `%s'" % self.getProcName()]
+        errlist = ["Error in procedure `{}'".format(self.getProcName())]
         for v in self.local_vars_list:
             if v in self.proc_args_dict:
                 errlist.append(
-                    "Local variable `%s' overrides parameter of same name" %
-                    (v,))
+                    "Local variable `{}' overrides parameter of same name"
+                    .format(v))
         if len(errlist) > 1:
             self.error("\n".join(errlist))
 
@@ -853,8 +853,8 @@ class VarList(GenericASTTraversal, ErrorTracker):
         self.proc_args_list = p.proc_args_list
         for arg in self.proc_args_list:
             if arg in self.proc_args_dict:
-                errmsg = "Argument `%s' repeated in procedure statement %s" % \
-                    (arg, self.getProcName())
+                errmsg = ("Argument `{}' repeated in procedure statement {}"
+                          .format(arg, self.getProcName()))
                 self.error(errmsg, node)
             else:
                 self.proc_args_dict[arg] = None
@@ -871,7 +871,7 @@ class VarList(GenericASTTraversal, ErrorTracker):
                 # try substituting from parlist parameter list
                 d[arg] = self.getFromInputList(arg)
                 if not d[arg]:
-                    errmsg = "Procedure argument `%s' is not declared" % (arg,)
+                    errmsg = "Procedure argument `{}' is not declared".format(arg)
                     self.error(errmsg, node)
         self.prune()
 
@@ -1204,7 +1204,8 @@ class GoToAnalyze(GenericASTTraversal, ErrorTracker):
         for label in self.goto_blockidlist.keys():
             if label not in self.label_blockid:
                 node = self.goto_nodelist[label][0]
-                self.error("GOTO refers to unknown label `%s'" % label, node)
+                self.error("GOTO refers to unknown label `{}'".format(label),
+                           node)
 
         # note that we count on the Tree2Python class to print errors
 
@@ -1259,22 +1260,21 @@ class GoToAnalyze(GenericASTTraversal, ErrorTracker):
     def n_label_stmt(self, node):
         label = node[0].attr
         if label in self.label_blockid:
-            self.error("Duplicate statement label `%s'" % label, node)
+            self.error("Duplicate statement label `{}'".format(label), node)
         else:
             cblockid = self.current_blockid
             self.label_blockid[label] = cblockid
             # make sure all gotos for this label are in this or deeper blocks
             for i in self.goto_blockidlist.get(label, []):
                 if self.blocks[i].blockid < cblockid:
-                    self.error(
-                        "GOTO branches to label `%s' in inner block" % label,
-                        node)
+                    self.error("GOTO branches to label `{}' in inner block"
+                               .format(label), node)
 
     def n_goto_stmt(self, node):
         label = str(node[1])
         if label in self.label_blockid:
-            self.error("Backwards GOTO to label `%s' is not allowed" % label,
-                       node)
+            self.error("Backwards GOTO to label `{}' is not allowed"
+                       .format(label), node)
         elif label in self.goto_blockidlist:
             self.goto_blockidlist[label].append(self.current_blockid)
             self.goto_nodelist[label].append(node)
@@ -1444,15 +1444,15 @@ def _convFunc(var, value):
                 # parameter indirection
                 return value
             else:
-                raise ValueError("Illegal value `%s' for boolean variable %s" %
-                                 (s, var.name))
+                raise ValueError("Illegal value `{}' for boolean variable {}"
+                                 .format(s, var.name))
             return s
         else:
             try:
                 return value.bool()
             except AttributeError as e:
                 raise AttributeError(var.name + ':' + str(e))
-    raise ValueError("unimplemented type `%s'" % (var.type,))
+    raise ValueError("unimplemented type `{}'".format(var.type))
 
 
 class CheckArgList(GenericASTTraversal, ErrorTracker):
@@ -1491,9 +1491,8 @@ class CheckArgList(GenericASTTraversal, ErrorTracker):
     def n_param_name(self, node):
         keyword = node[0].attr
         if keyword in self.keywords[-1]:
-            self.error(
-                "Duplicate keyword `%s' in call to %s" %
-                (keyword, self.taskname[-1]), node)
+            self.error("Duplicate keyword `{}' in call to {}"
+                       .format(keyword, self.taskname[-1]), node)
         else:
             self.keywords[-1][keyword] = 1
 
@@ -1501,16 +1500,14 @@ class CheckArgList(GenericASTTraversal, ErrorTracker):
         if node[0].type not in [
                 'keyword_arg', 'bool_arg', 'redir_arg', 'non_expr_arg'
         ] and self.keywords[-1]:
-            self.error(
-                "Non-keyword arg after keyword arg in call to %s" %
-                self.taskname[-1], node)
+            self.error("Non-keyword arg after keyword arg in call to {}"
+                       .format(self.taskname[-1]), node)
 
     def n_empty_arg(self, node):
         if self.keywords[-1]:
             # empty args don't have line number, so use task line
-            self.error(
-                "Non-keyword (empty) arg after keyword arg in call to %s" %
-                self.taskname[-1], self.tasknode[-1])
+            self.error("Non-keyword (empty) arg after keyword arg in call to {}"
+                       .format(self.taskname[-1]), self.tasknode[-1])
 
 
 class Tree2Python(GenericASTTraversal, ErrorTracker):
@@ -1552,7 +1549,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
             self.indent = 0
 
         if taskObj and self._ecl_iferr_entered:
-            self.write("taskObj = iraf.getTask('%s')\n" % taskObj)
+            self.write("taskObj = iraf.getTask('{}')\n".format(taskObj))
 
         # analyze goto structure
         # this assigns the label_count field for statement blocks
@@ -1756,12 +1753,12 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
 
         if pyrafglobals._use_ecl:
             self.writeIndent("from pyraf.irafecl import EclState")
-            self.writeIndent("_ecl = EclState(_ecl_linemap_%s)\n" %
-                             self.vars.proc_name)
+            self.writeIndent("_ecl = EclState(_ecl_linemap_{})\n"
+                             .format(self.vars.proc_name))
 
         # write goto label definitions if needed
         for label in self.gotos.labels():
-            self.writeIndent("class GoTo_%s(Exception): pass" % label)
+            self.writeIndent("class GoTo_{}(Exception): pass".format(label))
 
         # decrement indentation (which writes the pass if necessary)
         self.decrIndent()
@@ -1919,9 +1916,9 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         if s in self.vars:
             v = self.vars.get(s)
             if nsub < len(v.shape):
-                self.error("Too few subscripts for array %s" % s, node)
+                self.error("Too few subscripts for array {}".format(s), node)
             elif nsub > len(v.shape):
-                self.error("Too many subscripts for array %s" % s, node)
+                self.error("Too many subscripts for array {}".format(s), node)
         self.prune()
 
     def n_param_name(self, node):
@@ -2011,7 +2008,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
     def n_term(self, node):
         if pyrafglobals._use_ecl and node[1] in ['/', '%']:
             kind = {"/": "divide", "%": "modulo"}[node[1]]
-            self.write("taskObj._ecl_safe_%s(" % kind)
+            self.write("taskObj._ecl_safe_{}(".format(kind))
             self.preorder(node[0])
             self.write(",")
             self.preorder(node[2])
@@ -2226,15 +2223,15 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         label = node[0].attr
         if label in self.gotos:
             self.decrIndent()
-            self.writeIndent("except GoTo_%s:" %
-                             irafutils.translateName(label))
+            self.writeIndent("except GoTo_{}:".format(
+                irafutils.translateName(label)))
             self.incrIndent()
             self.writeIndent("pass")
             self.decrIndent()
         self.prune()
 
     def n_goto_stmt(self, node):
-        self.write("raise GoTo_%s" % irafutils.translateName(node[1].attr))
+        self.write("raise GoTo_{}".format(irafutils.translateName(node[1].attr)))
         self.prune()
 
     def n_inspect_stmt(self, node):
@@ -2254,7 +2251,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
     def n_switch_stmt(self, node):
         self.inSwitch = self.inSwitch + 1
         self.caseCount.append(0)
-        self.write("SwitchVal%d = " % (self.inSwitch,))
+        self.write("SwitchVal{:d} = ".format(self.inSwitch))
         self.preorder(node[2])
         self.preorder(node[4])
         self.inSwitch = self.inSwitch - 1
@@ -2272,7 +2269,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
             self.writeIndent("if ")
         else:
             self.writeIndent("elif ")
-        self.write("SwitchVal%d in [" % (self.inSwitch,))
+        self.write("SwitchVal{:d} in [".format(self.inSwitch))
         self.preorder(node[2])
         self.write("]")
         self.preorder(node[4])

--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -8,18 +8,18 @@ import io
 import os
 import sys
 
-from generic import GenericASTTraversal
-from clast import AST
-from cltoken import Token
-import clscan
-import clparse
-from clcache import codeCache, DISABLE_CLCACHING
+from .generic import GenericASTTraversal
+from .clast import AST
+from .cltoken import Token
+from . import clscan
+from . import clparse
+from .clcache import codeCache, DISABLE_CLCACHING
 
 from stsci.tools.irafglobals import Verbose
 from stsci.tools.for2to3 import PY3K
 from stsci.tools import basicpar, minmatch, irafutils
-import irafpar
-import pyrafglobals
+from . import irafpar
+from . import pyrafglobals
 
 # The parser object can be constructed once and used many times.
 # The other classes have instance variables (e.g. lineno in CLScanner),

--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -2,7 +2,7 @@
 
 R. White, 1999 December 20
 """
-from __future__ import division, print_function
+
 
 import io
 import os

--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -4,7 +4,7 @@ R. White, 1999 December 20
 """
 from __future__ import division, print_function
 
-import cStringIO
+import io
 import os
 import sys
 
@@ -1530,7 +1530,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         # Start with a reasonable size for printPass array.
         # (It gets extended if necessary.)
         self.printPass = [1] * 10
-        self.code_buffer = cStringIO.StringIO()
+        self.code_buffer = io.StringIO()
         self.importDict = {}
         self.specialDict = {}
         self.pipeOut = []
@@ -1578,7 +1578,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         # code.  Now that we have performed the entire translation,
         # we know which of the initialization steps we need.  Stick
         # them on the front of the translated python.
-        self.code_buffer = cStringIO.StringIO()
+        self.code_buffer = io.StringIO()
         self.writeProcHeader()
         header = self.code_buffer.getvalue()
         if pyrafglobals._use_ecl:
@@ -2423,7 +2423,7 @@ class Tree2Python(GenericASTTraversal, ErrorTracker):
         # Also add special character after arguments to make it
         # easier to break up long lines
 
-        arg_buffer = cStringIO.StringIO()
+        arg_buffer = io.StringIO()
         saveColumn = self.column
         saveBuffer = self.code_buffer
         self.code_buffer = arg_buffer

--- a/pyraf/clast.py
+++ b/pyraf/clast.py
@@ -1,6 +1,6 @@
 """clast.py: abstract syntax tree node type for CL parsing
 """
-from __future__ import division, print_function
+
 
 #  Copyright (c) 1998-1999 John Aycock
 #

--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -115,7 +115,7 @@ class _CodeCache:
         """
         # filenames to try, open flags to use
         filelist = [(filename, "w"),
-                    ('%s.%s' % (filename, _currentVersion()), "c")]
+                    ('{}.{}'.format(filename, _currentVersion()), "c")]
         msg = []
         for fname, flag in filelist:
             # first try opening the cache read-write
@@ -129,7 +129,7 @@ class _CodeCache:
                     writeflag = 0
                 except dirshelve.error:
                     # give up on this file and try the next one
-                    msg.append("Unable to open CL script cache %s" % fname)
+                    msg.append("Unable to open CL script cache {}".format(fname))
                     continue
             # check version of cache -- don't use it if version mismatch
             if len(fh) == 0:
@@ -141,17 +141,17 @@ class _CodeCache:
             elif fname.endswith(_currentVersion()):
                 # uh-oh, something is seriously wrong
                 msg.append(
-                    "CL script cache %s has version mismatch, may be corrupt?"
-                    % fname)
+                    "CL script cache {} has version mismatch, may be corrupt?"
+                    .format(fname))
             elif oldVersion > _currentVersion():
                 msg.append(
-                    ("CL script cache %s was created by " +
-                     "a newer version of pyraf (cache %s, this pyraf %s)") %
-                    (fname, repr(oldVersion), repr(_currentVersion())))
+                    ("CL script cache {} was created by "
+                     "a newer version of pyraf (cache {}, this pyraf {})")
+                    .format(fname, repr(oldVersion), repr(_currentVersion())))
             else:
                 msg.append(
-                    "CL script cache %s is obsolete version (old %s, current %s)"
-                    % (fname, repr(oldVersion), repr(_currentVersion())))
+                    "CL script cache {} is obsolete version (old {}, current {})"
+                    .format(fname, repr(oldVersion), repr(_currentVersion())))
             fh.close()
         # failed to open either cache
         self.warning("\n".join(msg))
@@ -273,16 +273,16 @@ class _CodeCache:
             if index in cache:
                 if writeflag:
                     del cache[index]
-                    self.warning(
-                        "Removed %s from CL script cache %s" %
-                        (filename, self.cacheFileList[i]), 2)
+                    self.warning("Removed {} from CL script cache {}"
+                                 .format(filename, self.cacheFileList[i]), 2)
                     nremoved = nremoved + 1
                 else:
-                    self.warning("Cannot remove %s from read-only "
-                                 "CL script cache %s" %
-                                 (filename, self.cacheFileList[i]))
+                    self.warning("Cannot remove {} from read-only "
+                                 "CL script cache {}"
+                                 .format(filename, self.cacheFileList[i]))
         if nremoved == 0:
-            self.warning("Did not find %s in CL script cache" % filename, 2)
+            self.warning("Did not find {} in CL script cache"
+                         .format(filename), 2)
 
 
 # create code cache
@@ -291,9 +291,9 @@ if not os.path.exists(userCacheDir):
     try:
         os.mkdir(userCacheDir)
         if '-s' not in sys.argv and '--silent' not in sys.argv:
-            print('Created directory %s for cache' % userCacheDir)
+            print('Created directory {} for cache'.format(userCacheDir))
     except OSError:
-        print('Could not create directory %s' % userCacheDir)
+        print('Could not create directory {}'.format(userCacheDir))
 
 dbfile = 'clcache'
 

--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -24,13 +24,10 @@ if PY3K or 'PYRAF_NO_CLCACHE' in os.environ:
 
 # set up pickle so it can pickle code objects
 
-import copy_reg
+import copyreg
 import marshal
 import types
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle  # noqa
+import pickle
 
 
 def code_unpickler(data):
@@ -41,7 +38,7 @@ def code_pickler(code):
     return code_unpickler, (marshal.dumps(code),)
 
 
-copy_reg.pickle(types.CodeType, code_pickler, code_unpickler)
+copyreg.pickle(types.CodeType, code_pickler, code_unpickler)
 
 # Code cache is implemented using a dictionary clFileDict and
 # a list of persistent dictionaries (shelves) in cacheList.

--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -13,9 +13,9 @@ if __name__.find('.') < 0:  # for unit test need absolute import
     for mmm in ('filecache', 'pyrafglobals', 'dirshelve'):
         exec('import ' + mmm, globals())  # 2to3 messes up simpler form
 else:
-    import filecache
-    import pyrafglobals
-    import dirshelve
+    from . import filecache
+    from . import pyrafglobals
+    from . import dirshelve
 
 # In case you wish to disable all CL script caching (for whatever reason)
 DISABLE_CLCACHING = False  # enable caching by default

--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -6,7 +6,6 @@ R. White, 2000 January 19
 
 import os
 import sys
-from stsci.tools.for2to3 import PY3K
 from stsci.tools.irafglobals import Verbose, userIrafHome
 
 if __name__.find('.') < 0:  # for unit test need absolute import
@@ -19,7 +18,7 @@ else:
 
 # In case you wish to disable all CL script caching (for whatever reason)
 DISABLE_CLCACHING = False  # enable caching by default
-if PY3K or 'PYRAF_NO_CLCACHE' in os.environ:
+if True or 'PYRAF_NO_CLCACHE' in os.environ:  # Disabled in Python 3 for the moment
     DISABLE_CLCACHING = True
 
 # set up pickle so it can pickle code objects
@@ -204,12 +203,8 @@ class _CodeCache:
             # there is no filename, but return md5 digest of source as key
             h = hashlib.md5()
 
-            if PY3K:  # unicode must be encoded to be hashed
-                h.update(source.encode('ascii'))
-                return str(h.digest())
-            else:
-                h.update(source)
-                return h.digest()
+            h.update(source.encode())
+            return str(h.digest())
 
     def add(self, index, pycode):
         """Add pycode to cache with key = index.  Ignores if index=None."""
@@ -303,7 +298,7 @@ if not os.path.exists(userCacheDir):
 dbfile = 'clcache'
 
 if DISABLE_CLCACHING:
-    # since CL code caching is turned off currently for PY3K,
+    # since CL code caching is turned off currently for Python 3,
     # there won't be any installed there, but still play with user area
     codeCache = _CodeCache([
         os.path.join(userCacheDir, dbfile),

--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -2,7 +2,7 @@
 
 R. White, 2000 January 19
 """
-from __future__ import division, print_function
+
 
 import os
 import sys

--- a/pyraf/cllinecache.py
+++ b/pyraf/cllinecache.py
@@ -20,7 +20,7 @@ def checkcache(filename=None, orig_checkcache=linecache.checkcache):
     cache = linecache.cache
     save = {}
     if filename is None:
-        filenames = cache.keys()
+        filenames = list(cache.keys())
     else:
         if filename in cache:
             filenames = [filename]

--- a/pyraf/cllinecache.py
+++ b/pyraf/cllinecache.py
@@ -78,7 +78,7 @@ def updateCLscript(filename):
     if filename in cache:
         del cache[filename]
     try:
-        import iraf
+        from . import iraf
         taskname = filename[11:-1]
         taskobj = iraf.getTask(taskname)
         fullname = taskobj.getFullpath()

--- a/pyraf/cllinecache.py
+++ b/pyraf/cllinecache.py
@@ -2,7 +2,7 @@
 
 CL scripts have special filename "<CL script taskname>"
 """
-from __future__ import division, print_function
+
 
 import linecache
 import os

--- a/pyraf/clparse.py
+++ b/pyraf/clparse.py
@@ -83,12 +83,12 @@ class CLStrictParser(GenericASTBuilder):
         if hasattr(token, 'lineno'):
             if len(finfo):
                 finfo += ', '
-            errmsg = "CL syntax error at `%s' (%sline %d)" % (token, finfo,
-                                                              token.lineno)
+            errmsg = ("CL syntax error at `{}' ({}line {:d})"
+                      .format(token, finfo, token.lineno))
         else:
             if len(finfo):
                 finfo = '(' + finfo + ')'
-            errmsg = "CL syntax error at `%s' %s" % (token, finfo)
+            errmsg = "CL syntax error at `{}' {}".format(token, finfo)
         if value is not None:
             errmsg = errmsg + "\n" + str(value)
         raise SyntaxError(errmsg)

--- a/pyraf/clparse.py
+++ b/pyraf/clparse.py
@@ -2,7 +2,7 @@
 
 R. White, 1999 August 24
 """
-from __future__ import division, print_function
+
 
 from .generic import GenericASTBuilder, GenericASTTraversal
 from .clast import AST

--- a/pyraf/clparse.py
+++ b/pyraf/clparse.py
@@ -4,9 +4,9 @@ R. White, 1999 August 24
 """
 from __future__ import division, print_function
 
-from generic import GenericASTBuilder, GenericASTTraversal
-from clast import AST
-from cltoken import Token
+from .generic import GenericASTBuilder, GenericASTTraversal
+from .clast import AST
+from .cltoken import Token
 
 
 class CLStrictParser(GenericASTBuilder):
@@ -485,7 +485,7 @@ def treelist(ast, terminal=1):
 
 
 def getParser():
-    import pyrafglobals
+    from . import pyrafglobals
     if pyrafglobals._use_ecl:
         _parser = EclParser(AST)
     else:

--- a/pyraf/clscan.py
+++ b/pyraf/clscan.py
@@ -4,7 +4,7 @@ This version uses a context-sensitive pattern stack
 
 R. White, 1999 September 10
 """
-from __future__ import division, print_function
+
 
 from .cgeneric import ContextSensitiveScanner
 from .generic import GenericScanner

--- a/pyraf/clscan.py
+++ b/pyraf/clscan.py
@@ -6,12 +6,12 @@ R. White, 1999 September 10
 """
 from __future__ import division, print_function
 
-from cgeneric import ContextSensitiveScanner
-from generic import GenericScanner
-from cltoken import Token
+from .cgeneric import ContextSensitiveScanner
+from .generic import GenericScanner
+from .cltoken import Token
 import re
 from stsci.tools import irafutils
-import pyrafglobals
+from . import pyrafglobals
 
 # contexts for scanner
 
@@ -987,7 +987,7 @@ def scan(f):
 
 def toklist(tlist, filename=None):
     # list tokens
-    import cltoken
+    from . import cltoken
     if filename:
         import sys
         sys.stdout = open(filename, 'w')

--- a/pyraf/cltoken.py
+++ b/pyraf/cltoken.py
@@ -1,6 +1,6 @@
 """cltoken.py: Token definition for CL parser
 """
-from __future__ import division, print_function
+
 
 #  Copyright (c) 1998-1999 John Aycock
 #

--- a/pyraf/describe.py
+++ b/pyraf/describe.py
@@ -113,7 +113,7 @@ def describe(func, name=None):
         if isinstance(arg, str):
             args.append(arg)
         else:
-            args.append("%s=%s" % (arg[0], repr(arg[1])))
+            args.append("{}={}".format(arg[0], repr(arg[1])))
     args = ", ".join(args)
 
     # function name
@@ -122,8 +122,8 @@ def describe(func, name=None):
         # name = func.func_name
         name = func.__name__
         if name == "<lambda>":
-            return "lambda %s" % args
-    return "%s(%s)" % (name, args)
+            return "lambda {}".format(args)
+    return "{}({})".format(name, args)
 
 
 def __getmethods(c, m):

--- a/pyraf/describe.py
+++ b/pyraf/describe.py
@@ -110,7 +110,7 @@ def describe(func, name=None):
     a = describeParams(func)
     args = []
     for arg in a:
-        if isinstance(arg, type("")):
+        if isinstance(arg, str):
             args.append(arg)
         else:
             args.append("%s=%s" % (arg[0], repr(arg[1])))

--- a/pyraf/describe.py
+++ b/pyraf/describe.py
@@ -21,7 +21,7 @@
 # http://www.pythonware.com
 #
 
-from __future__ import division, print_function
+
 
 from dis import opname, HAVE_ARGUMENT
 

--- a/pyraf/dirdbm.py
+++ b/pyraf/dirdbm.py
@@ -21,7 +21,7 @@ import builtins
 error = IOError
 
 
-class _Database(object):
+class _Database:
     """Dictionary-like object with entries stored in separate files
 
     Keys and values must be strings.

--- a/pyraf/dirdbm.py
+++ b/pyraf/dirdbm.py
@@ -35,31 +35,22 @@ class _Database:
         if not _os.path.exists(directory):
             if flag == 'c':
                 # create directory if it doesn't exist
-                try:
-                    _os.mkdir(directory)
-                except OSError as e:
-                    raise IOError(str(e))
+                _os.mkdir(directory)
             else:
-                raise IOError("Directory " + directory + " does not exist")
+                raise OSError("Directory " + directory + " does not exist")
         elif not _os.path.isdir(directory):
-            raise IOError("File " + directory + " is not a directory")
+            raise OSError("File " + directory + " is not a directory")
         elif self._writable:
             # make sure directory is writable
-            try:
-                testfile = _os.path.join(directory,
-                                         'junk' + repr(_os.getpid()))
-                fh = builtins.open(testfile, 'w')
-                fh.close()
-                _os.remove(testfile)
-            except IOError:
-                raise IOError("Directory %s cannot be opened for writing" %
-                              (directory,))
+            testfile = _os.path.join(directory,
+                                     'junk' + repr(_os.getpid()))
+            fh = builtins.open(testfile, 'w')
+            fh.close()
+            _os.remove(testfile)
+
         # initialize dictionary
         # get list of files from directory and translate to keys
-        try:
-            flist = _os.listdir(self._directory)
-        except OSError:
-            raise IOError("Directory " + directory + " is not readable")
+        flist = _os.listdir(self._directory)
         for fname in flist:
             # replace hyphens and add newline in base64
             key = fname.replace('-', '/') + '\n'
@@ -90,7 +81,7 @@ class _Database:
             # cache object in memory
             self._dict[key] = value
             return value
-        except IOError:
+        except OSError:
             raise KeyError(key)
 
     def __setitem__(self, key, value):
@@ -102,12 +93,12 @@ class _Database:
                 fh = builtins.open(fname, 'wb')
                 fh.write(value)
                 fh.close()
-            except IOError as e:
+            except OSError as e:
                 # clean up on IO error (e.g., if disk fills up)
                 try:
                     if _os.path.exists(fname):
                         _os.remove(fname)
-                except IOError:
+                except OSError:
                     pass
                 raise e
 

--- a/pyraf/dirdbm.py
+++ b/pyraf/dirdbm.py
@@ -11,7 +11,7 @@ XXX keys, len are incomplete if directory is not writable?
 R. White, 2000 September 26
 """
 
-from __future__ import division, print_function
+
 
 import os as _os
 import binascii as _binascii

--- a/pyraf/dirdbm.py
+++ b/pyraf/dirdbm.py
@@ -15,7 +15,7 @@ from __future__ import division, print_function
 
 import os as _os
 import binascii as _binascii
-import __builtin__
+import builtins
 
 # For anydbm
 error = IOError
@@ -48,7 +48,7 @@ class _Database(object):
             try:
                 testfile = _os.path.join(directory,
                                          'junk' + repr(_os.getpid()))
-                fh = __builtin__.open(testfile, 'w')
+                fh = builtins.open(testfile, 'w')
                 fh.close()
                 _os.remove(testfile)
             except IOError:
@@ -84,7 +84,7 @@ class _Database(object):
         # look for file even if dict doesn't have key because
         # another process could create it
         try:
-            fh = __builtin__.open(self._getFilename(key), 'rb')
+            fh = builtins.open(self._getFilename(key), 'rb')
             value = fh.read()
             fh.close()
             # cache object in memory
@@ -99,7 +99,7 @@ class _Database(object):
         if self._writable:
             try:
                 fname = self._getFilename(key)
-                fh = __builtin__.open(fname, 'wb')
+                fh = builtins.open(fname, 'wb')
                 fh.write(value)
                 fh.close()
             except IOError as e:

--- a/pyraf/dirshelve.py
+++ b/pyraf/dirshelve.py
@@ -13,7 +13,6 @@ R. White, 2000 Sept 26
 
 
 import shelve
-from stsci.tools.for2to3 import PY3K
 
 if __name__.find('.') < 0:  # for unit test need absolute import
     exec('import dirdbm', globals())  # 2to3 messes up simpler form
@@ -75,10 +74,7 @@ def open(filename, flag='c'):
            'n'     Always create a new, empty db, open for reading and writing
     """
 
-    if PY3K:
-        try:
-            return shelve.DbfilenameShelf(filename, flag)
-        except Exception as ex:  # is dbm.error
-            raise dirdbm.error(str(ex))
-    else:
-        return DirectoryShelf(filename, flag)
+    try:
+        return shelve.DbfilenameShelf(filename, flag)
+    except Exception as ex:  # is dbm.error
+        raise dirdbm.error(str(ex))

--- a/pyraf/dirshelve.py
+++ b/pyraf/dirshelve.py
@@ -10,7 +10,7 @@ XXX by another process after open
 R. White, 2000 Sept 26
 """
 
-from __future__ import division, print_function
+
 
 import shelve
 from stsci.tools.for2to3 import PY3K

--- a/pyraf/dirshelve.py
+++ b/pyraf/dirshelve.py
@@ -18,7 +18,7 @@ from stsci.tools.for2to3 import PY3K
 if __name__.find('.') < 0:  # for unit test need absolute import
     exec('import dirdbm', globals())  # 2to3 messes up simpler form
 else:
-    import dirdbm
+    from . import dirdbm
 
 # tuple of errors that can be raised
 error = (dirdbm.error,)

--- a/pyraf/dirshelve.py
+++ b/pyraf/dirshelve.py
@@ -34,8 +34,8 @@ class Shelf(shelve.Shelf):
             # apparently file is truncated; delete it and raise
             # and exception
             del self.dict[key]
-            raise KeyError("Corrupted or truncated file for key %s "
-                           "(bad file has been deleted)" % (repr(key),))
+            raise KeyError("Corrupted or truncated file for key {} "
+                           "(bad file has been deleted)".format(repr(key)))
 
     def __setitem__(self, key, value):
         f = shelve.StringIO()

--- a/pyraf/epar.py
+++ b/pyraf/epar.py
@@ -2,7 +2,7 @@
 
 M.D. De La Pena, 2000 February 04
 """
-from __future__ import division, print_function
+
 
 from stsci.tools import capable
 if capable.OF_GRAPHICS:

--- a/pyraf/epar.py
+++ b/pyraf/epar.py
@@ -8,7 +8,7 @@ from stsci.tools import capable
 if capable.OF_GRAPHICS:
     from Tkinter.tkMessageBox import askokcancel, showwarning, showerror
     import os
-    import cStringIO
+    import io
     from stsci.tools import listdlg, eparoption, editpar, irafutils
     import iraf
     import irafpar
@@ -346,7 +346,7 @@ class PyrafEparDialog(editpar.EditParDialog):
     def getHelpString(self, taskname):
         """ Override this - in PyRAF we'll always use use iraf system help.
             Do not query the task object. """
-        fh = cStringIO.StringIO()
+        fh = io.StringIO()
         iraf.system.help(taskname, page=0, Stdout=fh, Stderr=fh)
         result = fh.getvalue()
         fh.close()

--- a/pyraf/epar.py
+++ b/pyraf/epar.py
@@ -10,11 +10,11 @@ if capable.OF_GRAPHICS:
     import os
     import io
     from stsci.tools import listdlg, eparoption, editpar, irafutils
-    import iraf
-    import irafpar
-    import irafhelp
-    import wutil
-    from pyrafglobals import pyrafDir
+    from . import iraf
+    from . import irafpar
+    from . import irafhelp
+    from . import wutil
+    from .pyrafglobals import pyrafDir
 else:
     wutil = None
 
@@ -266,7 +266,7 @@ class PyrafEparDialog(editpar.EditParDialog):
         """ Override to allow use of PsetEparOption.
             Return None or a class which derives from EparOption. """
         if paramTypeStr == "pset":
-            import pseteparoption
+            from . import pseteparoption
             return pseteparoption.PsetEparOption
         else:
             return None

--- a/pyraf/epar.py
+++ b/pyraf/epar.py
@@ -225,7 +225,7 @@ class PyrafEparDialog(editpar.EditParDialog):
                     irafutils.setWritePrivs(filename, True)
                 retval = self._taskParsObj.saveParList(filename=filename,
                                                        comment=comment)
-            except IOError:
+            except OSError:
                 retval = "Error saving to " + str(
                     filename) + ".  Please check privileges."
                 showerror(message=retval, title='Error Saving File')

--- a/pyraf/filecache.py
+++ b/pyraf/filecache.py
@@ -96,7 +96,7 @@ class FileCache:
         if filename is None:
             filename = self.filename
         if isinstance(filename, str):
-            fh = open(filename, 'r')
+            fh = open(filename)
         elif hasattr(filename, 'read'):
             fh = filename
             if hasattr(filename, 'seek'):

--- a/pyraf/filecache.py
+++ b/pyraf/filecache.py
@@ -81,9 +81,9 @@ class FileCache:
             if oldattr != newattr:
                 if oldattr[1] > newattr[1] or oldattr[2] > newattr[2]:
                     # warning if current file appears older than cached version
-                    self._warning("Warning: current version of file %s"
-                                  " is older than cached version" %
-                                  self.filename)
+                    self._warning("Warning: current version of file {}"
+                                  " is older than cached version"
+                                  .format(self.filename))
                 self.updateValue()
                 self.attributes = newattr
         return self.getValue()

--- a/pyraf/filecache.py
+++ b/pyraf/filecache.py
@@ -26,7 +26,7 @@ index (cachedict[filename]) or using the .get() method.
 
 R. White, 2000 October 1
 """
-from __future__ import division, print_function
+
 
 import os
 import stat

--- a/pyraf/filecache.py
+++ b/pyraf/filecache.py
@@ -27,12 +27,10 @@ index (cachedict[filename]) or using the .get() method.
 R. White, 2000 October 1
 """
 
-
 import os
 import stat
 import sys
 import hashlib
-from stsci.tools.for2to3 import PY3K
 
 
 class FileCache:
@@ -144,15 +142,11 @@ class MD5Cache(FileCache):
     def updateValue(self):
         """Called when file has changed."""
 
-        contents = self._getFileHandle().read()  # is unicode str in PY3K
+        contents = self._getFileHandle().read()
         # md5 digest is the value associated with the file
         h = hashlib.md5()
-        if PY3K:  # unicode must be encoded to be hashed
-            h.update(contents.encode('ascii'))
-            self.value = str(h.digest())
-        else:
-            h.update(contents)
-            self.value = h.digest()
+        h.update(contents.encode())
+        self.value = str(h.digest())
 
 
 class FileCacheDict:

--- a/pyraf/fontdata.py
+++ b/pyraf/fontdata.py
@@ -1,6 +1,6 @@
 """fontdata.py
 """
-from __future__ import division, print_function
+
 
 from numpy import int8, array
 

--- a/pyraf/generic.py
+++ b/pyraf/generic.py
@@ -38,7 +38,7 @@ from __future__ import division, print_function
 __version__ = 'SPARK-0.6.1rlw'
 
 import re
-import cltoken
+from . import cltoken
 
 
 def _namelist(instance):

--- a/pyraf/generic.py
+++ b/pyraf/generic.py
@@ -69,7 +69,7 @@ class GenericScanner:
 
     def makeRE(self, name):
         doc = getattr(self, name).__doc__
-        rv = '(?P<%s>%s)' % (name[2:], doc)
+        rv = '(?P<{}>{})'.format(name[2:], doc)
         return rv
 
     def reflect(self):
@@ -82,7 +82,7 @@ class GenericScanner:
         return '|'.join(rv)
 
     def error(self, s, pos):
-        print("Lexical error at position %s" % pos)
+        print("Lexical error at position {}".format(pos))
         raise SystemExit()
 
     def tokenize(self, s):
@@ -272,7 +272,7 @@ class GenericParser:
         return None
 
     def error(self, token, value=None):
-        print("Syntax error at or near `%s' token" % token)
+        print("Syntax error at or near `{}' token".format(token))
         if value is not None:
             print(str(value))
         raise SystemExit()

--- a/pyraf/generic.py
+++ b/pyraf/generic.py
@@ -33,7 +33,7 @@
 # - Add optional value parameter to GenericParser.error.
 # - Add check for assertion error in ambiguity resolution.
 
-from __future__ import division, print_function
+
 
 __version__ = 'SPARK-0.6.1rlw'
 

--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -43,11 +43,11 @@ import sys
 import re
 from stsci.tools.irafglobals import IrafError
 from stsci.tools.for2to3 import ndarr2str, ndarr2bytes
-import wutil
-import graphcap
-import irafgwcs
-import fontdata
-from textattrib import (CHARPATH_RIGHT, JUSTIFIED_NORMAL, FONT_ROMAN,
+from . import wutil
+from . import graphcap
+from . import irafgwcs
+from . import fontdata
+from .textattrib import (CHARPATH_RIGHT, JUSTIFIED_NORMAL, FONT_ROMAN,
                         FQUALITY_NORMAL)
 
 # use this form since the iraf import is circular
@@ -998,13 +998,13 @@ class GkiController(GkiProxy):
                 # open (persistent) interactive kernel
                 if not self.interactiveKernel:
                     if wutil.hasGraphics:
-                        import gwm
+                        from . import gwm
                         self.interactiveKernel = gwm.getGraphicsWindowManager()
                     else:
                         self.interactiveKernel = GkiNull()
                 self.stdgraph = self.interactiveKernel
             else:
-                import gkiiraf
+                from . import gkiiraf
                 self.stdgraph = gkiiraf.GkiIrafKernel(device)
             self.stdin = self.stdgraph.stdin
             self.stdout = self.stdgraph.stdout
@@ -1253,8 +1253,8 @@ def printPlot(window=None):
     """Print contents of window (default active window) to stdplot
     window must be a GkiKernel object (with a gkibuffer attribute.)
     """
-    import gwm
-    import gkiiraf
+    from . import gwm
+    from . import gkiiraf
     if window is None:
         window = gwm.getActiveGraphicsWindow()
         if window is None:
@@ -1639,7 +1639,7 @@ kernel = GkiController()
 # Beware! This is highly experimental and was made only for a test case.
 def _resetGraphicsKernel():
     global kernel
-    import gwm
+    from . import gwm
     if kernel:
         kernel.clearReturnData()
         kernel.flush()

--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -36,7 +36,7 @@ GkiController is a GkiProxy that allows switching between different
 graphics kernels as directed by commands embedded in the metacode stream.
 
 """
-from __future__ import division, print_function
+
 
 import numpy
 import sys

--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -42,7 +42,6 @@ import numpy
 import sys
 import re
 from stsci.tools.irafglobals import IrafError
-from stsci.tools.for2to3 import ndarr2str, ndarr2bytes
 from . import wutil
 from . import graphcap
 from . import irafgwcs
@@ -976,8 +975,7 @@ class GkiController(GkiProxy):
         return self.stdgraph.control(gkiMetacode)
 
     def control_openws(self, arg):
-
-        device = ndarr2str(arg[2:].astype(numpy.int8)).strip()
+        device = arg[2:].astype(numpy.int8).tobytes().decode().strip()
         self.openKernel(device)
 
     def openKernel(self, device=None):
@@ -1096,7 +1094,7 @@ class GkiRedirection(GkiKernel):
     def append(self, metacode):
         # Overloads the baseclass implementation.
         # metacode is array of 16-bit ints
-        self.filehandle.write(ndarr2bytes(metacode))
+        self.filehandle.write(metacode.tobytes())
 
     # control needs to get and set WCS data
     def control_setwcs(self, arg):

--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -546,9 +546,10 @@ class GkiKernel:
             if not value:
                 badlist.append(name)
         if badlist:
-            raise SyntaxError("Bug: error in definition of class %s\n"
-                              "Special method name is incorrect: %s" %
-                              (self.__class__.__name__, " ".join(badlist)))
+            raise SyntaxError("Bug: error in definition of class {}\n"
+                              "Special method name is incorrect: {}"
+                              .format(self.__class__.__name__,
+                                      " ".join(badlist)))
 
     def control(self, gkiMetacode):
         gkiTranslate(gkiMetacode, self.controlFunctionTable)
@@ -1023,8 +1024,8 @@ class GkiController(GkiProxy):
             devstr = pyraf.iraf.envget(pdevstr, "")
             if not devstr:
                 raise IrafError(
-                    "No entry found for specified stdgraph device `%s'" %
-                    device)
+                    "No entry found for specified stdgraph device `{}'"
+                    .format(device))
             elif devstr in tried:
                 # track back through circular definition
                 s = [devstr]
@@ -1035,9 +1036,8 @@ class GkiController(GkiProxy):
                 if next:
                     s.append(next)
                 s.reverse()
-                raise IrafError(
-                    "Circular definition in graphcap for device\n%s" %
-                    ' -> '.join(s))
+                raise IrafError("Circular definition in graphcap for device\n{}"
+                                .format(' -> '.join(s)))
             else:
                 tried[devstr] = pdevstr
         return devstr
@@ -1264,14 +1264,14 @@ def printPlot(window=None):
         if not stdplot:
             msg = "No hardcopy device defined in stdplot"
         elif stdplot not in graphcap:
-            msg = "Unknown hardcopy device stdplot=`%s'" % stdplot
+            msg = "Unknown hardcopy device stdplot=`{}'".format(stdplot)
         else:
             printer = gkiiraf.GkiIrafKernel(stdplot)
             printer.append(gkibuff)
             printer.flush()
             msg = "snap completed"
     stdout = kernel.getStdout(default=sys.stdout)
-    stdout.write("%s\n" % msg)
+    stdout.write("{}\n".format(msg))
 
 
 # **********************************************************************
@@ -1338,8 +1338,8 @@ class IrafGkiConfig:
         ]
         self.cursorColor = 2  # red
         if len(self.defaultColors) != nIrafColors:
-            raise ValueError("defaultColors should have %d elements (has %d)" %
-                             (nIrafColors, len(self.defaultColors)))
+            raise ValueError("defaultColors should have {:d} elements (has {:d})"
+                             .format(nIrafColors, len(self.defaultColors)))
 
         # old colors
         #       (1.,0.5,0.),      # coral
@@ -1353,8 +1353,8 @@ class IrafGkiConfig:
 
     def setCursorColor(self, color):
         if not 0 <= color < len(self.defaultColors):
-            raise ValueError("Bad cursor color (%d) should be >=0 and <%d" %
-                             (color, len(self.defaultColors) - 1))
+            raise ValueError("Bad cursor color ({:d}) should be >=0 and <{:d}"
+                             .format(color, len(self.defaultColors) - 1))
         self.cursorColor = color
 
     def fontSize(self, gwidget):

--- a/pyraf/gkicmd.py
+++ b/pyraf/gkicmd.py
@@ -3,8 +3,8 @@ iraf gki metacode (primarily for interactive graphics)"""
 
 from __future__ import division, print_function
 
-import gki
-import gwm
+from . import gki
+from . import gwm
 import numpy
 
 

--- a/pyraf/gkicmd.py
+++ b/pyraf/gkicmd.py
@@ -17,7 +17,7 @@ def text(textstring, x, y):
     """Return metacode for text string written at x,y"""
     gkiX = gkiCoord(x)
     gkiY = gkiCoord(y)
-    data = numpy.fromstring(textstring, numpy.int8)  # OK if str or uni
+    data = numpy.frombuffer(textstring.encode('ascii'), numpy.int8)
     data = data.astype(numpy.int16)
     size = 6 + len(textstring)
     metacode = numpy.zeros(size, numpy.int16)

--- a/pyraf/gkicmd.py
+++ b/pyraf/gkicmd.py
@@ -1,7 +1,7 @@
 """gki metacode generating functions for use by Pyraf in generating
 iraf gki metacode (primarily for interactive graphics)"""
 
-from __future__ import division, print_function
+
 
 from . import gki
 from . import gwm

--- a/pyraf/gkigcur.py
+++ b/pyraf/gkigcur.py
@@ -4,7 +4,7 @@ implement IRAF gcur functionality
 from __future__ import division, print_function
 
 import sys
-import Tkinter as TKNTR
+import tkinter
 from stsci.tools import irafutils
 import wutil
 
@@ -54,7 +54,7 @@ class Gcursor:
                 self.active = 0
                 self.unbind()
                 self.cursorOff()
-            except TKNTR.TclError:
+            except tkinter.TclError:
                 pass
         # EOF flag can get set by window-close event or 'I' keystroke
         # It should be set to string message

--- a/pyraf/gkigcur.py
+++ b/pyraf/gkigcur.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function
 import sys
 import tkinter
 from stsci.tools import irafutils
-import wutil
+from . import wutil
 
 # The following class attempts to emulate the standard IRAF gcursor
 # mode of operation. That is to say, it is basically a keyboard driven
@@ -192,7 +192,7 @@ class Gcursor:
 
     def getKey(self, event):
 
-        import gkicmd
+        from . import gkicmd
         # The main character handling routine where no special keys
         # are used (e.g., arrow keys)
         key = event.char
@@ -228,7 +228,7 @@ class Gcursor:
                     self._setRetString(key, x, y, colonString)
         elif key == '=':
             # snap command - print the plot
-            import gki
+            from . import gki
             gki.printPlot(self.window)
         elif key.isupper():
             if key == 'I':

--- a/pyraf/gkigcur.py
+++ b/pyraf/gkigcur.py
@@ -222,8 +222,8 @@ class Gcursor:
                     elif colonString[1:] == 'markcur':
                         self.markcur = not self.markcur
                     else:
-                        self.writeString("Unimplemented CL gcur `:%s'" %
-                                         colonString)
+                        self.writeString("Unimplemented CL gcur `:{}'"
+                                         .format(colonString))
                 else:
                     self._setRetString(key, x, y, colonString)
         elif key == '=':
@@ -247,9 +247,10 @@ class Gcursor:
                 self.window.undoN()
             elif key == 'C':
                 wx, wy, gwcs = self._convertXY(x, y)
-                self.writeString("%g %g" % (wx, wy))
+                self.writeString("{:g} {:g}".format(wx, wy))
             else:
-                self.writeString("Unimplemented CL gcur command `%s'" % key)
+                self.writeString("Unimplemented CL gcur command `{}'"
+                                 .format(key))
         else:
             self._setRetString(key, x, y, "")
 
@@ -269,7 +270,7 @@ class Gcursor:
 
         wx, wy, gwcs = self._convertXY(x, y)
         if key <= ' ' or ord(key) >= 127:
-            key = '\\%03o' % ord(key)
+            key = '\\{:03o}'.format(ord(key))
         self.retString = str(wx) + ' ' + str(wy) + ' ' + str(gwcs) + ' ' + key
         if colonString:
             self.retString = self.retString + ' ' + colonString

--- a/pyraf/gkigcur.py
+++ b/pyraf/gkigcur.py
@@ -1,7 +1,7 @@
 """
 implement IRAF gcur functionality
 """
-from __future__ import division, print_function
+
 
 import sys
 import tkinter

--- a/pyraf/gkiiraf.py
+++ b/pyraf/gkiiraf.py
@@ -6,10 +6,10 @@ from __future__ import division, print_function
 import sys
 import os
 from stsci.tools.for2to3 import ndarr2bytes
-import gki
-import irafgwcs
-import iraftask
-import iraf
+from . import gki
+from . import irafgwcs
+from . import iraftask
+from . import iraf
 
 # kernels to flush frequently
 # imdkern does not erase, so always flush it
@@ -27,7 +27,7 @@ class GkiIrafKernel(gki.GkiKernel):
 
     def __init__(self, device):
 
-        import irafecl
+        from . import irafecl
         module = irafecl.getTaskModule()
 
         gki.GkiKernel.__init__(self)

--- a/pyraf/gkiiraf.py
+++ b/pyraf/gkiiraf.py
@@ -33,7 +33,8 @@ class GkiIrafKernel(gki.GkiKernel):
         graphcap = gki.getGraphcap()
         if device not in graphcap:
             raise iraf.IrafError(
-                "No entry found for specified stdgraph device `%s'" % device)
+                "No entry found for specified stdgraph device `{}'"
+                .format(device))
         gentry = graphcap[device]
         self.device = device
         self.executable = executable = gentry['kf']

--- a/pyraf/gkiiraf.py
+++ b/pyraf/gkiiraf.py
@@ -1,7 +1,7 @@
 """
 OpenGL implementation of the gki kernel class
 """
-from __future__ import division, print_function
+
 
 import sys
 import os

--- a/pyraf/gkiiraf.py
+++ b/pyraf/gkiiraf.py
@@ -5,7 +5,6 @@ OpenGL implementation of the gki kernel class
 
 import sys
 import os
-from stsci.tools.for2to3 import ndarr2bytes
 from . import gki
 from . import irafgwcs
 from . import iraftask
@@ -75,7 +74,7 @@ class GkiIrafKernel(gki.GkiKernel):
 
     def flush(self):
         # grab last part of buffer and delete it
-        metacode = ndarr2bytes(self.gkibuffer.delget())
+        metacode = self.gkibuffer.delget().tobytes()
         # only plot if buffer contains something
         if metacode:
             # write to a temporary file

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -7,7 +7,7 @@ import numpy
 import os
 import sys
 import time
-import Tkinter as TKNTR  # requires 2to3
+import tkinter
 import msgiobuffer
 import msgiowidget
 import wutil
@@ -17,9 +17,9 @@ from stsci.tools.for2to3 import ndarr2bytes
 import gki
 import irafgwcs
 from pyrafglobals import pyrafDir
-import tkFileDialog
-import tkMessageBox
-import tkSimpleDialog
+import tkinter.filedialog
+import tkinter.messagebox
+import tkinter.simpledialog
 
 nIrafColors = 16
 
@@ -182,16 +182,16 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         # Create the root window as required, but hide it
         irafutils.init_tk_default_root()
         # note size is just an estimate that helps window manager place window
-        self.top = TKNTR.Toplevel(visual='best', width=600, height=485)
+        self.top = tkinter.Toplevel(visual='best', width=600, height=485)
         # Read the epar options database file
         optfile = "epar.optionDB"
         try:
             self.top.option_readfile(os.path.join(os.curdir, optfile))
-        except TKNTR.TclError:
+        except tkinter.TclError:
             try:
                 self.top.option_readfile(os.path.join(userWorkingHome,
                                                       optfile))
-            except TKNTR.TclError:
+            except tkinter.TclError:
                 self.top.option_readfile(os.path.join(pyrafDir, optfile))
         self.top.title(windowName)
         self.top.iconname(windowName)
@@ -200,7 +200,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         self.makeGWidget()
         self.makeStatus()
         self.gwidget.redraw = self.redraw
-        self.gwidget.pack(side=TKNTR.TOP, expand=1, fill=TKNTR.BOTH)
+        self.gwidget.pack(side=tkinter.TOP, expand=1, fill=tkinter.BOTH)
         self.gwidget.bind('<Enter>', self.focusOnGwidget)  # if mouse enters gw
 
         self.colorManager.setColors(self.gwidget)
@@ -216,13 +216,13 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         self.history = [(self.gkibuffer, self.wcs, "", self.getHistory())]
         self._currentPage = 0
         # Master page variable, pageVar, any change to it is watched & acted on
-        self.pageVar = TKNTR.IntVar()
+        self.pageVar = tkinter.IntVar()
         self.pageVar.set(self._currentPage)
         # _setPageVar is callback for changes to pageVar
         self.pageVar.trace('w', self._setPageVar)
         # Also hold a var just for the # of the selected page button: bttnVar
         # This one causes no events when it is set!
-        self.bttnVar = TKNTR.IntVar()
+        self.bttnVar = tkinter.IntVar()
         self.bttnVar.set(0)
         windowID = self.gwidget.winfo_id()
         self.flush()
@@ -244,10 +244,10 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
         if 'PYRAF_OLD_STATUS' in os.environ:
             self.top.status = msgiobuffer.MsgIOBuffer(self.top, width=600)
-            self.top.status.msgIO.pack(side=TKNTR.BOTTOM, fill=TKNTR.X)
+            self.top.status.msgIO.pack(side=tkinter.BOTTOM, fill=tkinter.X)
         else:
             self.top.status = msgiowidget.MsgIOWidget(self.top, width=600)
-            self.top.status.pack(side=TKNTR.BOTTOM, fill=TKNTR.X)
+            self.top.status.pack(side=tkinter.BOTTOM, fill=tkinter.X)
 
     # -----------------------------------------------
     # Menu bar definitions
@@ -255,19 +255,19 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
     def makeMenuBar(self):
         """Make menu bar at top of window"""
 
-        self.menubar = TKNTR.Frame(self.top, bd=1, relief=TKNTR.FLAT)
+        self.menubar = tkinter.Frame(self.top, bd=1, relief=tkinter.FLAT)
         self.fileMenu = self.makeFileMenu(self.menubar)
         self.editMenu = self.makeEditMenu(self.menubar)
         self.pageMenu = self.makePageMenu(self.menubar)
         self.windowMenu = self.makeWindowMenu(self.menubar)
         self.helpMenu = self.makeHelpMenu(self.menubar)
-        self.menubar.pack(side=TKNTR.TOP, fill=TKNTR.X)
+        self.menubar.pack(side=tkinter.TOP, fill=tkinter.X)
 
     def makeFileMenu(self, menubar):
 
-        button = TKNTR.Menubutton(menubar, text='File')
-        button.pack(side=TKNTR.LEFT, padx=2)
-        button.menu = TKNTR.Menu(button, tearoff=0)
+        button = tkinter.Menubutton(menubar, text='File')
+        button.pack(side=tkinter.LEFT, padx=2)
+        button.menu = tkinter.Menu(button, tearoff=0)
         button.menu.add_command(label="Print", command=self.doprint)
         button.menu.add_command(label="Save...", command=self.save)
         button.menu.add_command(label="Load...", command=self.load)
@@ -289,7 +289,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         """Save metacode in a file"""
         curdir = os.getcwd()
         if capable.OF_TKFD_IN_EPAR:
-            fname = tkFileDialog.asksaveasfilename(parent=self.top,
+            fname = tkinter.filedialog.asksaveasfilename(parent=self.top,
                                                    title="Save Metacode")
         else:
             fd = filedlg.PersistSaveFileDialog(self.top, "Save Metacode", "*")
@@ -311,7 +311,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
         if not fname:
             if capable.OF_TKFD_IN_EPAR:
-                fname = tkFileDialog.askopenfilename(parent=self.top,
+                fname = tkinter.filedialog.askopenfilename(parent=self.top,
                                                      title="Load Metacode")
             else:
                 fd = filedlg.PersistLoadFileDialog(self.top, "Load Metacode",
@@ -338,9 +338,9 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def makeEditMenu(self, menubar):
 
-        button = TKNTR.Menubutton(menubar, text='Edit')
-        button.pack(side=TKNTR.LEFT, padx=2)
-        button.menu = TKNTR.Menu(button,
+        button = tkinter.Menubutton(menubar, text='Edit')
+        button.pack(side=tkinter.LEFT, padx=2)
+        button.menu = tkinter.Menu(button,
                                  tearoff=0,
                                  postcommand=self.editMenuInit)
         num = 0
@@ -387,32 +387,32 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         buffer = self.getBuffer()
         if buffer.isUndoable():
             self.editMenu.menu.entryconfigure(button.undoNum,
-                                              state=TKNTR.NORMAL)
+                                              state=tkinter.NORMAL)
             self.editMenu.menu.entryconfigure(button.redrawOriginalNum,
-                                              state=TKNTR.NORMAL)
+                                              state=tkinter.NORMAL)
         else:
             self.editMenu.menu.entryconfigure(button.undoNum,
-                                              state=TKNTR.DISABLED)
+                                              state=tkinter.DISABLED)
             self.editMenu.menu.entryconfigure(button.redrawOriginalNum,
-                                              state=TKNTR.DISABLED)
+                                              state=tkinter.DISABLED)
         # disable Redo item if not redoable
         if buffer.isRedoable():
             self.editMenu.menu.entryconfigure(button.redoNum,
-                                              state=TKNTR.NORMAL)
+                                              state=tkinter.NORMAL)
         else:
             self.editMenu.menu.entryconfigure(button.redoNum,
-                                              state=TKNTR.DISABLED)
+                                              state=tkinter.DISABLED)
         # disable Delete items if no plots
         if len(self.history) == 1 and self.isPageBlank():
             self.editMenu.menu.entryconfigure(button.deleteNum,
-                                              state=TKNTR.DISABLED)
+                                              state=tkinter.DISABLED)
             self.editMenu.menu.entryconfigure(button.deleteAllNum,
-                                              state=TKNTR.DISABLED)
+                                              state=tkinter.DISABLED)
         else:
             self.editMenu.menu.entryconfigure(button.deleteNum,
-                                              state=TKNTR.NORMAL)
+                                              state=tkinter.NORMAL)
             self.editMenu.menu.entryconfigure(button.deleteAllNum,
-                                              state=TKNTR.NORMAL)
+                                              state=tkinter.NORMAL)
 
     def deletePlot(self):
 
@@ -433,7 +433,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def deleteAllPlots(self):
 
-        if tkMessageBox.askokcancel("", "Delete all plots?"):
+        if tkinter.messagebox.askokcancel("", "Delete all plots?"):
             del self.history[:]
             # clear all buffers and put them back on the history
             self.gkibuffer.reset()
@@ -447,9 +447,9 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def makePageMenu(self, menubar):
 
-        button = TKNTR.Menubutton(menubar, text='Page')
-        button.pack(side=TKNTR.LEFT, padx=2)
-        button.menu = TKNTR.Menu(button,
+        button = tkinter.Menubutton(menubar, text='Page')
+        button.pack(side=tkinter.LEFT, padx=2)
+        button.menu = tkinter.Menu(button,
                                  tearoff=1,
                                  postcommand=self.pageMenuInit)
         num = 1  # tearoff is entry 0 on menu
@@ -480,24 +480,24 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         page = self._currentPage
         # Next
         if page < len(self.history) - 1:
-            menu.entryconfigure(button.nextNum, state=TKNTR.NORMAL)
+            menu.entryconfigure(button.nextNum, state=tkinter.NORMAL)
         else:
-            menu.entryconfigure(button.nextNum, state=TKNTR.DISABLED)
+            menu.entryconfigure(button.nextNum, state=tkinter.DISABLED)
         # Back
         if page > 0:
-            menu.entryconfigure(button.backNum, state=TKNTR.NORMAL)
+            menu.entryconfigure(button.backNum, state=tkinter.NORMAL)
         else:
-            menu.entryconfigure(button.backNum, state=TKNTR.DISABLED)
+            menu.entryconfigure(button.backNum, state=tkinter.DISABLED)
         # First
         if page > 0:
-            menu.entryconfigure(button.firstNum, state=TKNTR.NORMAL)
+            menu.entryconfigure(button.firstNum, state=tkinter.NORMAL)
         else:
-            menu.entryconfigure(button.firstNum, state=TKNTR.DISABLED)
+            menu.entryconfigure(button.firstNum, state=tkinter.DISABLED)
         # Last
         if page < len(self.history) - 1:
-            menu.entryconfigure(button.lastNum, state=TKNTR.NORMAL)
+            menu.entryconfigure(button.lastNum, state=tkinter.NORMAL)
         else:
-            menu.entryconfigure(button.lastNum, state=TKNTR.DISABLED)
+            menu.entryconfigure(button.lastNum, state=tkinter.DISABLED)
         # Delete everything past the separator
         menu.delete(str(button.sepNum), '10000')
         menu.add_separator()
@@ -583,9 +583,9 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def makeWindowMenu(self, menubar):
 
-        button = TKNTR.Menubutton(menubar, text='Window')
-        button.pack(side=TKNTR.LEFT, padx=2)
-        button.menu = TKNTR.Menu(button,
+        button = tkinter.Menubutton(menubar, text='Window')
+        button.pack(side=tkinter.LEFT, padx=2)
+        button.menu = tkinter.Menu(button,
                                  tearoff=0,
                                  postcommand=self.windowMenuInit)
         button.menu.add_command(label="New...", command=self.createNewWindow)
@@ -611,7 +611,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def createNewWindow(self):
 
-        newname = tkSimpleDialog.askstring(
+        newname = tkinter.simpledialog.askstring(
             "New Graphics Window",
             "Name of new graphics window",
             initialvalue=self.manager.getNewWindowName())
@@ -620,9 +620,9 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def makeHelpMenu(self, menubar):
 
-        button = TKNTR.Menubutton(menubar, text='Help')
-        button.pack(side=TKNTR.RIGHT, padx=2)
-        button.menu = TKNTR.Menu(button, tearoff=0)
+        button = tkinter.Menubutton(menubar, text='Help')
+        button.pack(side=tkinter.RIGHT, padx=2)
+        button.menu = tkinter.Menu(button, tearoff=0)
         button.menu.add_command(label="Help...", command=self.getHelp)
         button["menu"] = button.menu
         return button
@@ -630,36 +630,36 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
     def getHelp(self):
         """Display window with help on graphics"""
 
-        hb = TKNTR.Toplevel(self.top, visual='best')
+        hb = tkinter.Toplevel(self.top, visual='best')
         hb.title("PyRAF Graphics Help")
         hb.iconname("PyRAF Graphics Help")
 
         # Set up the Menu Bar with 'Close' button
-        hb.menubar = TKNTR.Frame(hb, relief=TKNTR.RIDGE, borderwidth=0)
-        hb.menubar.button = TKNTR.Button(hb.menubar,
+        hb.menubar = tkinter.Frame(hb, relief=tkinter.RIDGE, borderwidth=0)
+        hb.menubar.button = tkinter.Button(hb.menubar,
                                          text="Close",
-                                         relief=TKNTR.RAISED,
+                                         relief=tkinter.RAISED,
                                          command=hb.destroy)
         hb.menubar.button.pack()
-        hb.menubar.pack(side=TKNTR.BOTTOM, padx=5, pady=5)
+        hb.menubar.pack(side=tkinter.BOTTOM, padx=5, pady=5)
 
         # Define the Listbox and setup the Scrollbar
-        hb.list = TKNTR.Listbox(hb,
-                                relief=TKNTR.FLAT,
+        hb.list = tkinter.Listbox(hb,
+                                relief=tkinter.FLAT,
                                 height=25,
                                 width=80,
-                                selectmode=TKNTR.SINGLE,
+                                selectmode=tkinter.SINGLE,
                                 selectborderwidth=0)
 
-        scroll = TKNTR.Scrollbar(hb, command=hb.list.yview)
+        scroll = tkinter.Scrollbar(hb, command=hb.list.yview)
         hb.list.configure(yscrollcommand=scroll.set)
-        hb.list.pack(side=TKNTR.LEFT, fill=TKNTR.BOTH, expand=1)
-        scroll.pack(side=TKNTR.RIGHT, fill=TKNTR.Y)
+        hb.list.pack(side=tkinter.LEFT, fill=tkinter.BOTH, expand=1)
+        scroll.pack(side=tkinter.RIGHT, fill=tkinter.Y)
 
         # Insert each line of the helpString into the box
         listing = helpString.split('\n')
         for line in listing:
-            hb.list.insert(TKNTR.END, line)
+            hb.list.insert(tkinter.END, line)
 
     # -----------------------------------------------
     # start general functionality (independent of graphics panel
@@ -686,7 +686,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         try:
             if self.gwidget:
                 self.gwidget.update_idletasks()
-        except TKNTR.TclError:
+        except tkinter.TclError:
             pass
 
     def hasFocus(self):
@@ -848,7 +848,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
 
     def raiseWindow(self):
 
-        if self.top.state() != TKNTR.NORMAL:
+        if self.top.state() != tkinter.NORMAL:
             self.top.deiconify()
         if self._slowraise == 0:
             # Get start time for tkraise...

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -323,8 +323,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         if not fname:
             return
         fh = open(fname, 'rb')
-        metacode = numpy.fromstring(fh.read(),
-                                    numpy.int16)  # OK: bytes in PY3K
+        metacode = numpy.frombuffer(fh.read(), numpy.int16)
         fh.close()
         self.clear(name=fname)
         self.append(metacode, isUndoable=1)

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -8,15 +8,15 @@ import os
 import sys
 import time
 import tkinter
-import msgiobuffer
-import msgiowidget
-import wutil
+from . import msgiobuffer
+from . import msgiowidget
+from . import wutil
 from stsci.tools import capable, filedlg, irafutils
 from stsci.tools.irafglobals import IrafError, userWorkingHome
 from stsci.tools.for2to3 import ndarr2bytes
-import gki
-import irafgwcs
-from pyrafglobals import pyrafDir
+from . import gki
+from . import irafgwcs
+from .pyrafglobals import pyrafDir
 import tkinter.filedialog
 import tkinter.messagebox
 import tkinter.simpledialog

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -1,7 +1,7 @@
 """
 Tk gui implementation for the gki plot widget
 """
-from __future__ import division, print_function
+
 
 import numpy
 import os

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -517,11 +517,11 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         for i in range(pmin, pmax):
             task = h[i][2]
             if i == pmin and pmin > 0:
-                label = "<< %s" % task
+                label = "<< {}".format(task)
             elif i == pmax - 1 and pmax < lhis:
-                label = ">> %s" % task
+                label = ">> {}".format(task)
             else:
-                label = "%2d %s" % (i + 1, task)
+                label = "{:2d} {}".format(i + 1, task)
             menu.add_radiobutton(label=label,
                                  command=self.selectedPage,
                                  value=i,

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -13,7 +13,6 @@ from . import msgiowidget
 from . import wutil
 from stsci.tools import capable, filedlg, irafutils
 from stsci.tools.irafglobals import IrafError, userWorkingHome
-from stsci.tools.for2to3 import ndarr2bytes
 from . import gki
 from . import irafgwcs
 from .pyrafglobals import pyrafDir
@@ -303,7 +302,7 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         if not fname:
             return
         fh = open(fname, 'wb')
-        fh.write(ndarr2bytes(self.gkibuffer.get()))
+        fh.write(self.gkibuffer.get().tobytes())
         fh.close()
 
     def load(self, fname=None):

--- a/pyraf/gkitkplot.py
+++ b/pyraf/gkitkplot.py
@@ -2,7 +2,7 @@
 Tkplot implementation of the gki kernel class
 """
 
-from __future__ import division, print_function
+
 
 import numpy
 import tkinter

--- a/pyraf/gkitkplot.py
+++ b/pyraf/gkitkplot.py
@@ -2,11 +2,8 @@
 Tkplot implementation of the gki kernel class
 """
 
-
-
 import numpy
 import tkinter
-from stsci.tools.for2to3 import ndarr2str
 from . import wutil
 from . import Ptkplot
 from . import gki
@@ -171,7 +168,7 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         self.wcs.commit()
         x = gki.ndc(arg[0])
         y = gki.ndc(arg[1])
-        text = ndarr2str(arg[3:].astype(numpy.int8))
+        text = arg[3:].astype(numpy.int8).tobytes().decode('ascii')
         self._tkplotAppend(self.tkplot_text, x, y, text)
 
     def gki_fillarea(self, arg):

--- a/pyraf/gkitkplot.py
+++ b/pyraf/gkitkplot.py
@@ -427,4 +427,4 @@ class tkColorManager:
         red = int(255 * color[0])
         green = int(255 * color[1])
         blue = int(255 * color[2])
-        return "#%02x%02x%02x" % (red, green, blue)
+        return "#{:02x}{:02x}{:02x}".format(red, green, blue)

--- a/pyraf/gkitkplot.py
+++ b/pyraf/gkitkplot.py
@@ -7,12 +7,12 @@ from __future__ import division, print_function
 import numpy
 import tkinter
 from stsci.tools.for2to3 import ndarr2str
-import wutil
-import Ptkplot
-import gki
-import gkitkbase
-import gkigcur
-import tkplottext
+from . import wutil
+from . import Ptkplot
+from . import gki
+from . import gkitkbase
+from . import gkigcur
+from . import tkplottext
 
 TK_LINE_STYLE_PATTERNS = ['.', '.', '_', '.', '.._']
 

--- a/pyraf/gkitkplot.py
+++ b/pyraf/gkitkplot.py
@@ -5,7 +5,7 @@ Tkplot implementation of the gki kernel class
 from __future__ import division, print_function
 
 import numpy
-import Tkinter as TKNTR  # requires 2to3
+import tkinter
 from stsci.tools.for2to3 import ndarr2str
 import wutil
 import Ptkplot
@@ -143,7 +143,7 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         self.clear()
         # This is needed to clear all the previously plotted objects
         # within tkinter (it has its own buffer it uses to replot)
-        # self.gwidget.delete(TKNTR.ALL)
+        # self.gwidget.delete(tkinter.ALL)
 
     def gki_cancel(self, arg):
 
@@ -265,7 +265,7 @@ class GkiTkplotKernel(gkitkbase.GkiInteractiveTkBase):
         # finally ready to do the drawing
         self.activate()
         # Have Tk remove all previously plotted objects
-        self.gwidget.delete(TKNTR.ALL)
+        self.gwidget.delete(tkinter.ALL)
         # Clear the screen
         self.tkplot_faset(0, 0)
         self.tkplot_fillarea(numpy.array([0., 0., 1., 0., 1., 1., 0., 1.]))
@@ -425,7 +425,7 @@ class tkColorManager:
             self.config.setCursorColor(irafColorIndex)
 
     def setDrawingColor(self, irafColorIndex):
-        """Return the specified iraf color usable by TKNTR"""
+        """Return the specified iraf color usable by tkinter"""
         color = self.config.defaultColors[irafColorIndex]
         red = int(255 * color[0])
         green = int(255 * color[1])

--- a/pyraf/graphcap.py
+++ b/pyraf/graphcap.py
@@ -85,7 +85,7 @@ class GraphCap(filecache.FileCache):
 
     def updateValue(self):
         """Called on init and if file changes"""
-        lines = open(self.filename, 'r').readlines()
+        lines = open(self.filename).readlines()
         mergedlines = merge(lines)
         self.dict = getDevices(mergedlines)
 

--- a/pyraf/graphcap.py
+++ b/pyraf/graphcap.py
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from stsci.tools import compmixin
-import filecache
+from . import filecache
 
 
 def merge(inlines):

--- a/pyraf/graphcap.py
+++ b/pyraf/graphcap.py
@@ -1,6 +1,6 @@
 """Finds device attributes from the graphcap
 """
-from __future__ import division, print_function
+
 
 from stsci.tools import compmixin
 from . import filecache

--- a/pyraf/graphcap.py
+++ b/pyraf/graphcap.py
@@ -26,14 +26,16 @@ def getAliases(entry):
     # return list of aliases (and dump the comment)
     aend = entry.find(':')
     if aend < 0:
-        raise ValueError("Graphcap entry does not have any colons\n%s" % entry)
+        raise ValueError("Graphcap entry does not have any colons\n{}"
+                         .format(entry))
     return entry[:aend].split("|")[:-1]
 
 
 def getAttributes(entry):
     abeg = entry.find(':')
     if abeg < 0:
-        raise ValueError("Graphcap entry does not have any colons\n%s" % entry)
+        raise ValueError("Graphcap entry does not have any colons\n{}"
+                         .format(entry))
     astring = entry[abeg + 1:]
     attr = {}
     attrlist = astring.split(':')

--- a/pyraf/gwm.py
+++ b/pyraf/gwm.py
@@ -8,7 +8,7 @@ from __future__ import division, print_function
 import os
 from stsci.tools import capable
 if capable.OF_GRAPHICS:
-    import Tkinter as TKNTR  # requires 2to3
+    import tkinter
 import wutil
 import gki
 
@@ -66,7 +66,7 @@ class GraphicsWindowManager(gki.GkiProxy):
             self.createList.append(windowName)
         if self.windowVar is None:
             # create Tk string variable with active window name
-            self.windowVar = TKNTR.StringVar()
+            self.windowVar = tkinter.StringVar()
             self.windowVar.trace('w', self._setWindowVar)
         self.windowVar.set(windowName)
 

--- a/pyraf/gwm.py
+++ b/pyraf/gwm.py
@@ -93,7 +93,7 @@ class GraphicsWindowManager(gki.GkiProxy):
         windowName = str(windowName).strip()
         window = self.windows.get(windowName)
         if window is None:
-            print("error: graphics window `%s' doesn't exist" % (windowName,))
+            print("error: graphics window `{}' doesn't exist".format(windowName))
         else:
             changeActiveWindow = (self.stdgraph == window)
             window.top.destroy()

--- a/pyraf/gwm.py
+++ b/pyraf/gwm.py
@@ -3,7 +3,7 @@ Graphics window manager, creates multiple toplevel togl widgets for
 use by python plotting
 
 """
-from __future__ import division, print_function
+
 
 import os
 from stsci.tools import capable

--- a/pyraf/gwm.py
+++ b/pyraf/gwm.py
@@ -9,8 +9,8 @@ import os
 from stsci.tools import capable
 if capable.OF_GRAPHICS:
     import tkinter
-import wutil
-import gki
+from . import wutil
+from . import gki
 
 
 class GWMError(Exception):
@@ -139,14 +139,14 @@ def _setGraphicsWindowManager():
         if 'PYRAFGRAPHICS' in os.environ:
             kernelname = os.environ['PYRAFGRAPHICS'].lower()
             if kernelname == "tkplot":
-                import gkitkplot
+                from . import gkitkplot
                 kernel = gkitkplot.GkiTkplotKernel
             elif kernelname == "opengl":
                 print("OpenGL kernel no longer exists, using default instead")
                 kernelname = "default"
             elif kernelname == "matplotlib":
                 try:
-                    import GkiMpl
+                    from . import GkiMpl
                     kernel = GkiMpl.GkiMplKernel
                 except ImportError:
                     print("matplotlib is not installed, using default instead")
@@ -162,7 +162,7 @@ def _setGraphicsWindowManager():
         if 'PYRAFGRAPHICS_TEST' in os.environ:
             print("Using graphics kernel: " + kernelname)
         if kernelname == "default":
-            import gkitkplot
+            from . import gkitkplot
             kernel = gkitkplot.GkiTkplotKernel
         wutil.isGwmStarted = 1
         return GraphicsWindowManager(kernel)

--- a/pyraf/ipython_api.py
+++ b/pyraf/ipython_api.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Modified input for PyRAF CL-script execution and pre-processing.
 
 Modifies the IPython intepreter to process PyRAF "magic" prior to
@@ -119,7 +118,7 @@ class IPythonIrafCompleter(IrafCompleter):
 # ---------------------------------------------------------------------------
 
 
-class IPython_PyRAF_Integrator(object):
+class IPython_PyRAF_Integrator:
     """This class supports the integration of these features with IPython:
 
     1. PyRAF readline completion

--- a/pyraf/ipython_api.py
+++ b/pyraf/ipython_api.py
@@ -12,7 +12,7 @@ Code derived from pyraf.pycmdline.py
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 # *****************************************************************************
-from __future__ import division, print_function
+
 
 VERY_OLD_IPY = True  # this means prior to v0.12
 try:

--- a/pyraf/iraf.py
+++ b/pyraf/iraf.py
@@ -4,10 +4,10 @@ R. White, 1999 Jan 25
 """
 from __future__ import division, print_function
 
-from iraffunctions import *
+from .iraffunctions import *
 
 # a few CL tasks have modified names (because they start with '_')
-import iraffunctions
+from . import iraffunctions
 
 _curpack = iraffunctions.curpack
 _allocate = iraffunctions.clAllocate

--- a/pyraf/iraf.py
+++ b/pyraf/iraf.py
@@ -2,7 +2,7 @@
 
 R. White, 1999 Jan 25
 """
-from __future__ import division, print_function
+
 
 from .iraffunctions import *
 

--- a/pyraf/irafcompleter.py
+++ b/pyraf/irafcompleter.py
@@ -36,11 +36,11 @@ lab2char = {}
 for i in range(1, 27):
     char = chr(i)
     ichar = chr(ord('a') + i - 1)
-    lab = "Control-%s" % ichar
+    lab = "Control-{}".format(ichar)
     char2lab[char] = lab
     lab2char[lab] = char
-    lab2char["Control-%s" % ichar] = char
-    lab2char[r"\C-%s" % ichar] = char
+    lab2char["Control-{}".format(ichar)] = char
+    lab2char[r"\C-{}".format(ichar)] = char
 char2lab["\t"] = "tab"
 lab2char["tab"] = "\t"
 char2lab["\033"] = "esc"
@@ -92,7 +92,7 @@ class IrafCompleter(Completer):
         if lab == char:
             char = lab2char.get(lab, lab)
         readline.set_completer(self.complete)
-        readline.parse_and_bind("%s: complete" % lab)
+        readline.parse_and_bind("{}: complete".format(lab))
         readline.parse_and_bind("set bell-style none")
         readline.parse_and_bind("set show-all-if-ambiguous")
         self.completionChar = char
@@ -114,7 +114,7 @@ class IrafCompleter(Completer):
         if readline is not None and self.completionChar:
             # restore normal behavior for previous completion character
             lab = char2lab.get(self.completionChar, self.completionChar)
-            readline.parse_and_bind("%s: self-insert" % lab)
+            readline.parse_and_bind("{}: self-insert".format(lab))
             self.completionChar = None
 
     def executive(self, elist):
@@ -252,7 +252,7 @@ class IrafCompleter(Completer):
             # filename is preceded by path separator
             # match filenames with letters, numbers, $, ~, ., -, +,  and
             # directory separator
-            m = re.search(r'[\w.~$+-%s]*$' % os.sep, line)
+            m = re.search(r'[\w.~$+-{}]*$'.format(os.sep), line)
             dir = iraf.Expand(m.group())
         else:
             dir = ''
@@ -342,7 +342,7 @@ class IrafCompleter(Completer):
         """Return matches for iraf.package.task.param..."""
         head = ".".join(fields[:-1])
         tail = fields[-1]
-        matches = eval("%s.getAllMatches(%s)" % (head, repr(tail)))
+        matches = eval("{}.getAllMatches({})".format(head, repr(tail)))
 
         def addhead(s, head=head + "."):
             return head + s

--- a/pyraf/irafcompleter.py
+++ b/pyraf/irafcompleter.py
@@ -12,7 +12,7 @@ information.
 
 RLW, 2000 February 13
 """
-from __future__ import division, print_function
+
 
 import builtins
 import __main__

--- a/pyraf/irafcompleter.py
+++ b/pyraf/irafcompleter.py
@@ -105,7 +105,7 @@ class IrafCompleter(Completer):
         if os.path.exists(hfile):
             try:
                 readline.read_history_file(hfile)
-            except IOError as e:
+            except OSError as e:
                 # we do NOT want this to prevent startup.  see ticket #132
                 print('ERROR reading "' + hfile + '" -> ' + str(e))
 

--- a/pyraf/irafcompleter.py
+++ b/pyraf/irafcompleter.py
@@ -14,7 +14,7 @@ RLW, 2000 February 13
 """
 from __future__ import division, print_function
 
-import __builtin__
+import builtins
 import __main__
 import re
 import keyword
@@ -160,7 +160,7 @@ class IrafCompleter(Completer):
         n = len(text)
         for list in [
                 keyword.kwlist,
-                __builtin__.__dict__.keys(),
+                builtins.__dict__.keys(),
                 __main__.__dict__.keys()
         ]:
             for word in list:

--- a/pyraf/irafcompleter.py
+++ b/pyraf/irafcompleter.py
@@ -20,7 +20,7 @@ import re
 import keyword
 import glob
 import os
-import iraf
+from . import iraf
 from stsci.tools import minmatch
 try:
     import readline

--- a/pyraf/irafdisplay.py
+++ b/pyraf/irafdisplay.py
@@ -26,7 +26,7 @@ This could be used to maintain references to multiple display servers.
 Ultimately more functionality may be added to make this a complete
 replacement for CDL.
 """
-from __future__ import division, print_function
+
 
 import os
 import numpy

--- a/pyraf/irafdisplay.py
+++ b/pyraf/irafdisplay.py
@@ -106,7 +106,7 @@ def _open(imtdev=None):
             return InetImageDisplay(port, hostname)
         except ValueError:
             pass
-    raise ValueError("Illegal image device specification `%s'" % imtdev)
+    raise ValueError("Illegal image device specification `{}'".format(imtdev))
 
 
 class ImageDisplay:

--- a/pyraf/irafdisplay.py
+++ b/pyraf/irafdisplay.py
@@ -32,7 +32,6 @@ import os
 import numpy
 import socket
 import sys
-from stsci.tools.for2to3 import bytes_write, ndarr2bytes
 from stsci.tools import irafutils
 
 try:
@@ -168,7 +167,7 @@ class ImageDisplay:
         sum = numpy.add.reduce(a)
         sum = 0xffff - (sum & 0xffff)
         a[3] = sum
-        self._write(ndarr2bytes(a))
+        self._write(a.tobytes())
 
     def close(self, os_close=os.close):
         """Close image display connection"""
@@ -202,7 +201,7 @@ class ImageDisplay:
         try:
             n = len(s)
             while n > 0:
-                nwritten = bytes_write(self._fdout, s[-n:])
+                nwritten = os.write(self._fdout, s[-n:])
                 n -= nwritten
                 if nwritten <= 0:
                     raise IOError("Error writing to image display")

--- a/pyraf/irafdisplay.py
+++ b/pyraf/irafdisplay.py
@@ -26,27 +26,12 @@ This could be used to maintain references to multiple display servers.
 Ultimately more functionality may be added to make this a complete
 replacement for CDL.
 """
-
-
 import os
 import numpy
 import socket
 import sys
+import fcntl
 from stsci.tools import irafutils
-
-try:
-    import fcntl
-except ImportError:
-    if 0 == sys.platform.find('win'):  # not on win*, but IS on darwin & cygwin
-        fcntl = None
-    else:
-        raise
-
-# FCNTL is deprecated in Python 2.2
-if hasattr(fcntl, 'F_SETFL') or fcntl is None:
-    FCNTL = fcntl
-else:
-    import FCNTL
 
 _default_imtdev = ("unix:/tmp/.IMT%d", "fifo:/dev/imt1i:/dev/imt1o")
 
@@ -216,13 +201,11 @@ class FifoImageDisplay(ImageDisplay):
         ImageDisplay.__init__(self)
         try:
             self._fdin = os.open(infile, os.O_RDONLY | os.O_NDELAY)
-            fcntl.fcntl(self._fdin, FCNTL.F_SETFL, os.O_RDONLY)
+            fcntl.fcntl(self._fdin, fcntl.F_SETFL, os.O_RDONLY)
             self._fdout = os.open(outfile, os.O_WRONLY | os.O_NDELAY)
-            fcntl.fcntl(self._fdout, FCNTL.F_SETFL, os.O_WRONLY)
+            fcntl.fcntl(self._fdout, fcntl.F_SETFL, os.O_WRONLY)
         except OSError as error:
             raise IOError("Cannot open image display (%s)" % (error,))
-        except AttributeError:
-            raise RuntimeError("Image fcntl is not supported on this platform")
 
     def __del__(self):
         self.close()

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -15,7 +15,7 @@ import pyraf.iraf
 executionMonitor = None
 
 
-class EclState(object):
+class EclState:
     """An object which records the ECL state for one invocation of a CL proc:
 
     1. The procedure's linemap converting Python line numberss to CL line numbers.
@@ -46,7 +46,7 @@ def getTaskModule():
         return iraftask
 
 
-class Erract(object):
+class Erract:
     """Erract is a state variable (singleton) which corresponds to the IRAF ECL
     environment variable 'erract'.  erract has the following properties which
     control ECL exception handling:

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -1,6 +1,6 @@
 """This module adds IRAF ECL style error handling to PyRAF."""
 
-from __future__ import division, print_function
+
 
 import inspect
 import sys

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -392,7 +392,7 @@ class EclTraceback(EclBase):
         cl_file = self.getFilename()
         try:
             cl_code = open(cl_file).readlines()[lineno - 1].strip()
-        except IOError:
+        except OSError:
             cl_code = "<source code not available>"
         if hasattr(e, "_ecl_suppress_first_trace") and \
                 e._ecl_suppress_first_trace:

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -5,9 +5,9 @@ from __future__ import division, print_function
 import inspect
 import sys
 from stsci.tools.irafglobals import Verbose
-import pyrafglobals
-import iraftask
-import irafexecute
+from . import pyrafglobals
+from . import iraftask
+from . import irafexecute
 
 # this is better than what 2to3 does, since the iraf import is circular
 import pyraf.iraf
@@ -40,7 +40,7 @@ def getTaskModule():
     language mode,  either ECL or classic CL.
     """
     if pyrafglobals._use_ecl:
-        import irafecl
+        from . import irafecl
         return irafecl
     else:
         return iraftask

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -185,8 +185,8 @@ class EclBase:
         self.setParList(*args, **kw)
 
         if Verbose > 1:
-            print("run %s (%s: %s)" %
-                  (self._name, self.__class__.__name__, self._fullpath))
+            print("run {} ({}: {})"
+                  .format(self._name, self.__class__.__name__, self._fullpath))
             if self._runningParList:
                 self._runningParList.lParam()
 
@@ -291,8 +291,9 @@ class EclBase:
         """Formats an ECL error message from an exception and returns it as a string."""
         errno, errmsg, errtask = self._ecl_exception_properties(e)
         if errno and errmsg and errtask:
-            text = "Error (%d): on line %d of '%s' from '%s':\n\t'%s'" % \
-                   (errno, self._ecl_get_lineno(), self._name, errtask, errmsg)
+            text = ("Error ({:d}): on line {:d} of '{}' from '{}':\n\t'{}'"
+                    .format(errno, self._ecl_get_lineno(),
+                            self._name, errtask, errmsg))
         else:
             text = str(e)
         return text
@@ -326,8 +327,8 @@ class EclBase:
         if b == 0:
             if not erract.abort or self._ecl_iferr_entered():
                 self._ecl_trace(
-                    "Warning on line %d of '%s':  divide by zero - using $err_dzvalue ="
-                    % (self._ecl_get_lineno(), self._name),
+                    "Warning on line {:d} of '{}':  divide by zero - using $err_dzvalue ="
+                    .format(self._ecl_get_lineno(), self._name),
                     self.DOLLARerr_dzvalue)
                 return self.DOLLARerr_dzvalue
             else:
@@ -342,8 +343,8 @@ class EclBase:
         if b == 0:
             if not erract.abort or self._ecl_iferr_entered():
                 self._ecl_trace(
-                    "Warning on line %d of task '%s':  modulo by zero - using $err_dzvalue ="
-                    % (self._ecl_get_lineno(), self._name),
+                    "Warning on line {:d} of task '{}':  modulo by zero - using $err_dzvalue ="
+                    .format(self._ecl_get_lineno(), self._name),
                     self.DOLLARerr_dzvalue)
                 return self.DOLLARerr_dzvalue
             else:
@@ -375,7 +376,7 @@ class EclTraceback(EclBase):
             raise e
         else:
             try:
-                self._ecl_trace("ERROR (%d): %s" % (e.errno, e.errmsg))
+                self._ecl_trace("ERROR ({:d}): {}".format(e.errno, e.errmsg))
             except:
                 self._ecl_trace("ERROR:", str(e))
             self._ecl_traceback(e)
@@ -399,7 +400,7 @@ class EclTraceback(EclBase):
             del e._ecl_suppress_first_trace
         else:
             self._ecl_trace("  ", repr(cl_code))
-        self._ecl_trace("      line %d: %s" % (lineno, cl_file))
+        self._ecl_trace("      line {:d}: {}".format(lineno, cl_file))
         parent = _ecl_parent_task()
         if parent:
             parent_lineno = self._ecl_get_lineno()

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -8,7 +8,7 @@ import signal
 import struct
 import sys
 import numpy
-import cStringIO
+import io
 from stsci.tools import irafutils
 from stsci.tools.for2to3 import tobytes, ndarr2bytes, ndarr2str
 from stsci.tools.irafglobals import IrafError, IrafTask, Verbose
@@ -995,7 +995,7 @@ class IrafProcess:
                         (cmd,))
                 sys.stdout.flush()
                 # strip the redirection off and capture output of command
-                buffer = cStringIO.StringIO()
+                buffer = io.StringIO()
                 # redirect other I/O (but don't use graphics status line)
                 pyraf.iraf.clExecute(cmd[:ll] + "\n",
                                      Stdout=buffer,

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -73,7 +73,7 @@ def _getExecutable(arg):
         task = pyraf.iraf.getTask(arg, found=1)
         if task is not None:
             return task.getFullpath()
-    raise IrafProcessError("Cannot find task or executable %s" % arg)
+    raise IrafProcessError("Cannot find task or executable {}".format(arg))
 
 
 class _ProcessProxy(filecache.FileCache):
@@ -141,8 +141,8 @@ class _ProcessCache:
                 # Kill it and start a new one
                 # XXX Eventually can make this a level 0 message
                 # XXX Leave as level -1 for now so we see if bug is gone
-                self.error("Warning: process %s is bad, restarting it\n" %
-                           (executable,),
+                self.error("Warning: process {} is bad, restarting it\n"
+                           .format(executable),
                            level=-1)
                 self.kill(executable, verbose=0)
             # Whoops, process is already active...
@@ -233,7 +233,7 @@ class _ProcessCache:
         for taskname in args:
             task = pyraf.iraf.getTask(taskname, found=1)
             if task is None:
-                print("No such task `%s'" % taskname)
+                print("No such task `{}'".format(taskname))
             elif task.__class__.__name__ == "IrafTask":
                 # cache only executable tasks (not CL tasks, etc.)
                 executable = task.getFullpath()
@@ -242,7 +242,7 @@ class _ProcessCache:
                 if executable in self._data:
                     self._locked[executable] = 1
                 else:
-                    self.error("Cannot cache %s\n" % taskname)
+                    self.error("Cannot cache {}\n".format(taskname))
 
     def delget(self, process):
         """Get process object and delete it from cache
@@ -306,9 +306,9 @@ class _ProcessCache:
             n = n + 1
             executable = proxy.process.executable
             if executable in self._locked:
-                print("%2d: L %s" % (n, executable))
+                print("{:2d}: L {}".format(n, executable))
             else:
-                print("%2d:   %s" % (n, executable))
+                print("{:2d}:   {}".format(n, executable))
 
     def __del__(self):
         self._locked = {}
@@ -333,7 +333,6 @@ def IrafExecute(task,
         irafprocess = processCache.get(task, envdict)
     except (IrafError, subproc.SubprocessError, IrafProcessError) as value:
         raise
-        raise IrafProcessError("Cannot start IRAF executable\n%s" % value)
 
     # Run it
     try:
@@ -405,7 +404,8 @@ class IrafProcess:
         """Start IRAF task executable."""
 
         if test_probe:
-            sys.stdout.write("Starting IRAF process for %s\n" % executable)
+            sys.stdout.write("Starting IRAF process for {}\n"
+                             .format(executable))
 
         self.executable = executable
         self.process = subproc.Subprocess(executable + ' -c')
@@ -427,8 +427,8 @@ class IrafProcess:
 
         outenvstr = []
         for key, value in envdict.items():
-            outenvstr.append("set %s=%s\n" % (key, str(value)))
-        outenvstr.append("chdir %s\n" % os.getcwd())
+            outenvstr.append("set {}={}\n".format(key, str(value)))
+        outenvstr.append("chdir {}\n".format(os.getcwd()))
         if outenvstr:
             self.writeString("".join(outenvstr))
         self.envVarList = []
@@ -458,8 +458,8 @@ class IrafProcess:
         """
 
         if test_probe:
-            sys.stdout.write("Running IRAF task %s from %s\n" %
-                             (task, self.executable))
+            sys.stdout.write("Running IRAF task {} from {}\n"
+                             .format(task, self.executable))
         self.task = task
         # set IO streams
         stdin = pstdin or sys.stdin
@@ -502,8 +502,8 @@ class IrafProcess:
         # (which is better than the CL does)
         if self.stdoutIsatty:
             nlines, ncols = wutil.getTermWindowSize()
-            self.writeString('set ttynlines=%d\nset ttyncols=%d\n' %
-                             (nlines, ncols))
+            self.writeString('set ttynlines={:d}\nset ttyncols={:d}\n'
+                             .format(nlines, ncols))
 
         taskname = self.task.getName()
         # remove leading underscore, which is just a convention for CL
@@ -545,8 +545,8 @@ class IrafProcess:
         except subproc.SubprocessError as e:
             if Verbose > 0:
                 # too bad, if we can't kill it assume it is already dead
-                self.stderr.write("Warning: cannot terminate process %s\n" %
-                                  (e,))
+                self.stderr.write("Warning: cannot terminate process {}\n"
+                                  .format(e))
                 self.stderr.flush()
 
     def kill(self, verbose=1):
@@ -562,7 +562,8 @@ class IrafProcess:
         self.stderr.flush()
         from . import pyrafglobals
         if verbose and not pyrafglobals._use_ecl:
-            sys.stderr.write("Killing IRAF task `%s'\n" % self.task.getName())
+            sys.stderr.write("Killing IRAF task `{}'\n"
+                             .format(self.task.getName()))
             sys.stderr.flush()
         if self.process.cont():
             # get the task's attention for input
@@ -600,7 +601,7 @@ class IrafProcess:
                                    dsection)
                 i = i + block
         except subproc.SubprocessError as e:
-            raise IrafProcessError("Error in write: %s" % str(e))
+            raise IrafProcessError("Error in write: {}".format(str(e)))
 
     def read(self):
         """Read binary data from IRAF pipe"""
@@ -616,7 +617,7 @@ class IrafProcess:
             data = self.process.read(nbytes)  # read returns bytes
             return data
         except subproc.SubprocessError as e:
-            raise IrafProcessError("Error in read: %s" % str(e))
+            raise IrafProcessError("Error in read: {}".format(str(e)))
 
     def slave(self):
         """Talk to the IRAF process in slave mode.
@@ -699,7 +700,7 @@ class IrafProcess:
                     # should never get here
                     #                   L.log("Program bug: uninterpreted message: " + msg)
                     raise RuntimeError(
-                        "Program bug: uninterpreted message `%s'" % (msg,))
+                        "Program bug: uninterpreted message `{}'".format(msg))
 
     def _scanErrno(self, msg):
         sp = "\\s*"
@@ -782,7 +783,7 @@ class IrafProcess:
         except ValueError as e:
             # on ValueError, just print warning and then force set
             if Verbose > 0:
-                self.stderr.write('Warning: %s\n' % (e,))
+                self.stderr.write('Warning: {}\n'.format(e))
                 self.stderr.flush()
             self.task.setParam(paramname, newvalue, check=0)
 
@@ -796,8 +797,8 @@ class IrafProcess:
 
         if len(xdata) != 2 * nbytes:
             raise IrafProcessError("Error, wrong number of bytes read\n" +
-                                   ("(got %d, expected %d, chan %d)" %
-                                    (len(xdata), 2 * nbytes, chan)))
+                                   ("(got {:d}, expected {:d}, chan {:d})"
+                                    .format(len(xdata), 2 * nbytes, chan)))
         if chan == 4:
             if self.task.getTbflag():
                 # for tasks with .tb flag, stdout is binary data
@@ -864,11 +865,11 @@ class IrafProcess:
                     self.write(wcs)
                     stdimagekernel.clearReturnData()
             else:
-                self.stdout.write("GRAPHICS control data for channel %d\n" %
-                                  (forChan,))
+                self.stdout.write("GRAPHICS control data for channel {:d}\n"
+                                  .format(forChan))
                 self.stdout.flush()
         else:
-            self.stdout.write("data for channel %d\n" % (chan,))
+            self.stdout.write("data for channel {:d}\n".format(chan))
             self.stdout.flush()
 
     def xfer(self):
@@ -933,8 +934,8 @@ class IrafProcess:
                 self.writeString(line)
                 self.xferline = ''
         else:
-            raise IrafProcessError("xfer request for unknown channel %d" %
-                                   chan)
+            raise IrafProcessError("xfer request for unknown channel {:d}"
+                                   .format(chan))
 
     def chanbytes(self):
         """Parse xmit(chan,nbytes) and return integer tuple
@@ -950,7 +951,8 @@ class IrafProcess:
             nbytes = int(msg[i + 1:-2])
             self.msg = ''
         except ValueError:
-            raise IrafProcessError("Illegal message format `%s'" % self.msg)
+            raise IrafProcessError("Illegal message format `{}'"
+                                   .format(self.msg))
         return chan, nbytes
 
     def executeClCommand(self):
@@ -985,10 +987,10 @@ class IrafProcess:
                 # Just raise an exception if it does not fit my preconceptions.
                 #
                 ll = -(len(IPCOUT) + 3)
-                if cmd[ll:] != "> %s\n" % IPCOUT:
+                if cmd[ll:] != "> {}\n".format(IPCOUT):
                     raise IrafProcessError(
-                        "Error: cannot understand IPCOUT syntax in `%s'" %
-                        (cmd,))
+                        "Error: cannot understand IPCOUT syntax in `{}'"
+                        .format(cmd))
                 sys.stdout.flush()
                 # strip the redirection off and capture output of command
                 buffer = io.StringIO()
@@ -1009,8 +1011,8 @@ class IrafProcess:
                 # a kluge -- if self.stdout is not a tty, assume it is a
                 # file and give a large number for the number of lines
                 nlines, ncols = 100000, 80
-            self.writeString('set ttynlines=%d\nset ttyncols=%d\n' %
-                             (nlines, ncols))
+            self.writeString('set ttynlines={:d}\nset ttyncols={:d}\n'
+                             .format(nlines, ncols))
             self.msg = self.msg[mcmd.end():]
         elif mcmd.group('curpack'):
             # current package request
@@ -1029,8 +1031,8 @@ class IrafProcess:
             # self.stdout.write(self.msg + "\n")
         else:
             # should never get here
-            raise RuntimeError("Program bug: uninterpreted message `%s'" %
-                               (self.msg,))
+            raise RuntimeError("Program bug: uninterpreted message `{}'"
+                               .format(self.msg))
 
 
 # IRAF string conversions using numpy module

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -12,12 +12,12 @@ import io
 from stsci.tools import irafutils
 from stsci.tools.for2to3 import tobytes, ndarr2bytes, ndarr2str
 from stsci.tools.irafglobals import IrafError, IrafTask, Verbose
-import subproc
-import filecache
-import wutil
-import gki
-import irafukey
-import irafgwcs
+from . import subproc
+from . import filecache
+from . import wutil
+from . import gki
+from . import irafukey
+from . import irafgwcs
 
 # use this form since the iraf import is circular
 import pyraf.iraf
@@ -561,7 +561,7 @@ class IrafProcess:
 
         self.stdout.flush()
         self.stderr.flush()
-        import pyrafglobals
+        from . import pyrafglobals
         if verbose and not pyrafglobals._use_ecl:
             sys.stderr.write("Killing IRAF task `%s'\n" % self.task.getName())
             sys.stderr.flush()

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -829,17 +829,14 @@ class IrafProcess:
             self.stderr.write(Iraf2AscString(xdata))
             self.stderr.flush()
         elif chan == 6:
-            gki.kernel.append(numpy.fromstring(
-                xdata, dtype=numpy.int16))  # OK if str or uni
+            gki.kernel.append(numpy.frombuffer(xdata, dtype=numpy.int16))
         elif chan == 7:
-            stdimagekernel.append(numpy.fromstring(
-                xdata, dtype=numpy.int16))  # OK if str or uni
+            stdimagekernel.append(numpy.frombuffer(xdata, dtype=numpy.int16))
         elif chan == 8:
             self.stdout.write("data for STDPLOT\n")
             self.stdout.flush()
         elif chan == 9:
-            sdata = numpy.fromstring(xdata,
-                                     dtype=numpy.int16)  # OK if str or uni
+            sdata = numpy.frombuffer(xdata, dtype=numpy.int16)
             if isBigEndian:
                 # Actually, the channel destination is sent
                 # by the iraf process as a 4 byte int, the following
@@ -1041,7 +1038,7 @@ class IrafProcess:
 
 def Asc2IrafString(ascii_string):
     """translate ascii to IRAF 16-bit string format"""
-    inarr = numpy.fromstring(ascii_string, numpy.int8)  # OK if str or uni
+    inarr = numpy.frombuffer(ascii_string.encode('ascii'), numpy.int8)
     retval = inarr.astype(numpy.int16).tobytes()
     #   log_task_comm('Asc2IrafString (write to task)', retval, False)
     return retval
@@ -1049,7 +1046,7 @@ def Asc2IrafString(ascii_string):
 
 def Iraf2AscString(iraf_string):
     """translate 16-bit IRAF characters to ascii"""
-    inarr = numpy.fromstring(iraf_string, numpy.int16)  # OK if str or uni
+    inarr = numpy.frombuffer(iraf_string, numpy.int16)
     retval = inarr.astype(numpy.int8).tobytes().decode('ascii')
     #   log_task_comm('Iraf2AscString', retval, True)
     return retval

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -68,7 +68,7 @@ def _getExecutable(arg):
         return arg.executable
     elif isinstance(arg, IrafTask):
         return arg.getFullpath()
-    elif isinstance(arg, (str, unicode)):
+    elif isinstance(arg, str):
         if os.path.exists(arg):
             return arg
         task = pyraf.iraf.getTask(arg, found=1)
@@ -747,7 +747,7 @@ class IrafProcess:
         try:
             try:
                 pmsg = self.task.getParam(paramname, native=0)
-                if not isinstance(pmsg, (str, unicode)):
+                if not isinstance(pmsg, str):
                     # Only psets should return a non-string type (they
                     # return the task object).
                     # Work a little to get the underlying string value.
@@ -1059,10 +1059,10 @@ def Iraf2AscString(iraf_string):
 def log_task_comm(pfx, strbuf, expectAsStr, shorten=True):
     import some_pkg_w_a_log_func as L
     assert isinstance(strbuf,
-                      (str, unicode, bytes)), "?!: " + str(type(strbuf))
+                      (str, str, bytes)), "?!: " + str(type(strbuf))
     if expectAsStr:
         assert isinstance(strbuf, str), "Unexpected type: " + str(type(strbuf))
-    if isinstance(strbuf, (str, unicode)):
+    if isinstance(strbuf, (str, str)):
         out = strbuf.strip()
         if shorten:
             out = out[0:30]

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -1,6 +1,6 @@
 """irafexecute.py: Functions to execute IRAF connected subprocesses
 """
-from __future__ import division, print_function
+
 
 import os
 import re

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -10,7 +10,7 @@ import sys
 import numpy
 import io
 from stsci.tools import irafutils
-from stsci.tools.for2to3 import tobytes, ndarr2bytes, ndarr2str
+from stsci.tools.for2to3 import ndarr2bytes, ndarr2str
 from stsci.tools.irafglobals import IrafError, IrafTask, Verbose
 from . import subproc
 from . import filecache
@@ -598,7 +598,7 @@ class IrafProcess:
                 # the arg parts to the following are all type bytes in PY3K
                 self.process.write(IPC_PREFIX +
                                    struct.pack('=h', len(dsection)) +
-                                   tobytes(dsection))
+                                   dsection)
                 i = i + block
         except subproc.SubprocessError as e:
             raise IrafProcessError("Error in write: %s" % str(e))

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -10,7 +10,6 @@ import sys
 import numpy
 import io
 from stsci.tools import irafutils
-from stsci.tools.for2to3 import ndarr2bytes, ndarr2str
 from stsci.tools.irafglobals import IrafError, IrafTask, Verbose
 from . import subproc
 from . import filecache
@@ -34,7 +33,7 @@ test_probe = False
 
 # stdgraph = None
 
-IPC_PREFIX = ndarr2bytes(numpy.array([0o1120], numpy.int16))
+IPC_PREFIX = b'P\x02'
 
 # weirdo protocol to get output from task back to subprocess
 # definitions from cl/task.h and lib/clio.h
@@ -1043,7 +1042,7 @@ class IrafProcess:
 def Asc2IrafString(ascii_string):
     """translate ascii to IRAF 16-bit string format"""
     inarr = numpy.fromstring(ascii_string, numpy.int8)  # OK if str or uni
-    retval = ndarr2bytes(inarr.astype(numpy.int16))
+    retval = inarr.astype(numpy.int16).tobytes()
     #   log_task_comm('Asc2IrafString (write to task)', retval, False)
     return retval
 
@@ -1051,7 +1050,7 @@ def Asc2IrafString(ascii_string):
 def Iraf2AscString(iraf_string):
     """translate 16-bit IRAF characters to ascii"""
     inarr = numpy.fromstring(iraf_string, numpy.int16)  # OK if str or uni
-    retval = ndarr2str(inarr.astype(numpy.int8))
+    retval = inarr.astype(numpy.int8).tobytes().decode('ascii')
     #   log_task_comm('Iraf2AscString', retval, True)
     return retval
 

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -293,7 +293,7 @@ class _ProcessCache:
                 if task is not None:
                     self.terminate(task)
         else:
-            for rank, proxy in self._data.values():
+            for rank, proxy in list(self._data.values()):
                 executable = proxy.process.executable
                 if executable not in self._locked:
                     self.terminate(executable)

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -84,7 +84,7 @@ from . import gki
 from . import irafecl
 try:
     from . import sscanf
-except IOError:
+except OSError:
     # basic usage does not actually require sscanf
     sscanf = None
     print("Warning: sscanf library not installed on " + sys.platform)
@@ -166,7 +166,7 @@ def Init(doprint=1, hush=0, savefile=None):
                         _os.environ[key] = value
                 iraf = _os.environ['iraf']
                 arch = _os.environ['IRAFARCH']
-            except IOError:
+            except OSError:
                 raise SystemExit("""
 Your "iraf" and "IRAFARCH" environment variables are not defined and could not
 be determined from /usr/local/bin/cl.  These are needed to find IRAF tasks.
@@ -266,8 +266,8 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
     if not _irafinst.EXISTS:
         return {'iraf': '/iraf/is/not/here/', 'IRAFARCH': 'arch_is_unused'}
     if not _os.path.exists(file):
-        raise IOError("CL startup file %s does not exist" % file)
-    lines = open(file, 'r').readlines()
+        raise OSError("CL startup file %s does not exist" % file)
+    lines = open(file).readlines()
     # replace commands that exec cl with commands to print environment vars
     pat = _re.compile(r'^\s*exec\s+')
     newlines = []
@@ -281,7 +281,7 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
         else:
             newlines.append(line)
     if nfound == 0:
-        raise IOError("No exec statement found in script %s" % file)
+        raise OSError("No exec statement found in script %s" % file)
     # write new script to temporary file
     (fd, newfile) = _tempfile.mkstemp()
     _os.close(fd)
@@ -293,7 +293,7 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
     fh = _io.StringIO()
     status = clOscmd(newfile, Stdout=fh)
     if status:
-        raise IOError("Execution error in script %s (derived from %s)" %
+        raise OSError("Execution error in script %s (derived from %s)" %
                       (newfile, file))
     _os.remove(newfile)
     result = fh.getvalue().split('\n')
@@ -388,7 +388,7 @@ def saveToFile(savefile, **kw):
         savefile = Expand(savefile)
         if (not kw.get('clobber')) and envget(
                 "clobber", "") != yes and _os.path.exists(savefile):
-            raise IOError("Output file `%s' already exists" % savefile)
+            raise OSError("Output file `%s' already exists" % savefile)
         # open binary pickle file
         fh = open(savefile, 'wb')
         doclose = 1
@@ -3746,7 +3746,7 @@ def redirProcess(kw):
                     else:
                         # IRAF doesn't raise an exception here (e.g., on
                         # input redirection from "STDOUT"), but it should
-                        raise IOError("Illegal value `%s' for %s redirection" %
+                        raise OSError("Illegal value `%s' for %s redirection" %
                                       (value, key))
                 else:
                     # expand IRAF variables
@@ -3763,7 +3763,7 @@ def redirProcess(kw):
                                 envget("clobber", "") != yes and \
                                 _os.path.exists(value):
                             # don't overwrite unless clobber is set
-                            raise IOError("Output file `%s' already exists" %
+                            raise OSError("Output file `%s' already exists" %
                                           value)
                     fh = open(value, openArgs)
                     # close this when we're done

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -33,7 +33,7 @@ def setVerbose(value=1, **kw):
     cannot avail itself of the decorator which wraps redirProcess since it
     needs to be defined here up front.
     """
-    if isinstance(value, (str, unicode)):
+    if isinstance(value, str):
         try:
             value = int(value)
         except ValueError:
@@ -670,7 +670,7 @@ def getTask(taskname, found=0):
 
     if isinstance(taskname, _iraftask.IrafTask):
         return taskname
-    elif not isinstance(taskname, (str, unicode)):
+    elif not isinstance(taskname, str):
         raise TypeError(
             "Argument to getTask is not a string or IrafTask instance")
 
@@ -889,7 +889,7 @@ def listTasks(pkglist=None, hidden=0, **kw):
         pkgdict = _pkgs
     else:
         pkgdict = {}
-        if isinstance(pkglist, (str, unicode, _iraftask.IrafPkg)):
+        if isinstance(pkglist, (str, _iraftask.IrafPkg)):
             pkglist = [pkglist]
         for p in pkglist:
             try:
@@ -1225,7 +1225,7 @@ def real(x):
     """Return real/float representation of x"""
     if x == INDEF:
         return INDEF
-    elif isinstance(x, (str, unicode)):
+    elif isinstance(x, str):
         x = x.strip()
         if x.find(':') >= 0:
             # ...handle the special a:b:c case here...
@@ -1254,7 +1254,7 @@ def integer(x):
     """Return integer representation of x"""
     if x == INDEF:
         return INDEF
-    elif isinstance(x, (str, unicode)):
+    elif isinstance(x, str):
         x = x.strip()
         i = 0
         j = len(x)
@@ -1861,7 +1861,7 @@ def boolean(value):
         return int(value)
     elif value in [INDEF, "", None]:
         return INDEF
-    if isinstance(value, (str, unicode)):
+    if isinstance(value, str):
         v2 = _irafutils.stripQuotes(value.strip())
         if v2 == "INDEF":
             return INDEF
@@ -2176,7 +2176,7 @@ def set(*args, **kw):
         #
         # Flag any other syntax as an error.
         if len(args) != 1 or len(kw) != 0 or \
-           (not isinstance(args[0], (str, unicode))) or args[0][:1] != '@':
+           (not isinstance(args[0], str)) or args[0][:1] != '@':
             raise SyntaxError("set requires name=value pairs")
 
 
@@ -2738,7 +2738,7 @@ def clProcedure(input=None, mode="", DOLLARnargs=0, **kw):
         else:
             filename = 'tmp'
     elif input is not None:
-        if isinstance(input, (str, unicode)):
+        if isinstance(input, str):
             # input is a string -- stick it in a StringIO buffer
             stdin = _io.StringIO(input)
             filename = input
@@ -2972,7 +2972,7 @@ def clPrint(*args):
     for n, arg in enumerate(args, start=1):
         print(arg, end='')
         # add separator space, except after string arguments and at the end
-        if n < nargs and not isinstance(arg, (str, unicode)):
+        if n < nargs and not isinstance(arg, str):
             print(end=' ')
     print()
 
@@ -3150,7 +3150,7 @@ def chdir(directory=None):
     if directory is None:
         # use startup directory as home if argument is omitted
         directory = userWorkingHome
-    if not isinstance(directory, (str, unicode)):
+    if not isinstance(directory, str):
         raise IrafError("Illegal non-string value for directory:" +
                         +repr(directory))
     if Verbose > 2:

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -17,7 +17,7 @@ from __future__ import division, print_function
 # define INDEF, yes, no, EOF, Verbose, IrafError, userIrafHome
 
 from stsci.tools.irafglobals import *
-from subproc import SubprocessError
+from .subproc import SubprocessError
 
 # -----------------------------------------------------
 # setVerbose: set verbosity level
@@ -72,16 +72,16 @@ import stsci.tools.minmatch as _minmatch
 import stsci.tools.irafutils as _irafutils
 import stsci.tools.teal as _teal
 import numpy as _numpy
-import subproc as _subproc
-import wutil as _wutil
-import irafnames as _irafnames
-import irafinst as _irafinst
-import irafpar as _irafpar
-import iraftask as _iraftask
-import irafexecute as _irafexecute
-import cl2py as _cl2py
-import gki
-import irafecl
+from . import subproc as _subproc
+from . import wutil as _wutil
+from . import irafnames as _irafnames
+from . import irafinst as _irafinst
+from . import irafpar as _irafpar
+from . import iraftask as _iraftask
+from . import irafexecute as _irafexecute
+from . import cl2py as _cl2py
+from . import gki
+from . import irafecl
 try:
     from . import sscanf
 except IOError:
@@ -135,7 +135,7 @@ cl = None
 # help: implemented in irafhelp.py
 # -----------------------------------------------------
 
-from irafhelp import help
+from .irafhelp import help
 
 # -----------------------------------------------------
 # Init: basic initialization
@@ -448,8 +448,8 @@ def restoreFromFile(savefile, doprint=1, **kw):
     from stsci.tools import irafglobals
     import __main__
     import pyraf
-    import irafpar
-    import cltoken
+    from . import irafpar
+    from . import cltoken
     for module in (__main__, pyraf, irafpar, irafglobals, cltoken):
         if hasattr(module, 'INDEF'):
             module.INDEF = INDEF

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -12,7 +12,7 @@ initialization is complete.
 
 R. White, 2000 January 20
 """
-from __future__ import division, print_function
+
 
 # define INDEF, yes, no, EOF, Verbose, IrafError, userIrafHome
 

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -266,7 +266,7 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
     if not _irafinst.EXISTS:
         return {'iraf': '/iraf/is/not/here/', 'IRAFARCH': 'arch_is_unused'}
     if not _os.path.exists(file):
-        raise OSError("CL startup file %s does not exist" % file)
+        raise OSError("CL startup file {} does not exist".format(file))
     lines = open(file).readlines()
     # replace commands that exec cl with commands to print environment vars
     pat = _re.compile(r'^\s*exec\s+')
@@ -276,12 +276,12 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
         if pat.match(line):
             nfound += 1
             for var in vars:
-                newlines.append('echo "%s=$%s"\n' % (var, var))
+                newlines.append('echo "{}=${}"\n'.format(var, var))
             newlines.append('exit 0\n')
         else:
             newlines.append(line)
     if nfound == 0:
-        raise OSError("No exec statement found in script %s" % file)
+        raise OSError("No exec statement found in script {}".format(file))
     # write new script to temporary file
     (fd, newfile) = _tempfile.mkstemp()
     _os.close(fd)
@@ -293,8 +293,8 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
     fh = _io.StringIO()
     status = clOscmd(newfile, Stdout=fh)
     if status:
-        raise OSError("Execution error in script %s (derived from %s)" %
-                      (newfile, file))
+        raise OSError("Execution error in script {} (derived from {})"
+                      .format(newfile, file))
     _os.remove(newfile)
     result = fh.getvalue().split('\n')
     fh.close()
@@ -388,7 +388,7 @@ def saveToFile(savefile, **kw):
         savefile = Expand(savefile)
         if (not kw.get('clobber')) and envget(
                 "clobber", "") != yes and _os.path.exists(savefile):
-            raise OSError("Output file `%s' already exists" % savefile)
+            raise OSError("Output file `{}' already exists".format(savefile))
         # open binary pickle file
         fh = open(savefile, 'wb')
         doclose = 1
@@ -735,8 +735,8 @@ def getTask(taskname, found=0):
                     return None
                 else:
                     raise _minmatch.AmbiguousKeyError(
-                        "Task `%s' is ambiguous, could be %s" %
-                        (taskname, ', '.join(fullname)))
+                        "Task `{}' is ambiguous, could be {}"
+                        .format(taskname, ', '.join(fullname)))
             pkglist.append(sp[0])
         trylist = fullname
 
@@ -775,7 +775,7 @@ def getPkg(pkgname, found=0):
         if isinstance(pkgname, _iraftask.IrafPkg):
             return pkgname
         if not pkgname:
-            raise TypeError("Bad package name `%s'" % repr(pkgname))
+            raise TypeError("Bad package name `{}'".format(repr(pkgname)))
         # undo any modifications to the pkgname
         pkgname = _irafutils.untranslateName(pkgname)
         return _pkgs[pkgname]
@@ -785,7 +785,7 @@ def getPkg(pkgname, found=0):
     except KeyError:
         if found:
             return None
-        raise KeyError("Package `%s' not found" % (pkgname,))
+        raise KeyError("Package `{}' not found".format(pkgname))
 
 
 # -----------------------------------------------------
@@ -897,8 +897,8 @@ def listTasks(pkglist=None, hidden=0, **kw):
                 if pthis.isLoaded():
                     pkgdict[pthis.getName()] = 1
                 else:
-                    _writeError('Package %s has not been loaded' %
-                                pthis.getName())
+                    _writeError('Package {} has not been loaded'
+                                .format(pthis.getName()))
             except KeyError as e:
                 _writeError(str(e))
     if not len(pkgdict):
@@ -954,7 +954,7 @@ def listVars(prefix="", equals="\t= "):
     else:
         keylist.sort()
         for word in keylist:
-            print("%s%s%s%s" % (prefix, word, equals, envget(word)))
+            print("{}{}{}{}".format(prefix, word, equals, envget(word)))
 
 
 @handleRedirAndSaveKwds
@@ -1063,7 +1063,8 @@ def envget(var, default=None):
                 print("Using default TERM value for session.")
                 return 'xterm'
             else:
-                raise KeyError("Undefined environment variable `%s'" % var)
+                raise KeyError("Undefined environment variable `{}'"
+                               .format(var))
 
 
 _tmpfileCounter = 0
@@ -1301,7 +1302,7 @@ def radix(value, base=10, length=0):
     ivalue = int(value)
     if ivalue == 0:
         # handle specially so don't have to worry about it below
-        return "%0*d" % (length, ivalue)
+        return '{:0{:d}d}'.format(ivalue, length)
     # convert to an unsigned long integer
     hexIvalue = hex(ivalue)  # hex() can return a string for an int or a long
     isLong = hexIvalue[-1] == 'L'
@@ -1711,7 +1712,8 @@ def _imextn():
     for f in fields:
         ilist = f.split(":")
         if len(ilist) != 2:
-            raise IrafError("Illegal field `%s' in IRAF variable imextn" % f)
+            raise IrafError("Illegal field `{}' in IRAF variable imextn"
+                            .format(f))
         exts = ilist[1].split(",")
         extlist.append((ilist[0], exts))
     return extlist
@@ -1878,7 +1880,7 @@ def boolean(value):
                 return ival
         except (ValueError, OverflowError):
             pass
-    raise ValueError("Illegal boolean value %s" % repr(value))
+    raise ValueError("Illegal boolean value {}".format(repr(value)))
 
 
 # -----------------------------------------------------
@@ -1937,8 +1939,8 @@ def fscan(theLocals, line, *namelist, **kw):
         # consume the entire remaining string
         if _isStruct(theLocals, namelist[i]):
             if i < len(namelist) - 1:
-                raise TypeError("Struct type param `%s' must be the final"
-                                " argument to scan" % namelist[i])
+                raise TypeError("Struct type param `{}' must be the final"
+                                " argument to scan".format(namelist[i]))
             # ultramessy -- struct needs rest of line with embedded whitespace
             if i == 0:
                 iend = 0
@@ -1953,8 +1955,8 @@ def fscan(theLocals, line, *namelist, **kw):
                 pat = ''.join(pat)
                 mm = _re.match(pat, line)
                 if mm is None:
-                    raise RuntimeError("Bug: line '%s' pattern '%s' failed" %
-                                       (line, pat))
+                    raise RuntimeError("Bug: line '{}' pattern '{}' failed"
+                                       .format(line, pat))
                 iend = mm.end()
             if line[-1:] == '\n':
                 cmd = namelist[i] + ' = ' + repr(line[iend:-1])
@@ -2028,8 +2030,8 @@ def _weirdEOF(theLocals, namelist):
     # (I warned you to abandon hope!)
     if namelist and _isStruct(theLocals, namelist[0], checklegal=1):
         if len(namelist) > 1:
-            raise TypeError("Struct type param `%s' must be the final"
-                            " argument to scan" % namelist[0])
+            raise TypeError("Struct type param `{}' must be the final"
+                            " argument to scan".format(namelist[0]))
         # it is an undefined struct, so set it to null string
         cmd = namelist[0] + ' = ""'
         exec(cmd, theLocals)
@@ -2044,7 +2046,7 @@ def _isStruct(theLocals, name, checklegal=0):
     c = name.split('.')
     if len(c) > 1:
         # must get the parameter object, not the value
-        c[-1] = 'getParObject(%s)' % repr(c[-1])
+        c[-1] = 'getParObject({})'.format(repr(c[-1]))
     fname = '.'.join(c)
     try:
         par = eval(fname, theLocals)
@@ -2161,7 +2163,7 @@ def set(*args, **kw):
                         # vars with sequential commented-out continuation lines
                         svalue = svalue[0:svalue.find('#')]
                     _varDict[keyword] = svalue
-                msg.append("set %s=%s\n" % (keyword, svalue))
+                msg.append("set {}={}\n".format(keyword, svalue))
             _irafexecute.processCache.setenv("".join(msg))
         else:
             # set with no arguments lists all variables (using same format
@@ -2311,8 +2313,8 @@ def stty(terminal=None, **kw):
         except:
             pass  # No error message here - may not always be available
         # no args: print terminal type and size
-        print('%s ncols=%s nlines=%s' %
-              (envget('terminal', 'undefined'), envget(
+        print('{} ncols={} nlines={}'
+              .format(envget('terminal', 'undefined'), envget(
                   'ttyncols', dftNcol), envget('ttynlines', dftNlin)))
     elif expkw['resize'] or expkw['terminal'] == "resize":
         # resize: sets CL env parameters giving screen size; show errors
@@ -2385,8 +2387,8 @@ def tparam(*args):
             # try:
             getTask(taskname).tParam()
             # except (KeyError, TypeError):
-            #    _writeError("Warning: Could not find task %s for tpar\n" %
-            #            taskname)
+            #    _writeError("Warning: Could not find task {} for tpar\n"
+            #            .format(taskname))
 
 
 @handleRedirAndSaveKwds
@@ -2399,8 +2401,8 @@ def lparam(*args):
             try:
                 getTask(taskname).lParam()
             except (KeyError, TypeError):
-                _writeError("Warning: Could not find task %s for lpar\n" %
-                            taskname)
+                _writeError("Warning: Could not find task {} for lpar\n"
+                            .format(taskname))
 
 
 @handleRedirAndSaveKwdsPlus
@@ -2421,8 +2423,8 @@ def dparam(*args, **kw):
             try:
                 getTask(taskname).dParam(cl=cl)
             except (KeyError, TypeError):
-                _writeError("Warning: Could not find task %s for dpar\n" %
-                            taskname)
+                _writeError("Warning: Could not find task {} for dpar\n"
+                            .format(taskname))
 
 
 @handleRedirAndSaveKwds
@@ -2432,8 +2434,8 @@ def update(*args):
         try:
             getTask(taskname).saveParList()
         except KeyError:
-            _writeError("Warning: Could not find task %s for update" %
-                        taskname)
+            _writeError("Warning: Could not find task {} for update"
+                        .format(taskname))
 
 
 @handleRedirAndSaveKwdsPlus
@@ -2460,8 +2462,8 @@ def unlearn(*args, **kw):
                         'delete these files:\n\n\t' + '\n\t'.join(ans) +
                         '\n\nor type "unlearn ' + taskname + ' force=yes"')
             except _teal.cfgpars.NoCfgFileError:
-                _writeError("Warning: Could not find task %s to unlearn" %
-                            taskname)
+                _writeError("Warning: Could not find task {} to unlearn"
+                            .format(taskname))
 
 
 @handleRedirAndSaveKwdsPlus
@@ -2572,7 +2574,7 @@ def pyexecute(filename, **kw):
     spkgname = pkgname.replace('.', '_')
     if spkgname != pkgname:
         _writeError("Warning: `.' illegal in task name, changing "
-                    "`%s' to `%s'" % (pkgname, spkgname))
+                    "`{}' to `{}'".format(pkgname, spkgname))
         pkgname = spkgname
     if len(kw):
         raise TypeError('unexpected keyword argument: ' +
@@ -2641,7 +2643,7 @@ bye = keep = logout = clbye = cache = language = clDummy
 def _notImplemented(cmd):
     """Dummy unimplemented function"""
     if Verbose > 0:
-        _writeError("The %s task has not been implemented" % cmd)
+        _writeError("The {} task has not been implemented".format(cmd))
 
 
 @handleRedirAndSaveKwdsPlus
@@ -2774,7 +2776,8 @@ def hidetask(*args):
         try:
             getTask(taskname).setHidden()
         except KeyError:
-            _writeError("Warning: Could not find task %s to hide" % taskname)
+            _writeError("Warning: Could not find task {} to hide"
+                        .format(taskname))
 
 
 # pattern matching single task name, possibly with $ prefix and/or
@@ -2818,7 +2821,7 @@ def task(*args, **kw):
     spkgname = pkgname.replace('.', '_')
     if spkgname != pkgname:
         _writeError("Warning: `.' illegal in task name, changing "
-                    "`%s' to `%s'" % (pkgname, spkgname))
+                    "`{}' to `{}'".format(pkgname, spkgname))
         pkgname = spkgname
     # get the task name
     if len(kw) > 1:
@@ -2865,7 +2868,7 @@ def task(*args, **kw):
     for tlist in args:
         mtl = _re_taskname.match(tlist)
         if not mtl:
-            raise SyntaxError("Illegal task name `%s'" % (tlist,))
+            raise SyntaxError("Illegal task name `{}'".format(tlist))
         name = mtl.group('taskname')
         prefix = mtl.group('taskprefix')
         suffix = mtl.group('tasksuffix')
@@ -2914,7 +2917,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
                 pkgname = pkg.getName()
                 if pkgname not in printed:
                     printed[pkgname] = 1
-                    print('    %s' % pkgname)
+                    print('    {}'.format(pkgname))
             rv1 = (PkgName, PkgBinary)
         else:
             spkgname = pkgname.replace('.', '_')
@@ -2923,7 +2926,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
                 spkgname = spkgname[:-1]
             if (spkgname != pkgname) and (Verbose > 0):
                 _writeError("Warning: illegal characters in task name, "
-                            "changing `%s' to `%s'" % (pkgname, spkgname))
+                            "changing `{}' to `{}'".format(pkgname, spkgname))
             pkgname = spkgname
             # is the package defined?
             # if not, is there a CL task by this name?
@@ -2933,7 +2936,7 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
                 pkg = getTask(pkgname, found=1)
                 if pkg is None or not isinstance(pkg, _iraftask.IrafCLTask) or \
                         pkg.getName() != pkgname:
-                    raise KeyError("Package `%s' not defined" % pkgname)
+                    raise KeyError("Package `{}' not defined".format(pkgname))
                 # Hack city -- there is a CL task with the package name, but it was
                 # not defined to be a package.  Convert it to an IrafPkg object.
 
@@ -2949,8 +2952,8 @@ def package(pkgname=None, bin=None, PkgName='', PkgBinary='', **kw):
                 loadedPath.append(pkg)
                 addLoaded(pkg)
                 if Verbose > 0:
-                    _writeError("Warning: CL task `%s' apparently is "
-                                "a package" % pkgname)
+                    _writeError("Warning: CL task `{}' apparently is "
+                                "a package".format(pkgname))
 
             # Make sure that this is the current package, even
             # if another package was loaded in the package script
@@ -2982,20 +2985,20 @@ def clPrint(*args):
 
 def _quietConv(w, d, c, args, i):
     """Format codes that are quietly converted to %s"""
-    return "%%%ss" % w
+    return "%{}s".format(w)
 
 
 def _boolConv(w, d, c, args, i):
     """Boolean gets converted to upper case before printing"""
     args[i] = str(args[i]).upper()
-    return "%%%ss" % w
+    return "%{}s".format(w)
 
 
 def _badConv(w, d, c, args, i):
     """Format codes that are converted to %s with warning"""
-    _writeError("Warning: printf cannot handle format '%%%s', "
-                "using '%%%ss' instead\n" % (w + d + c, w))
-    return "%%%ss" % w
+    _writeError("Warning: printf cannot handle format '%{}', "
+                "using '%{}s' instead\n".format(w + d + c, w))
+    return "%{}s".format(w)
 
 
 def _hConv(w, d, c, args, i):
@@ -3014,7 +3017,7 @@ def _hConv(w, d, c, args, i):
             args[i] = clDms(value, digits=digits, seconds=c not in "mM")
         except ValueError:
             pass
-    return "%%%ss" % w
+    return "%{}s".format(w)
 
 
 def _rConv(w, d, c, args, i):
@@ -3029,7 +3032,7 @@ def _rConv(w, d, c, args, i):
             args[i] = radix(args[i], base, length=int(w))
         else:
             args[i] = radix(args[i], base)
-    return "%%%ss" % w
+    return "%{}s".format(w)
 
 
 def _wConv(w, d, c, args, i):
@@ -3044,7 +3047,7 @@ def _wConv(w, d, c, args, i):
             except ValueError:
                 w = 0
     args[i] = ""
-    return "%%%ss" % w
+    return "%{}s".format(w)
 
 
 # pattern matching %w.dc where c is single letter format code
@@ -3123,8 +3126,8 @@ def printf(format, *args):
     except ValueError as e:
         raise IrafError(str(e))
     except TypeError as e:
-        raise IrafError('%s\nFormat/datatype mismatch in printf '
-                        '(format is %s)' % (str(e), repr(format)))
+        raise IrafError('{}\nFormat/datatype mismatch in printf '
+                        '(format is {})'.format(str(e), repr(format)))
 
 
 # _backDir is previous working directory
@@ -3164,15 +3167,15 @@ def chdir(directory=None):
         edir = Expand(directory)
         _os.chdir(edir)
         _backDir = _newBack
-        _irafexecute.processCache.setenv('chdir %s\n' % edir)
+        _irafexecute.processCache.setenv('chdir {}\n'.format(edir))
     except (IrafError, OSError):
         try:
             edir = Expand(directory + '$')
             _os.chdir(edir)
             _backDir = _newBack
-            _irafexecute.processCache.setenv('chdir %s\n' % edir)
+            _irafexecute.processCache.setenv('chdir {}\n'.format(edir))
         except (IrafError, OSError):
-            raise IrafError("Cannot change directory to `%s'" % (directory,))
+            raise IrafError("Cannot change directory to `{}'".format(directory))
 
 
 cd = chdir
@@ -3191,13 +3194,13 @@ def back():
         _newBack = _backDir
     _os.chdir(_backDir)
     print(_backDir)
-    _irafexecute.processCache.setenv('chdir %s\n' % _backDir)
+    _irafexecute.processCache.setenv('chdir {}\n'.format(_backDir))
     _backDir = _newBack
 
 
 def error(errno=0, errmsg='', task="error", _save=False, suppress=True):
     """Print error message"""
-    e = IrafError("ERROR: %s\n" % errmsg,
+    e = IrafError("ERROR: {}\n".format(errmsg),
                   errno=errno,
                   errmsg=errmsg,
                   errtask=task)
@@ -3246,7 +3249,7 @@ def clCompatibilityMode(verbose=0, _save=0):
         vmode = ' (verbose)'
     else:
         vmode = ''
-    print('Entering CL-compatibility%s mode...' % vmode)
+    print('Entering CL-compatibility{} mode...'.format(vmode))
 
     # logging may be active if Monty is in use
     if hasattr(__main__, '_pycmdline'):
@@ -3343,7 +3346,7 @@ def clArray(array_size,
                                     array_size=array_size,
                                     strict=strict)
     except ValueError as e:
-        raise ValueError("Error creating Cl array `%s'\n%s" % (name, str(e)))
+        raise ValueError("Error creating Cl array `{}'\n{}".format(name, str(e)))
 
 
 # -----------------------------------------------------
@@ -3378,8 +3381,8 @@ def clExecute(s,
                               local_vars_dict=local_vars_dict,
                               local_vars_list=local_vars_list)
         # use special scriptname
-        taskname = "CL%s" % (_clExecuteCount,)
-        scriptname = "<CL script %s>" % (taskname,)
+        taskname = "CL{}".format(_clExecuteCount)
+        scriptname = "<CL script {}>".format(taskname)
         code = pycode.code.lstrip()  # XXX needed?
         #       DBG('*'*80)
         #       DBG('pycode for task,script='+str((taskname,scriptname,))+':\n'+code)
@@ -3466,8 +3469,8 @@ def _expand1(instring, noerror):
         elif noerror:
             varname = ""
         else:
-            raise IrafError("Undefined variable `%s' in string `%s'" %
-                            (varname, instring))
+            raise IrafError("Undefined variable `{}' in string `{}'"
+                            .format(varname, instring))
         instring = instring[:mm.start()] + varname + instring[mm.end():]
         mm = __re_var_paren.search(instring)
     # now expand variable name at start of string
@@ -3481,8 +3484,8 @@ def _expand1(instring, noerror):
     elif noerror:
         return _expand1(varname + instring[mm.end():], noerror)
     else:
-        raise IrafError("Undefined variable `%s' in string `%s'" %
-                        (varname, instring))
+        raise IrafError("Undefined variable `{}' in string `{}'"
+                        .format(varname, instring))
 
 
 def IrafTaskFactory(prefix='',
@@ -3519,13 +3522,13 @@ def IrafTaskFactory(prefix='',
     spkgname = pkgname.replace('.', '_')
     if spkgname != pkgname:
         _writeError("Warning: `.' illegal in package name, changing "
-                    "`%s' to `%s'" % (pkgname, spkgname))
+                    "`{}' to `{}'".format(pkgname, spkgname))
         pkgname = spkgname
 
     staskname = taskname.replace('.', '_')
     if staskname != taskname:
         _writeError("Warning: `.' illegal in task name, changing "
-                    "`%s' to `%s'" % (taskname, staskname))
+                    "`{}' to `{}'".format(taskname, staskname))
         taskname = staskname
 
     if suffix == '.pkg':
@@ -3553,7 +3556,7 @@ def IrafTaskFactory(prefix='',
     # existing task object (if any)
     task = _tasks.get(fullname)
     if task is None and redefine:
-        _writeError("Warning: `%s' is not a defined task" % taskname)
+        _writeError("Warning: `{}' is not a defined task".format(taskname))
 
     if function is not None:
         newtask = module.IrafPythonTask(prefix,
@@ -3578,7 +3581,8 @@ def IrafTaskFactory(prefix='',
         if not task.isConsistent(newtask):
             # looks different -- print warning and continue
             if not redefine:
-                _writeError("Warning: `%s' is a task redefinition" % fullname)
+                _writeError("Warning: `{}' is a task redefinition"
+                            .format(fullname))
         else:
             # new task is consistent with old task, so return old task
             if task.getPkgbinary() != newtask.getPkgbinary():
@@ -3616,7 +3620,7 @@ def IrafPsetFactory(prefix,
     fullname = pkgname + '.' + taskname
     task = _tasks.get(fullname)
     if task is None and redefine:
-        _writeError("Warning: `%s' is not a defined task" % taskname)
+        _writeError("Warning: `{}' is not a defined task".format(taskname))
 
     newtask = module.IrafPset(prefix, taskname, suffix, value, pkgname,
                               pkgbinary)
@@ -3625,7 +3629,8 @@ def IrafPsetFactory(prefix,
         # object (which will be discarded)
         if task.getFilename() != newtask.getFilename():
             if redefine:
-                _writeError("Warning: `%s' is a task redefinition" % fullname)
+                _writeError("Warning: `{}' is a task redefinition"
+                            .format(fullname))
         else:
             # old version of task is same as new
             return task
@@ -3665,20 +3670,20 @@ def IrafPkgFactory(prefix,
     # dictionary _pkgs?
     pkg = _pkgs.get_exact_key(taskname)
     if pkg is None and redefine:
-        _writeError("Warning: `%s' is not a defined task" % taskname)
+        _writeError("Warning: `{}' is not a defined task".format(taskname))
     newpkg = module.IrafPkg(prefix, taskname, suffix, value, pkgname,
                             pkgbinary)
     if pkg is not None:
         if pkg.getFilename() != newpkg.getFilename() or \
            pkg.hasParfile()  != newpkg.hasParfile():
             if pkg.isLoaded():
-                _writeError("Warning: currently loaded package `%s' was not "
-                            "redefined" % taskname)
+                _writeError("Warning: currently loaded package `{}' was not "
+                            "redefined".format(taskname))
                 return pkg
             else:
                 if not redefine:
-                    _writeError("Warning: `%s' is a task redefinition" %
-                                taskname)
+                    _writeError("Warning: `{}' is a task redefinition"
+                                .format(taskname))
                 _addPkg(newpkg)
                 return newpkg
         if pkg.getPkgbinary() != newpkg.getPkgbinary():
@@ -3746,8 +3751,8 @@ def redirProcess(kw):
                     else:
                         # IRAF doesn't raise an exception here (e.g., on
                         # input redirection from "STDOUT"), but it should
-                        raise OSError("Illegal value `%s' for %s redirection" %
-                                      (value, key))
+                        raise OSError("Illegal value `{}' for {} redirection"
+                                      .format(value, key))
                 else:
                     # expand IRAF variables
                     value = Expand(value)
@@ -3763,8 +3768,8 @@ def redirProcess(kw):
                                 envget("clobber", "") != yes and \
                                 _os.path.exists(value):
                             # don't overwrite unless clobber is set
-                            raise OSError("Output file `%s' already exists" %
-                                          value)
+                            raise OSError("Output file `{}' already exists"
+                                          .format(value))
                     fh = open(value, openArgs)
                     # close this when we're done
                     closeFHList.append(fh)
@@ -3773,9 +3778,9 @@ def redirProcess(kw):
                 # that output should be captured and returned as
                 # function value
                 if not outputFlag:
-                    raise IrafError("%s redirection must "
+                    raise IrafError("{} redirection must "
                                     "be from a file handle or string\n"
-                                    "Value is `%s'" % (key, value))
+                                    "Value is `{}'".format(key, value))
                 if not value:
                     fh = None
                 else:
@@ -3791,9 +3796,9 @@ def redirProcess(kw):
             elif isinstance(value, (list, tuple)):
                 # list/tuple of strings is OK for input
                 if outputFlag:
-                    raise IrafError("%s redirection must "
+                    raise IrafError("{} redirection must "
                                     "be to a file handle or string\n"
-                                    "Value is type %s" % (key, type(value)))
+                                    "Value is type {}".format(key, type(value)))
                 try:
                     if value and value[0][-1:] == '\n':
                         s = ''.join(value)
@@ -3806,19 +3811,19 @@ def redirProcess(kw):
                     # close this when we're done
                     closeFHList.append(fh)
                 except TypeError:
-                    raise IrafError("%s redirection must "
-                                    "be from a sequence of strings\n" % key)
+                    raise IrafError("{} redirection must be from a "
+                                    "sequence of strings\n".format(key))
             else:
                 # must be a file handle
                 if outputFlag:
                     if not hasattr(value, 'write'):
-                        raise IrafError("%s redirection must "
+                        raise IrafError("{} redirection must "
                                         "be to a file handle or string\n"
-                                        "Value is `%s'" % (key, value))
+                                        "Value is `{}'".format(key, value))
                 elif not hasattr(value, 'read'):
-                    raise IrafError("%s redirection must "
+                    raise IrafError("{} redirection must "
                                     "be from a file handle or string\n"
-                                    "Value is `%s'" % (key, value))
+                                    "Value is `{}'".format(key, value))
                 fh = value
             if fh is not None:
                 redirKW[standardName] = fh

--- a/pyraf/irafgwcs.py
+++ b/pyraf/irafgwcs.py
@@ -9,7 +9,6 @@ only commit the change when it appears to really be applicable.
 
 import numpy
 import math
-from stsci.tools.for2to3 import ndarr2bytes
 from stsci.tools.irafglobals import IrafError
 from . import irafinst
 
@@ -136,8 +135,7 @@ class IrafGWcs:
         for i in range(WCS_SLOTS):
             record = wcsStruct[_WCS_RECORD_SIZE * i:_WCS_RECORD_SIZE * (i + 1)]
             # read 8 4-byte floats from beginning of record
-            fvals = numpy.fromstring(ndarr2bytes(record[:8 * SZ]),
-                                     numpy.float32)
+            fvals = numpy.fromstring(record[:8 * SZ].tobytes(), numpy.float32)
             if _IRAF64BIT:
                 # seems to send an extra 0-valued int32 after each 4 bytes
                 fvalsView = fvals.reshape(-1, 2).transpose()
@@ -145,7 +143,7 @@ class IrafGWcs:
                     raise IrafError("Assumed WCS float padding is non-zero")
                 fvals = fvalsView[0]
             # read 3 4-byte ints after that
-            ivals = numpy.fromstring(ndarr2bytes(record[8 * SZ:11 * SZ]),
+            ivals = numpy.fromstring(record[8 * SZ:11 * SZ].tobytes(),
                                      numpy.int32)
             if _IRAF64BIT:
                 # seems to send an extra 0-valued int32 after each 4 bytes
@@ -196,8 +194,8 @@ class IrafGWcs:
             # if the padding doesn't bring the size out to exactly the
             # correct length (_WCS_RECORD_SIZE)
             wcsStruct[_WCS_RECORD_SIZE*i:_WCS_RECORD_SIZE*(i+1)] = \
-                numpy.fromstring(ndarr2bytes(farr)+ndarr2bytes(iarr)+pad, numpy.int16)
-        return ndarr2bytes(wcsStruct)
+                numpy.fromstring(farr.tobytes()+iarr.tobytes()+pad, numpy.int16)
+        return wcsStruct.tobytes()
 
     def transform(self, x, y, wcsID):
         """Transform x,y to wcs coordinates for the given

--- a/pyraf/irafgwcs.py
+++ b/pyraf/irafgwcs.py
@@ -9,7 +9,7 @@ only commit the change when it appears to really be applicable.
 
 import numpy
 import math
-from stsci.tools.for2to3 import ndarr2bytes, tobytes, BNULLSTR
+from stsci.tools.for2to3 import ndarr2bytes, BNULLSTR
 from stsci.tools.irafglobals import IrafError
 from . import irafinst
 
@@ -165,9 +165,9 @@ class IrafGWcs:
         init_wcs_sizes()
         self.commit()
         wcsStruct = numpy.zeros(_WCS_RECORD_SIZE * WCS_SLOTS, numpy.int16)
-        pad = tobytes('\x00\x00\x00\x00')
+        pad = b'\x00\x00\x00\x00'
         if _IRAF64BIT:
-            pad = tobytes('\x00\x00\x00\x00\x00\x00\x00\x00')
+            pad = b'\x00\x00\x00\x00\x00\x00\x00\x00'
         for i in range(WCS_SLOTS):
             x = self.wcs[i]
             farr = numpy.array(x[:8], numpy.float32)

--- a/pyraf/irafgwcs.py
+++ b/pyraf/irafgwcs.py
@@ -135,7 +135,7 @@ class IrafGWcs:
         for i in range(WCS_SLOTS):
             record = wcsStruct[_WCS_RECORD_SIZE * i:_WCS_RECORD_SIZE * (i + 1)]
             # read 8 4-byte floats from beginning of record
-            fvals = numpy.fromstring(record[:8 * SZ].tobytes(), numpy.float32)
+            fvals = numpy.frombuffer(record[:8 * SZ].tobytes(), numpy.float32)
             if _IRAF64BIT:
                 # seems to send an extra 0-valued int32 after each 4 bytes
                 fvalsView = fvals.reshape(-1, 2).transpose()
@@ -143,7 +143,7 @@ class IrafGWcs:
                     raise IrafError("Assumed WCS float padding is non-zero")
                 fvals = fvalsView[0]
             # read 3 4-byte ints after that
-            ivals = numpy.fromstring(record[8 * SZ:11 * SZ].tobytes(),
+            ivals = numpy.frombuffer(record[8 * SZ:11 * SZ].tobytes(),
                                      numpy.int32)
             if _IRAF64BIT:
                 # seems to send an extra 0-valued int32 after each 4 bytes
@@ -194,7 +194,7 @@ class IrafGWcs:
             # if the padding doesn't bring the size out to exactly the
             # correct length (_WCS_RECORD_SIZE)
             wcsStruct[_WCS_RECORD_SIZE*i:_WCS_RECORD_SIZE*(i+1)] = \
-                numpy.fromstring(farr.tobytes()+iarr.tobytes()+pad, numpy.int16)
+                numpy.frombuffer(farr.tobytes()+iarr.tobytes()+pad, numpy.int16)
         return wcsStruct.tobytes()
 
     def transform(self, x, y, wcsID):

--- a/pyraf/irafgwcs.py
+++ b/pyraf/irafgwcs.py
@@ -9,7 +9,7 @@ only commit the change when it appears to really be applicable.
 
 import numpy
 import math
-from stsci.tools.for2to3 import ndarr2bytes, BNULLSTR
+from stsci.tools.for2to3 import ndarr2bytes
 from stsci.tools.irafglobals import IrafError
 from . import irafinst
 
@@ -190,7 +190,7 @@ class IrafGWcs:
                 iarr = iarr.flatten()
             # end-pad?
             if len(farr) + len(iarr) == (_WCS_RECORD_SIZE // 2):
-                pad = BNULLSTR  # for IRAF2.14 or prior; all new vers need end-pad
+                pad = b''  # for IRAF2.14 or prior; all new vers need end-pad
 
             # Pack the wcsStruct - this will throw "ValueError: shape mismatch"
             # if the padding doesn't bring the size out to exactly the

--- a/pyraf/irafgwcs.py
+++ b/pyraf/irafgwcs.py
@@ -11,7 +11,7 @@ import numpy
 import math
 from stsci.tools.for2to3 import ndarr2bytes, tobytes, BNULLSTR
 from stsci.tools.irafglobals import IrafError
-import irafinst
+from . import irafinst
 
 # global vars
 _IRAF64BIT = False

--- a/pyraf/irafgwcs.py
+++ b/pyraf/irafgwcs.py
@@ -5,7 +5,7 @@ possibly other tasks) where the WCS for an existing plot gets changed
 before the plot is cleared.  I save the changed wcs in self.pending and
 only commit the change when it appears to really be applicable.
 """
-from __future__ import division, print_function
+
 
 import numpy
 import math

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -34,7 +34,7 @@ The **kw argument allows minimum matching for the keyword arguments
 
 R. White, 1999 September 23
 """
-from __future__ import division, print_function
+
 
 import __main__
 import re

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -49,7 +49,7 @@ except ImportError:  # only for Python 2.5
 from stsci.tools import minmatch, irafutils
 from stsci.tools.irafglobals import IrafError, IrafTask, IrafPkg
 from stsci.tools.for2to3 import PY3K
-import describe
+from . import describe
 
 # use this form since the iraf import is circular
 import pyraf.iraf

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -48,7 +48,6 @@ except ImportError:  # only for Python 2.5
 
 from stsci.tools import minmatch, irafutils
 from stsci.tools.irafglobals import IrafError, IrafTask, IrafPkg
-from stsci.tools.for2to3 import PY3K
 from . import describe
 
 # use this form since the iraf import is circular
@@ -72,10 +71,6 @@ _functionTypes = (types.BuiltinFunctionType, types.FunctionType,
                   types.LambdaType)
 
 _methodTypes = (types.BuiltinMethodType, types.MethodType)
-
-if not PY3K:
-    # in PY3K, UnboundMethodType is simply FunctionType
-    _methodTypes += (types.UnboundMethodType,)
 
 _listTypes = (list, tuple, dict)
 
@@ -112,8 +107,6 @@ def _isinstancetype(an_obj):
     Return True if the passed object is an instance of a class, else False. """
     if an_obj is None:
         return False
-    if not PY3K:
-        return isinstance(an_obj, types.InstanceType)
     typstr = str(type(an_obj))
     # the following logic works, as PyRAF users expect, in both v2 and v3
     return typstr=="<type 'instance'>" or \
@@ -344,8 +337,7 @@ def _getContents(vlist, regexp, an_obj):
                 sortlist[vorder].append((vname, value))
                 namedict[vname] = 1
     # add methods from base classes if this is a class
-    if (not PY3K and isinstance(an_obj, types.ClassType)) or \
-       (PY3K and isinstance(an_obj, type(object))): # i.e. "<class 'type'>"
+    if isinstance(an_obj, type(object)): # i.e. "<class 'type'>"
         classlist = list(an_obj.__bases__)
         for c in classlist:
             classlist.extend(list(c.__bases__))
@@ -401,8 +393,7 @@ def _valueString(value, verbose=0):
             vstr = vstr + ", value = " + repr(value)
     elif issubclass(t, _listTypes):
         return "%s [%d entries]" % (vstr, len(value))
-    elif (PY3K and issubclass(t, io.IOBase)) or \
-         (not PY3K and issubclass(t, file)):
+    elif issubclass(t, io.IOBase):
         vstr = vstr + ", " + repr(value)
     elif issubclass(t, _numericTypes):
         vstr = vstr + ", value = " + repr(value)

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -392,7 +392,7 @@ def _valueString(value, verbose=0):
         else:
             vstr = vstr + ", value = " + repr(value)
     elif issubclass(t, _listTypes):
-        return "%s [%d entries]" % (vstr, len(value))
+        return "{} [{:d} entries]".format(vstr, len(value))
     elif issubclass(t, io.IOBase):
         vstr = vstr + ", " + repr(value)
     elif issubclass(t, _numericTypes):

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -79,7 +79,7 @@ if not PY3K:
 
 _listTypes = (list, tuple, dict)
 
-_numericTypes = (float, int, long, complex)
+_numericTypes = (float, int, complex)
 if 'bool' in globals():
     _numericTypes = _numericTypes + (bool,)
 

--- a/pyraf/irafimcur.py
+++ b/pyraf/irafimcur.py
@@ -31,7 +31,7 @@ def _getDevice(displayname=None):
         device = gwm.gki.getGraphcap()[displayname]
         dd = device['DD'].split(',')
         if len(dd) > 1 and dd[1] != '':
-            imtdev = 'fifo:%si:%so' % (dd[1], dd[1])
+            imtdev = 'fifo:{}i:{}o'.format(dd[1], dd[1])
         else:
             imtdev = None
         # multiple stdimage/graphcap entries can share the same device
@@ -49,7 +49,7 @@ def _getDevice(displayname=None):
         return device
     except (ValueError, OSError):
         pass
-    raise IrafError("Unable to open image display `%s'\n" % displayname)
+    raise IrafError("Unable to open image display `{}'\n".format(displayname))
 
 
 def imcur(displayname=None):
@@ -71,7 +71,7 @@ def imcur(displayname=None):
         # Read cursor position at keystroke
         result = device.readCursor()
         if Verbose > 1:
-            sys.__stdout__.write("%s\n" % (result,))
+            sys.__stdout__.write("{}\n".format(result))
             sys.__stdout__.flush()
         if result == 'EOF':
             raise EOFError()

--- a/pyraf/irafimcur.py
+++ b/pyraf/irafimcur.py
@@ -39,7 +39,7 @@ def _getDevice(displayname=None):
             _devices[imtdev] = irafdisplay.ImageDisplayProxy(imtdev)
         device = _devices[displayname] = _devices[imtdev]
         return device
-    except (KeyError, IOError, OSError):
+    except (KeyError, OSError):
         pass
 
     # last gasp is to assume display is an imtdev string
@@ -47,7 +47,7 @@ def _getDevice(displayname=None):
         device = _devices[displayname] = irafdisplay.ImageDisplayProxy(
             displayname)
         return device
-    except (ValueError, IOError):
+    except (ValueError, OSError):
         pass
     raise IrafError("Unable to open image display `%s'\n" % displayname)
 
@@ -86,5 +86,5 @@ def imcur(displayname=None):
             sys.stdout.flush()
             result = result + ' ' + irafutils.tkreadline()[:-1]
         return result
-    except IOError as error:
+    except OSError as error:
         raise IrafError(str(error))

--- a/pyraf/irafimcur.py
+++ b/pyraf/irafimcur.py
@@ -4,7 +4,7 @@ Read the cursor position from stdimage image display device (DS9,
 SAOIMAGE or XIMTOOL) and return a string compatible with IRAF's
 imcur parameter.
 """
-from __future__ import division, print_function
+
 
 import sys
 from stsci.tools import irafutils

--- a/pyraf/irafimcur.py
+++ b/pyraf/irafimcur.py
@@ -9,9 +9,9 @@ from __future__ import division, print_function
 import sys
 from stsci.tools import irafutils
 from stsci.tools.irafglobals import Verbose, IrafError
-import irafdisplay
-import gwm
-import iraf
+from . import irafdisplay
+from . import gwm
+from . import iraf
 
 # dictionary of devices to support multiple active displays
 _devices = {}

--- a/pyraf/irafimport.py
+++ b/pyraf/irafimport.py
@@ -10,7 +10,7 @@ module attributes.  Only affects imports of iraf module.
 
 R. White, 1999 August 17
 """
-from __future__ import absolute_import, division, print_function
+
 
 import builtins
 import sys

--- a/pyraf/irafimport.py
+++ b/pyraf/irafimport.py
@@ -20,14 +20,14 @@ IMPORT_DEBUG = False
 
 # Save the original hooks;  replaced at bottom of module...
 _originalImport = builtins.__import__
-import imp
-_originalReload = imp.reload
+import importlib
+_originalReload = importlib.reload
 
 
 def restoreBuiltins():
     """ Called before exiting pyraf - this puts import and reload back. """
     builtins.__import__ = _originalImport
-    imp.reload = _originalReload
+    importlib.reload = _originalReload
 
 
 def _irafImport(name, globals={}, locals={}, fromlist=[], level=-1):
@@ -178,7 +178,7 @@ class _irafModuleClass:
 
 # Install our hooks
 builtins.__import__ = _irafImport
-imp.reload = _irafReload
+importlib.reload = _irafReload
 
 # create the module proxy
 _irafModuleProxy = _irafModuleClass()

--- a/pyraf/irafimport.py
+++ b/pyraf/irafimport.py
@@ -12,7 +12,7 @@ R. White, 1999 August 17
 """
 from __future__ import absolute_import, division, print_function
 
-import __builtin__
+import builtins
 import sys
 from stsci.tools import minmatch
 
@@ -23,9 +23,9 @@ _reloadIsBuiltin = sys.version_info[0] < 3
 IMPORT_DEBUG = False
 
 # Save the original hooks;  replaced at bottom of module...
-_originalImport = __builtin__.__import__
+_originalImport = builtins.__import__
 if _reloadIsBuiltin:
-    _originalReload = __builtin__.reload
+    _originalReload = builtins.reload
 else:
     import imp
     _originalReload = imp.reload
@@ -33,9 +33,9 @@ else:
 
 def restoreBuiltins():
     """ Called before exiting pyraf - this puts import and reload back. """
-    __builtin__.__import__ = _originalImport
+    builtins.__import__ = _originalImport
     if _reloadIsBuiltin:
-        __builtin__.reload = _originalReload
+        builtins.reload = _originalReload
     else:
         imp.reload = _originalReload
 
@@ -193,9 +193,9 @@ class _irafModuleClass:
 
 
 # Install our hooks
-__builtin__.__import__ = _irafImport
+builtins.__import__ = _irafImport
 if _reloadIsBuiltin:
-    __builtin__.reload = _irafReload
+    builtins.reload = _irafReload
 else:
     imp.reload = _irafReload
 

--- a/pyraf/irafimport.py
+++ b/pyraf/irafimport.py
@@ -86,8 +86,8 @@ def _irafImport(name, globals={}, locals={}, fromlist=[], level=-1):
                 'minmatch', 'irafutils', 'dialog', 'listdlg', 'filedlg',
                 'alert', 'irafglobals'
         ]:
-            if name == ('pyraf.%s' % module):
-                name = 'stsci.tools.%s' % module
+            if name == 'pyraf.{}'.format(module):
+                name = 'stsci.tools.{}'.format(module)
         # Replace any instances of 'pytools' with 'stsci.tools' -- the
         # new name of the former pytools package
         name = name.replace('pytools.', 'stsci.tools.')
@@ -154,7 +154,7 @@ class _irafModuleClass:
         try:
             return self.mmdict[attr]
         except KeyError:
-            raise AttributeError("Undefined IRAF task `%s'" % (attr,))
+            raise AttributeError("Undefined IRAF task `{}'".format(attr))
 
     def __setattr__(self, attr, value):
         # add an attribute to the module itself

--- a/pyraf/irafimport.py
+++ b/pyraf/irafimport.py
@@ -95,7 +95,7 @@ def _irafImport(name, globals={}, locals={}, fromlist=[], level=-1):
     # Same for everything in fromlist (which is a tuple in PY3K)
     if fromlist:
         fromlist = tuple(
-            [item.replace('pytools', 'stsci.tools') for item in fromlist])
+            item.replace('pytools', 'stsci.tools') for item in fromlist)
     # !!! END TEMPORARY KLUDGE !!!
 
     hadIrafInList = fromlist and 'iraf' in fromlist and name == '' and level > 0

--- a/pyraf/irafinst.py
+++ b/pyraf/irafinst.py
@@ -264,7 +264,7 @@ keep
 
 def getIrafVer():
     """ Return current IRAF version as a string """
-    import iraffunctions
+    from . import iraffunctions
     cltask = iraffunctions.getTask('cl')
     # must use default par list, in case they have a local override
     plist = cltask.getDefaultParList()

--- a/pyraf/irafinst.py
+++ b/pyraf/irafinst.py
@@ -6,7 +6,7 @@ Obviously, this module should refrain as much as possible from importing any
 IRAF related code (at least globally), since this is heavily relied upon in
 non-IRAF situations.
 """
-from __future__ import division, print_function
+
 
 import os
 import shutil

--- a/pyraf/irafnames.py
+++ b/pyraf/irafnames.py
@@ -4,7 +4,7 @@ be changed.
 
 R. White, 1999 March 26
 """
-from __future__ import division, print_function
+
 
 import __main__
 from stsci.tools import irafglobals

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -10,7 +10,6 @@ import os
 import re
 import types
 from stsci.tools import basicpar, minmatch, irafutils, taskpars
-from stsci.tools.for2to3 import PY3K
 from stsci.tools.irafglobals import INDEF, Verbose, yes, no
 from stsci.tools.basicpar import (warning, _StringMixin, IrafPar, IrafParS,
                                   _cmdlineFlag)
@@ -751,11 +750,7 @@ class IrafParList(taskpars.TaskPars):
         # hidden Python parameters go into the standard dictionary
         # (hope there are none of these in IRAF tasks)
         if name and name[0] == '_':
-            if PY3K:
-                object.__setattr__(self, name,
-                                   value)  # new-style class objects
-            else:
-                self.__dict__[name] = value  # for old-style classes
+            object.__setattr__(self, name, value)
         else:
             self.setParam(name, value)
 

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -2,7 +2,7 @@
 
 R. White, 2000 January 7
 """
-from __future__ import division, print_function
+
 
 import copy
 import glob

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -154,9 +154,8 @@ def makeIrafPar(init_value,
             fields.extend([min, max, prompt])
         if init_value is not None:
             if len(init_value) != array_size:
-                raise ValueError(
-                    "Initial value list does not match array size for parameter `%s'"
-                    % name)
+                raise ValueError("Initial value list does not match array "
+                                 "size for parameter `{}'".format(name))
             for iv in init_value:
                 fields.append(iv)
         else:
@@ -167,7 +166,7 @@ def makeIrafPar(init_value,
     try:
         return IrafParFactory(fields, strict=strict)
     except ValueError as e:
-        errmsg = "Bad value for parameter `%s'\n%s" % (name, str(e))
+        errmsg = "Bad value for parameter `{}'\n{}".format(name, str(e))
         raise ValueError(errmsg)
 
 
@@ -326,14 +325,15 @@ class IrafParL(_StringMixin, IrafPar):
                     value = ''
                 if not value:
                     # EOF -- raise exception
-                    raise EOFError("EOF from list parameter `%s'" % self.name)
+                    raise EOFError("EOF from list parameter `{}'"
+                                   .format(self.name))
                 if value[-1:] == "\n":
                     value = value[:-1]
             except OSError as e:
                 if not self.errMsg:
-                    warning("Unable to read values for list parameter `%s' "
-                            "from file `%s'\n%s" %
-                            (self.name, self.value, str(e)),
+                    warning("Unable to read values for list parameter `{}' "
+                            "from file `{}'\n{}"
+                            .format(self.name, self.value, str(e)),
                             level=-1)
                     # only print message one time
                     self.errMsg = 1
@@ -655,11 +655,11 @@ class IrafParList(taskpars.TaskPars):
                         self.__pars[j] = p
                         return
                 else:
-                    raise RuntimeError("Bug: parameter `%s' is in dictionary "
-                                       "__pardict but not in list __pars??" %
-                                       p.name)
-            raise ValueError("Parameter named `%s' is already defined" %
-                             p.name)
+                    raise RuntimeError("Bug: parameter `{}' is in dictionary "
+                                       "__pardict but not in list __pars??"
+                                       .format(p.name))
+            raise ValueError("Parameter named `{}' is already defined"
+                             .format(p.name))
         # add it just before the mode and $nargs parameters (if present)
         j = -1
         for i in range(len(self.__pars)):
@@ -691,7 +691,8 @@ class IrafParList(taskpars.TaskPars):
         """
         if not isinstance(other, self.__class__):
             if Verbose > 0:
-                print('Comparison list is not a %s' % self.__class__.__name__)
+                print('Comparison list is not a {}'
+                      .format(self.__class__.__name__))
             return 0
         # compare minimal set of parameter attributes
         thislist = self._getConsistentList()
@@ -1095,7 +1096,7 @@ class IrafParList(taskpars.TaskPars):
         for i in range(len(self.__pars)):
             p = self.__pars[i]
             if p.name != '$nargs':
-                print("%s%s" % (taskname, p.dpar(cl=cl)))
+                print("{}{}".format(taskname, p.dpar(cl=cl)))
         if cl:
             print("# EOF")
 
@@ -1130,11 +1131,11 @@ class IrafParList(taskpars.TaskPars):
                 fh.write(par.save() + '\n')
         if fh != filename:
             fh.close()
-            return "%d parameters written to %s" % (nsave, filename)
+            return "{:d} parameters written to {}".format(nsave, filename)
         elif hasattr(fh, 'name'):
-            return "%d parameters written to %s" % (nsave, fh.name)
+            return "{:d} parameters written to {}".format(nsave, fh.name)
         else:
-            return "%d parameters written" % (nsave,)
+            return "{:d} parameters written".format(nsave)
 
     def __getinitargs__(self):
         """Return parameters for __init__ call in pickle"""
@@ -1200,12 +1201,12 @@ def _extractDiffInfo(alist):
 def _printHiddenDiff(pd1, hd1, pd2, hd2):
     for key in pd1.keys():
         if key in hd2:
-            print("Parameter `%s' is hidden in list 2 but not list 1" % (key,))
+            print("Parameter `{}' is hidden in list 2 but not list 1".format(key))
             del pd1[key]
             del hd2[key]
     for key in pd2.keys():
         if key in hd1:
-            print("Parameter `%s' is hidden in list 1 but not list 2" % (key,))
+            print("Parameter `{}' is hidden in list 1 but not list 2".format(key))
             del pd2[key]
             del hd1[key]
 
@@ -1230,27 +1231,27 @@ def _printDiff(pd1, pd2, label):
             else:
                 # one or both parameters missing
                 if key1 not in pd2:
-                    print("Extra %s parameter `%s' (type `%s') in list 1" %
-                          (label, key1, pd1[key1][0]))
+                    print("Extra {} parameter `{}' (type `{}') in list 1"
+                          .format(label, key1, pd1[key1][0]))
                     # delete the extra parameter
                     del pd1[key1]
                     i1 = i1 + 1
                 if key2 not in pd1:
-                    print("Extra %s parameter `%s' (type `%s') in list 2" %
-                          (label, key2, pd2[key2][0]))
+                    print("Extra {} parameter `{}' (type `{}') in list 2"
+                          .format(label, key2, pd2[key2][0]))
                     del pd2[key2]
                     i2 = i2 + 1
         # other parameters must be missing
         while i1 < len(k1):
             key1 = k1[i1]
-            print("Extra %s parameter `%s' (type `%s') in list 1" %
-                  (label, key1, pd1[key1][0]))
+            print("Extra {} parameter `{}' (type `{}') in list 1"
+                  .format(label, key1, pd1[key1][0]))
             del pd1[key1]
             i1 = i1 + 1
         while i2 < len(k2):
             key2 = k2[i2]
-            print("Extra %s parameter `%s' (type `%s') in list 2" %
-                  (label, key2, pd2[key2][0]))
+            print("Extra {} parameter `{}' (type `{}') in list 2"
+                  .format(label, key2, pd2[key2][0]))
             del pd2[key2]
             i2 = i2 + 1
     # remaining parameters are in both lists
@@ -1264,8 +1265,8 @@ def _printDiff(pd1, pd2, label):
             if noextra and order1 != order2:
                 mm.append("order disagreement")
             if type1 != type2:
-                mm.append("type disagreement (`%s' vs. `%s')" % (type1, type2))
-            print("Parameter `%s': %s" % (key, ", ".join(mm)))
+                mm.append("type disagreement (`{}' vs. `{}')".format(type1, type2))
+            print("Parameter `{}': {}".format(key, ", ".join(mm)))
 
 
 # The dictionary of all special-use par files found on disk.

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -310,7 +310,7 @@ class IrafParL(_StringMixin, IrafPar):
             # non-null value means we're reading from a file
             try:
                 if not self.fh:
-                    self.fh = open(pyraf.iraf.Expand(self.value), "r")
+                    self.fh = open(pyraf.iraf.Expand(self.value))
                     if self.fh.isatty():
                         self.lines = None
                     else:
@@ -1321,7 +1321,7 @@ def _updateSpecialParFileDict(dirToCheck=None, strict=False):
     for supfname in flist:
         buf = []
         try:
-            supfile = open(supfname, 'r')
+            supfile = open(supfname)
             buf = supfile.readlines()
             supfile.close()
         except OSError:
@@ -1474,7 +1474,7 @@ def _readpar(filename, strict=0):
 
     param_dict = {}
     param_list = []
-    fh = open(os.path.expanduser(filename), 'r')
+    fh = open(os.path.expanduser(filename))
     lines = fh.readlines()
     fh.close()
     # reverse order of lines so we can use pop method

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -277,7 +277,7 @@ class IrafParL(_StringMixin, IrafPar):
             if self.fh:
                 try:
                     self.fh.close()
-                except IOError:
+                except OSError:
                     pass
                 self.fh = None
                 self.lines = None
@@ -329,7 +329,7 @@ class IrafParL(_StringMixin, IrafPar):
                     raise EOFError("EOF from list parameter `%s'" % self.name)
                 if value[-1:] == "\n":
                     value = value[:-1]
-            except IOError as e:
+            except OSError as e:
                 if not self.errMsg:
                     warning("Unable to read values for list parameter `%s' "
                             "from file `%s'\n%s" %
@@ -477,7 +477,7 @@ class ParCache(filecache.FileCache):
             filename = ''
         try:
             filecache.FileCache.__init__(self, filename)
-        except (OSError, IOError):
+        except OSError:
             # whoops, couldn't open that file
             # start with a null file instead unless strict is set
             if strict:
@@ -1324,7 +1324,7 @@ def _updateSpecialParFileDict(dirToCheck=None, strict=False):
             supfile = open(supfname, 'r')
             buf = supfile.readlines()
             supfile.close()
-        except IOError:
+        except OSError:
             pass
         if len(buf) < 1:
             warning("Unable to read special use parameter file: " + supfname,

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -208,7 +208,7 @@ class IrafParPset(IrafParS):
         f = self.value.split('.')
         if len(f) > 1 and f[-1] == 'par':
             # must be a file name
-            from iraffunctions import IrafTaskFactory
+            from .iraffunctions import IrafTaskFactory
             irf_val = pyraf.iraf.Expand(self.value)
             return IrafTaskFactory(taskname=irf_val.split(".")[0],
                                    value=irf_val)
@@ -426,7 +426,7 @@ class IrafParGCur(IrafParCursor):
 
     def _getNextValue(self):
         """Return next graphics cursor value"""
-        import gki  # lazy import - reduce circular imports on startup
+        from . import gki  # lazy import - reduce circular imports on startup
         return gki.kernel.gcur()
 
 
@@ -440,7 +440,7 @@ class IrafParImCur(IrafParCursor):
 
     def _getNextValue(self):
         """Return next image display cursor value"""
-        import irafimcur  # lazy import - reduce circular imports on startup
+        from . import irafimcur  # lazy import - reduce circular imports on startup
         return irafimcur.imcur()
 
 
@@ -454,7 +454,7 @@ class IrafParUKey(IrafParL):
 
     def _getNextValue(self):
         """Return next typed character"""
-        import irafukey  # lazy import - reduce circular imports on startup
+        from . import irafukey  # lazy import - reduce circular imports on startup
         return irafukey.ukey()
 
 
@@ -465,7 +465,7 @@ class IrafParUKey(IrafParL):
 if __name__.find('.') < 0:  # for unit test need absolute import
     exec('import filecache', globals())  # 2to3 messes up simpler form
 else:
-    import filecache
+    from . import filecache
 
 
 class ParCache(filecache.FileCache):
@@ -1062,11 +1062,11 @@ class IrafParList(taskpars.TaskPars):
         self.setParam('$nargs', nargs)
 
     def eParam(self):
-        import epar
+        from . import epar
         epar.epar(self)
 
     def tParam(self):
-        import tpar
+        from . import tpar
         tpar.tpar(self)
 
     def lParam(self, verbose=0):

--- a/pyraf/iraftask.py
+++ b/pyraf/iraftask.py
@@ -16,11 +16,11 @@ import copy
 import re
 from stsci.tools import basicpar, minmatch, irafutils, irafglobals, taskpars
 from stsci.tools.irafglobals import IrafError, Verbose
-import subproc
-import irafinst
-import irafpar
-import irafexecute
-import cl2py
+from . import subproc
+from . import irafinst
+from . import irafpar
+from . import irafexecute
+from . import cl2py
 
 # use this form since the iraf import is circular
 import pyraf.iraf
@@ -713,7 +713,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         self.initTask(force=1)
         # XXX always runs on current par list, not running par list?
         if self._currentParList:
-            import epar
+            from . import epar
             epar.epar(self)
         else:
             sys.stderr.write("Task %s has no parameter file\n" % self._name)
@@ -724,7 +724,7 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         self.initTask(force=1)
         # XXX always runs on current par list, not running par list?
         if self._currentParList:
-            import tpar
+            from . import tpar
             tpar.tpar(self)
         else:
             sys.stderr.write("Task %s has no parameter file\n" % self._name)

--- a/pyraf/iraftask.py
+++ b/pyraf/iraftask.py
@@ -7,7 +7,7 @@ the creation of IRAF ECL.  irafecl is closely related and derived from
 iraftask,  providing drop-in replacements for the Task classes defined
 here which also support ECL syntax like "iferr" and $errno.
 """
-from __future__ import division, print_function
+
 
 import fnmatch
 import os

--- a/pyraf/iraftask.py
+++ b/pyraf/iraftask.py
@@ -271,8 +271,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                 return paramdict[paramname]
         except minmatch.AmbiguousKeyError as e:
             # re-raise the error with a bit more info
-            raise IrafError("Cannot get parameter `%s'\n%s" %
-                            (paramname, str(e)))
+            raise IrafError("Cannot get parameter `{}'\n{}"
+                            .format(paramname, str(e)))
 
         if alldict:
             # OK, the easy case didn't work -- now initialize the
@@ -361,8 +361,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         self.setParList(*args, **kw)
 
         if Verbose > 1:
-            print("run %s (%s: %s)" %
-                  (self._name, self.__class__.__name__, self._fullpath),
+            print("run {} ({}: {})"
+                  .format(self._name, self.__class__.__name__, self._fullpath),
                   file=sys.stderr)
             if self._runningParList:
                 self._runningParList.lParam()
@@ -673,8 +673,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                                             prompt=prompt)
         except minmatch.AmbiguousKeyError as e:
             # re-raise the error with a bit more info
-            raise IrafError("Cannot get parameter `%s'\n%s" %
-                            (paramname, str(e)))
+            raise IrafError("Cannot get parameter `{}'\n{}"
+                            .format(paramname, str(e)))
 
         # OK, the easy case didn't work -- now initialize the
         # complete parDictList (if necessary) and search them all
@@ -705,7 +705,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         if plist:
             plist.lParam(verbose=verbose)
         else:
-            sys.stderr.write("Task %s has no parameter file\n" % self._name)
+            sys.stderr.write("Task {} has no parameter file\n"
+                             .format(self._name))
             sys.stderr.flush()
 
     def eParam(self):
@@ -716,7 +717,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             from . import epar
             epar.epar(self)
         else:
-            sys.stderr.write("Task %s has no parameter file\n" % self._name)
+            sys.stderr.write("Task {} has no parameter file\n"
+                             .format(self._name))
             sys.stderr.flush()
 
     def tParam(self):
@@ -727,7 +729,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             from . import tpar
             tpar.tpar(self)
         else:
-            sys.stderr.write("Task %s has no parameter file\n" % self._name)
+            sys.stderr.write("Task {} has no parameter file\n"
+                             .format(self._name))
             sys.stderr.flush()
 
     def dParam(self, cl=1):
@@ -742,10 +745,11 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             if cl:
                 taskname = self._name
             else:
-                taskname = "iraf.%s" % self._name
+                taskname = "iraf.{}".format(self._name)
             plist.dParam(taskname, cl=cl)
         else:
-            sys.stderr.write("Task %s has no parameter file\n" % self._name)
+            sys.stderr.write("Task {} has no parameter file\n"
+                             .format(self._name))
             sys.stderr.flush()
 
     def saveParList(self, filename=None, comment=None):
@@ -757,13 +761,13 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         self.initTask()
         # XXX always runs on current par list, not running par list?
         if not self._currentParList:
-            return "No parameters to save for task %s" % (self._name,)
+            return "No parameters to save for task {}".format(self._name)
         if filename is None:
             if self._scrunchParpath:
                 filename = self._scrunchParpath
             else:
-                status = "Unable to save parameters for task %s" % \
-                    (self._name,)
+                status = ("Unable to save parameters for task {}"
+                          .format(self._name))
                 if Verbose > 0:
                     print(status, file=sys.stderr)
                 return status
@@ -843,9 +847,9 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
         return self.run(*args, **kw)
 
     def __repr__(self):
-        s = '<%s %s (%s) Pkg: %s Bin: %s' % \
-            (self.__class__.__name__, self._name, self._filename,
-             self._pkgname, ':'.join(self._pkgbinary))
+        s = ('<{} {} ({}) Pkg: {} Bin: {}'
+             .format(self.__class__.__name__, self._name, self._filename,
+                     self._pkgname, ':'.join(self._pkgbinary)))
         if self._foreign:
             s = s + ' Foreign'
         if self._hidden:
@@ -1025,8 +1029,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
             basename = s[-1]
         if basename == "":
             self._fullpath = ""
-            raise IrafError("No filename in task %s definition: `%s'" %
-                            (self._name, self._filename))
+            raise IrafError("No filename in task {} definition: `{}'"
+                            .format(self._name, self._filename))
         # for foreign tasks, just set path to filename (XXX will
         # want to improve this by checking os path for existence)
         if self._foreign:
@@ -1053,8 +1057,8 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                     self._fullpath = ""
                     exelist.append(exename1)
                     raise IrafError(
-                        "Cannot find executable for task %s\nTried %s" %
-                        (self._name, ", ".join(exelist)))
+                        "Cannot find executable for task {}\nTried {}"
+                        .format(self._name, ", ".join(exelist)))
 
     def _initParpath(self):
         """Initialize parameter file paths"""
@@ -1122,12 +1126,11 @@ class IrafTask(irafglobals.IrafTask, taskpars.TaskPars):
                 self._name, pyraf.iraf.Expand(self._currentParpath, noerror=1))
             # are lists consistent?
             if not self._isConsistentPar():
-                sys.stderr.write("uparm parameter list `%s' inconsistent "
-                                 "with default parameters for %s `%s'\n" % (
-                                     self._currentParpath,
-                                     self.__class__.__name__,
-                                     self._name,
-                                 ))
+                sys.stderr.write("uparm parameter list `{}' inconsistent "
+                                 "with default parameters for {} `{}'\n"
+                                 .format(self._currentParpath,
+                                         self.__class__.__name__,
+                                         self._name))
                 sys.stderr.flush()
                 # XXX just toss it for now -- later can try to merge new,old
                 try:
@@ -1195,8 +1198,8 @@ class IrafPset(IrafTask):
         # - not a foreign task
         # - has a parameter file
         if self.getForeign():
-            raise IrafError("Bad filename for pset %s: %s" %
-                            (self.getName(), filename))
+            raise IrafError("Bad filename for pset {}: {}"
+                            .format(self.getName(), filename))
         if not self.hasParfile():
             raise KeyError("Pset " + self.getName() + " has no parameter file")
 
@@ -1225,8 +1228,8 @@ class IrafPythonTask(IrafTask):
                           pkgbinary)
         if self.getForeign():
             raise IrafError(
-                "Python task `%s' cannot be foreign (filename=`%s')" %
-                (self.getName(), filename))
+                "Python task `{}' cannot be foreign (filename=`{}')"
+                .format(self.getName(), filename))
         self.__dict__['_pyFunction'] = function
 
     def isConsistent(self, other):
@@ -1320,8 +1323,8 @@ class ParDictListSearch:
         # it was found, but we don't allow min-match in CL scripts
         # print a more useful message
         raise AttributeError(
-            "Unknown parameter `%s' (possibly intended `%s'?)" %
-            (paramname, p.name))
+            "Unknown parameter `{}' (possibly intended `{}'?)"
+            .format(paramname, p.name))
 
     def getParObject(self, paramname):
         # try exact match
@@ -1338,8 +1341,8 @@ class ParDictListSearch:
         # it was found, but we don't allow min-match in CL scripts
         # print a more useful message
         raise AttributeError(
-            "Unknown parameter `%s' (possibly intended `%s'?)" %
-            (paramname, p.name))
+            "Unknown parameter `{}' (possibly intended `{}'?)"
+            .format(paramname, p.name))
 
     def __setattr__(self, paramname, value):
         if self._taskObj.is_pseudo(paramname):
@@ -1360,8 +1363,8 @@ class ParDictListSearch:
         # it was found, but we don't allow min-match in CL scripts
         # print a more useful message
         raise AttributeError(
-            "Unknown parameter `%s' (possibly intended `%s'?)" %
-            (paramname, p.name))
+            "Unknown parameter `{}' (possibly intended `{}'?)"
+            .format(paramname, p.name))
 
 
 # -----------------------------------------------------
@@ -1388,8 +1391,8 @@ class IrafCLTask(IrafTask):
         IrafTask.__init__(self, prefix, name, suffix, filename, pkgname,
                           pkgbinary)
         if self.getForeign():
-            raise IrafError("CL task `%s' cannot be foreign (filename=`%s')" %
-                            (self.getName(), filename))
+            raise IrafError("CL task `{}' cannot be foreign (filename=`{}')"
+                            .format(self.getName(), filename))
         # placeholder for Python translation of CL code
         # (lazy instantiation)
         self.__dict__['_pycode'] = None
@@ -1486,10 +1489,10 @@ class IrafCLTask(IrafTask):
             # again in any case.
             self._clFunction = None
             if self._pkgname:
-                scriptname = '<CL script %s.%s>' % (self._pkgname, self._name)
+                scriptname = '<CL script {}.{}>'.format(self._pkgname, self._name)
             else:
                 # null pkgname -- just use task in name
-                scriptname = '<CL script %s>' % self._name
+                scriptname = '<CL script {}>'.format(self._name)
             # force compile to inherit future div. so we don't rely on 2.x div.
             self._codeObject = compile(self._pycode.code, scriptname, 'exec',
                                        0, 0)
@@ -1507,13 +1510,11 @@ class IrafCLTask(IrafTask):
             # use currentParList from .par file if exists and consistent
             if self._currentParpath:
                 if not self._defaultParList.isConsistent(self._currentParList):
-                    sys.stderr.write("uparm parameter list `%s' inconsistent "
-                                     "with default parameters for %s `%s'\n" %
-                                     (
-                                         self._currentParpath,
-                                         self.__class__.__name__,
-                                         self._name,
-                                     ))
+                    sys.stderr.write("uparm parameter list `{}' inconsistent "
+                                     "with default parameters for {} `{}'\n"
+                                     .format(self._currentParpath,
+                                             self.__class__.__name__,
+                                             self._name))
                     sys.stderr.flush()
                     # XXX just toss it for now -- later can try to merge new,old
                     if self._currentParpath == self._scrunchParpath:
@@ -1693,7 +1694,7 @@ class IrafPkg(IrafCLTask, irafglobals.IrafPkg):
         if fullname:
             return pyraf.iraf.getTask(fullname)
         else:
-            raise AttributeError("Parameter %s not found" % name)
+            raise AttributeError("Parameter {} not found".format(name))
 
     # =========================================================
     # private methods
@@ -1808,7 +1809,8 @@ def mutateCLTask2Pkg(o, loaded=1, klass=IrafPkg):
     if isinstance(o, IrafPkg):
         return
     if not isinstance(o, IrafCLTask):
-        raise TypeError("Cannot turn object `%s' into an IrafPkg" % repr(o))
+        raise TypeError("Cannot turn object `{}' into an IrafPkg"
+                        .format(repr(o)))
 
     # add the extra attributes used in IrafPkg
     # this is usually called while actually loading the package, so by
@@ -1841,8 +1843,8 @@ class IrafForeignTask(IrafTask):
         # - foreign flag set
         # - no parameter file
         if not self.getForeign():
-            raise IrafError("Bad filename for foreign task %s: %s" %
-                            (self.getName(), filename))
+            raise IrafError("Bad filename for foreign task {}: {}"
+                            .format(self.getName(), filename))
         if self.hasParfile():
             if Verbose > 0:
                 print("Foreign task " + self.getName() +
@@ -1859,7 +1861,7 @@ class IrafForeignTask(IrafTask):
         if '_setMode' in kw:
             del kw['_setMode']
         if len(kw) > 0:
-            raise ValueError('Illegal keyword parameters %s for task %s' % (
+            raise ValueError('Illegal keyword parameters {} for task {}'.format(
                 list(kw.keys()),
                 self._name,
             ))
@@ -1929,8 +1931,8 @@ class IrafForeignTask(IrafTask):
         if n is not None:
             # $(*) -- append all arguments with virtual filenames converted
             return ' '.join(map(pyraf.iraf.Expand, self._args))
-        raise IrafError("Cannot handle foreign string `%s' "
-                        "for task %s" % (self._filename, self._name))
+        raise IrafError("Cannot handle foreign string `{}' "
+                        "for task {}".format(self._filename, self._name))
 
 
 # -----------------------------------------------------
@@ -2002,7 +2004,7 @@ def printable_task_def(x):
 
     # I wonder if there is a significance to using getFullpath instead of _filename
 
-    s = "%s : %s - pkgbinary=%s class=%s" % (x._name, x.getFullpath(),
+    s = "{} : {} - pkgbinary={} class={}".format(x._name, x.getFullpath(),
                                              x._pkgbinary, cl)
     return s
 
@@ -2013,7 +2015,7 @@ def printable_task_def(x):
 def showtasklong(name, level=0):
     l = gettask(name)
     if len(l) < 1:
-        print(("    " * level) + '%s : NOT FOUND' % name)
+        print(("    " * level) + '{} : NOT FOUND'.format(name))
     else:
         l.sort()
         for x in l:

--- a/pyraf/irafukey.py
+++ b/pyraf/irafukey.py
@@ -6,7 +6,7 @@ implement IRAF ukey functionality
 import os
 import sys
 from . import wutil
-from stsci.tools import capable, for2to3, irafutils
+from stsci.tools import capable, irafutils
 
 try:
     import termios
@@ -45,9 +45,7 @@ def getSingleTTYChar():  # return type str in all Python versions
         if capable.OF_GRAPHICS:
             c = irafutils.tkread(fd, 1)
         else:
-            c = os.read(fd, 1)
-            if for2to3.PY3K:
-                c = c.decode('ascii', 'replace')
+            c = os.read(fd, 1).decode(errors='replace')
     finally:
         termios.tcsetattr(fd, TERMIOS.TCSAFLUSH, old)
         return c

--- a/pyraf/irafukey.py
+++ b/pyraf/irafukey.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function
 
 import os
 import sys
-import wutil
+from . import wutil
 from stsci.tools import capable, for2to3, irafutils
 
 try:

--- a/pyraf/irafukey.py
+++ b/pyraf/irafukey.py
@@ -53,7 +53,7 @@ def ukey():
         raise EOFError()
     elif ord(char) <= ord(' '):
         # convert to octal ascii representation
-        returnStr = '\\' + "%03o" % ord(char)
+        returnStr = '\\{:03o}'.format(ord(char))
     elif char == ':':
         # suck in colon string until newline is encountered
         done = 0

--- a/pyraf/irafukey.py
+++ b/pyraf/irafukey.py
@@ -1,7 +1,7 @@
 """
 implement IRAF ukey functionality
 """
-from __future__ import division, print_function
+
 
 import os
 import sys

--- a/pyraf/irafukey.py
+++ b/pyraf/irafukey.py
@@ -5,22 +5,9 @@ implement IRAF ukey functionality
 
 import os
 import sys
+import termios
 from . import wutil
 from stsci.tools import capable, irafutils
-
-try:
-    import termios
-except ImportError:
-    if 0 == sys.platform.find('win'):  # not on win*, but IS on darwin & cygwin
-        termios = None
-    else:
-        raise
-
-# TERMIOS is deprecated in Python 2.1
-if hasattr(termios, 'ICANON') or termios is None:
-    TERMIOS = termios
-else:
-    import TERMIOS
 
 # This class emulates the IRAF ukey parameter mechanism. IRAF calls for
 # a ukey parameter and expects that the user will type a character in
@@ -34,10 +21,10 @@ def getSingleTTYChar():  # return type str in all Python versions
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)
     new = termios.tcgetattr(fd)
-    new[3] = new[3] & ~(TERMIOS.ICANON | TERMIOS.ECHO | TERMIOS.ISIG)
-    new[6][TERMIOS.VMIN] = 1
-    new[6][TERMIOS.VTIME] = 0
-    termios.tcsetattr(fd, TERMIOS.TCSANOW, new)
+    new[3] = new[3] & ~(termios.ICANON | termios.ECHO | termios.ISIG)
+    new[6][termios.VMIN] = 1
+    new[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, new)
     c = None
     try:
         # allow Tk mainloop to run while waiting...
@@ -47,7 +34,7 @@ def getSingleTTYChar():  # return type str in all Python versions
         else:
             c = os.read(fd, 1).decode(errors='replace')
     finally:
-        termios.tcsetattr(fd, TERMIOS.TCSAFLUSH, old)
+        termios.tcsetattr(fd, termios.TCSAFLUSH, old)
         return c
 
 

--- a/pyraf/msgiobuffer.py
+++ b/pyraf/msgiobuffer.py
@@ -5,7 +5,7 @@
 
 M.D. De La Pena, 2000 June 28
 """
-from __future__ import division, print_function
+
 
 # System level modules
 from tkinter import (StringVar, BooleanVar, Canvas, Frame, Scrollbar, Label,

--- a/pyraf/msgiobuffer.py
+++ b/pyraf/msgiobuffer.py
@@ -8,7 +8,7 @@ M.D. De La Pena, 2000 June 28
 from __future__ import division, print_function
 
 # System level modules
-from Tkinter import (StringVar, BooleanVar, Canvas, Frame, Scrollbar, Label,
+from tkinter import (StringVar, BooleanVar, Canvas, Frame, Scrollbar, Label,
                      Entry, Message, TRUE, FALSE, VERTICAL, NORMAL, DISABLED,
                      FLAT, SUNKEN, RAISED, TOP, LEFT, RIGHT, Y, X, NW, SW, END)
 

--- a/pyraf/msgiowidget.py
+++ b/pyraf/msgiowidget.py
@@ -3,7 +3,7 @@
    scrolling canvas composed of a text widget and frame.  When "hidden",
    it turns into a single-line text widget.
 """
-from __future__ import division, print_function
+
 
 # System level modules
 import tkinter

--- a/pyraf/msgiowidget.py
+++ b/pyraf/msgiowidget.py
@@ -6,7 +6,7 @@
 from __future__ import division, print_function
 
 # System level modules
-import Tkinter as TKNTR  # requires 2to3
+import tkinter
 
 # Our modules
 from stsci.tools import tkrotext
@@ -21,25 +21,25 @@ def is_USING_X():
     return wutil.WUTIL_USING_X
 
 
-class MsgIOWidget(TKNTR.Frame):
+class MsgIOWidget(tkinter.Frame):
     """MsgIOWidget class"""
 
     def __init__(self, parent, width=100, text=""):
         """Constructor"""
 
         # We are the main frame that holds everything we do
-        TKNTR.Frame.__init__(self, parent)
+        tkinter.Frame.__init__(self, parent)
         self._parent = parent
 
         # Create two sub-frames, one to hold the 1-liner msg I/O, and
         # the other one to hold the whole scrollable history.
-        self._nowFrame = TKNTR.Frame(self,
+        self._nowFrame = tkinter.Frame(self,
                                      bd=2,
-                                     relief=TKNTR.SUNKEN,
+                                     relief=tkinter.SUNKEN,
                                      takefocus=False)
-        self._histFrame = TKNTR.Frame(self,
+        self._histFrame = tkinter.Frame(self,
                                       bd=2,
-                                      relief=TKNTR.SUNKEN,
+                                      relief=tkinter.SUNKEN,
                                       takefocus=False)
 
         # Put in the expand/collapse button (determine it's sizes)
@@ -51,67 +51,67 @@ class MsgIOWidget(TKNTR.Frame):
         else:  # Aqua
             px = 5
             py = 3
-            if TKNTR.TkVersion > 8.4:
+            if tkinter.TkVersion > 8.4:
                 px = py = 0
                 btxt = ''
                 self._expBttnHasTxt = False
-        self._expBttn = TKNTR.Checkbutton(self._nowFrame,
+        self._expBttn = tkinter.Checkbutton(self._nowFrame,
                                           command=self._expand,
                                           padx=px,
                                           pady=py,
                                           text=btxt,
                                           indicatoron=0,
-                                          state=TKNTR.DISABLED)
-        self._expBttn.pack(side=TKNTR.LEFT, padx=3)  # , ipadx=0)
+                                          state=tkinter.DISABLED)
+        self._expBttn.pack(side=tkinter.LEFT, padx=3)  # , ipadx=0)
 
         # Overlay a label on the frame
-        self._msgLabelVar = TKNTR.StringVar()
+        self._msgLabelVar = tkinter.StringVar()
         self._msgLabelVar.set(text)
         self._msgLabelMaxWidth = 65  # 70 works but causes plot redraws when
         # the history panel is opened/closed
-        self._msgLabel = TKNTR.Label(self._nowFrame,
+        self._msgLabel = tkinter.Label(self._nowFrame,
                                      textvariable=self._msgLabelVar,
-                                     anchor=TKNTR.W,
-                                     justify=TKNTR.LEFT,
+                                     anchor=tkinter.W,
+                                     justify=tkinter.LEFT,
                                      width=self._msgLabelMaxWidth,
                                      wraplength=width - 100,
                                      takefocus=False)
-        self._msgLabel.pack(side=TKNTR.LEFT, fill=TKNTR.X, expand=False)
+        self._msgLabel.pack(side=tkinter.LEFT, fill=tkinter.X, expand=False)
         self._msgLabel.bind('<Double-Button-1>', self._lblDblClk)
 
-        self._entry = TKNTR.Entry(self._nowFrame,
-                                  state=TKNTR.DISABLED,
+        self._entry = tkinter.Entry(self._nowFrame,
+                                  state=tkinter.DISABLED,
                                   width=1,
                                   takefocus=False,
-                                  relief=TKNTR.FLAT,
+                                  relief=tkinter.FLAT,
                                   highlightthickness=0)
-        self._entry.pack(side=TKNTR.LEFT, fill=TKNTR.X, expand=True)
+        self._entry.pack(side=tkinter.LEFT, fill=tkinter.X, expand=True)
         self._entry.bind('<Return>', self._enteredText)
-        self._entryTyping = TKNTR.BooleanVar()
+        self._entryTyping = tkinter.BooleanVar()
         self._entryTyping.set(False)
 
         # put in a spacer here for label height stability
-        self._spacer = TKNTR.Label(self._nowFrame, text='', takefocus=False)
-        self._spacer.pack(side=TKNTR.LEFT, expand=False, padx=5)
+        self._spacer = tkinter.Label(self._nowFrame, text='', takefocus=False)
+        self._spacer.pack(side=tkinter.LEFT, expand=False, padx=5)
 
-        self._nowFrame.pack(side=TKNTR.TOP, fill=TKNTR.X, expand=True)
+        self._nowFrame.pack(side=tkinter.TOP, fill=tkinter.X, expand=True)
 
         self._hasHistory = False
-        self._histScrl = TKNTR.Scrollbar(self._histFrame)
-        self._histScrl.pack(side=TKNTR.RIGHT, fill=TKNTR.Y)
+        self._histScrl = tkinter.Scrollbar(self._histFrame)
+        self._histScrl.pack(side=tkinter.RIGHT, fill=tkinter.Y)
 
         self._histText = tkrotext.ROText(self._histFrame,
-                                         wrap=TKNTR.WORD,
+                                         wrap=tkinter.WORD,
                                          takefocus=False,
                                          height=10,
                                          yscrollcommand=self._histScrl.set)
-        # (use if just TKNTR.Text) state=TKNTR.DISABLED, takefocus=False,
+        # (use if just tkinter.Text) state=tkinter.DISABLED, takefocus=False,
         #                        exportselection=True is the default
-        self._histText.pack(side=TKNTR.TOP, fill=TKNTR.X, expand=True)
+        self._histText.pack(side=tkinter.TOP, fill=tkinter.X, expand=True)
         self._histScrl.config(command=self._histText.yview)
 
         # don't pack this one now - start out with it hidden
-        #       self._histFrame.pack(side=TKNTR.TOP, fill=TKNTR.X)
+        #       self._histFrame.pack(side=tkinter.TOP, fill=tkinter.X)
 
         ### Do not pack the main frame here.  Let the application do it. ###
 
@@ -132,12 +132,12 @@ class MsgIOWidget(TKNTR.Frame):
             if self._expBttnHasTxt:
                 self._expBttn.configure(text='+')
         else:  # need to expand
-            self._histFrame.pack(side=TKNTR.TOP, fill=TKNTR.BOTH,
+            self._histFrame.pack(side=tkinter.TOP, fill=tkinter.BOTH,
                                  expand=True)  # .X)
             if self._expBttnHasTxt:
                 self._expBttn.configure(text='-')
             if self._hasHistory:
-                self._histText.see(TKNTR.END)
+                self._histText.see(tkinter.END)
 
     def updateIO(self, text=""):
         """ Update the text portion of the scrolling canvas """
@@ -164,8 +164,8 @@ class MsgIOWidget(TKNTR.Frame):
         self._msgLabel.configure(width=min(self._msgLabelMaxWidth, lblTxtLen))
 
         # Enable the entry widget
-        self._entry.configure(state=TKNTR.NORMAL,
-                              relief=TKNTR.SUNKEN,
+        self._entry.configure(state=tkinter.NORMAL,
+                              relief=tkinter.SUNKEN,
                               width=15,
                               takefocus=True,
                               highlightthickness=2)
@@ -179,11 +179,11 @@ class MsgIOWidget(TKNTR.Frame):
         ans = self._entry.get().strip()
 
         # Clear and disable the entry widget
-        self._entry.delete(0, TKNTR.END)
-        self._entry.configure(state=TKNTR.DISABLED,
+        self._entry.delete(0, tkinter.END)
+        self._entry.configure(state=tkinter.DISABLED,
                               takefocus=False,
                               width=1,
-                              relief=TKNTR.FLAT,
+                              relief=tkinter.FLAT,
                               highlightthickness=0)
         self._entryTyping.set(False)
 
@@ -210,25 +210,25 @@ class MsgIOWidget(TKNTR.Frame):
             return
 
         # enable widget temporarily so we can add text
-#       self._histText.config(state=TKNTR.NORMAL)
+#       self._histText.config(state=tkinter.NORMAL)
 #       self._histText.delete(1.0, END)
 
 # add the new text
         if self._hasHistory:
-            self._histText.insert(TKNTR.END, '\n' + txt.strip(), force=True)
+            self._histText.insert(tkinter.END, '\n' + txt.strip(), force=True)
         else:
-            self._histText.insert(TKNTR.END, txt.strip(), force=True)
+            self._histText.insert(tkinter.END, txt.strip(), force=True)
             self._hasHistory = True
 
         # disable it again
-#       self._histText.config(state=TKNTR.DISABLED)
+#       self._histText.config(state=tkinter.DISABLED)
 
 # show it
         if self._histFrame.winfo_ismapped():
-            self._histText.see(TKNTR.END)
+            self._histText.see(tkinter.END)
 
 
 #       self._histFrame.update_idletasks()
 
 # finally, make sure expand/collapse button is enabled now
-        self._expBttn.configure(state=TKNTR.NORMAL)
+        self._expBttn.configure(state=tkinter.NORMAL)

--- a/pyraf/newWindowHack.py
+++ b/pyraf/newWindowHack.py
@@ -7,16 +7,16 @@ code:  the dialog is created,  but it is withdrawn just like the
 root window (!) so there is nothing to interact with and the system
 hangs.
 
-import Tkinter as TKNTR
-tk = TKNTR.Tk()
+import tkinter
+tk = tkinter.Tk()
 tk.withdraw()
 import tkSimpleDialog
 tkSimpleDialog.askstring("window title", "question?")
 """
 from __future__ import division, print_function
 
-import tkSimpleDialog
-from Tkinter import Toplevel, Frame
+import tkinter.simpledialog
+from tkinter import Toplevel, Frame
 
 
 def __init__(self, parent, title=None):
@@ -63,7 +63,7 @@ def __init__(self, parent, title=None):
     self.wait_window(self)
 
 
-tkSimpleDialog.Dialog.__init__ = __init__
+tkinter.simpledialog.Dialog.__init__ = __init__
 """
 Here are some more notes from my "investigation":
 

--- a/pyraf/newWindowHack.py
+++ b/pyraf/newWindowHack.py
@@ -13,7 +13,7 @@ tk.withdraw()
 import tkSimpleDialog
 tkSimpleDialog.askstring("window title", "question?")
 """
-from __future__ import division, print_function
+
 
 import tkinter.simpledialog
 from tkinter import Toplevel, Frame

--- a/pyraf/newWindowHack.py
+++ b/pyraf/newWindowHack.py
@@ -55,8 +55,8 @@ def __init__(self, parent, title=None):
     self.protocol("WM_DELETE_WINDOW", self.cancel)
 
     if self.parent is not None:
-        self.geometry("+%d+%d" %
-                      (parent.winfo_rootx() + 50, parent.winfo_rooty() + 50))
+        self.geometry("+{:d}+{:d}".format(parent.winfo_rootx() + 50,
+                                          parent.winfo_rooty() + 50))
 
     self.initial_focus.focus_set()
 

--- a/pyraf/pseteparoption.py
+++ b/pyraf/pseteparoption.py
@@ -2,7 +2,7 @@
    options to be used for PSETs in the parameter editor task.  Code was
    broken out from eparoption.py.
 """
-from __future__ import division, print_function
+
 
 # local modules
 from stsci.tools import eparoption

--- a/pyraf/pseteparoption.py
+++ b/pyraf/pseteparoption.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function
 
 # local modules
 from stsci.tools import eparoption
-import epar
+from . import epar
 
 
 class PsetEparOption(eparoption.ActionEparButton):

--- a/pyraf/pycmdline.py
+++ b/pyraf/pycmdline.py
@@ -90,11 +90,11 @@ class CmdConsole(code.InteractiveConsole):
 
         Also is modified so it does not catch EOFErrors."""
         if banner is None:
-            self.write("Python %s on %s\n%s\n(%s)\n" %
-                       (sys.version, sys.platform, sys.copyright,
+            self.write("Python {} on {}\n{}\n({})\n"
+                       .format(sys.version, sys.platform, sys.copyright,
                         self.__class__.__name__))
         else:
-            self.write("%s\n" % str(banner))
+            self.write("{}\n".format(str(banner)))
         more = 0
         # number of consecutive EOFs
         neofs = 0
@@ -243,7 +243,7 @@ class PyCmdLine(CmdConsole):
     def do_help(self, line='', i=0):
         """Print help on executive commands"""
         if self.debug > 1:
-            self.write('do_help: %s\n' % line[i:])
+            self.write('do_help: {}\n'.format(line[i:]))
         self.write("""Executive commands (commands can be abbreviated):
 .exit
 Exit from Pyraf.
@@ -272,7 +272,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
     def do_exit(self, line='', i=0):
         """Exit from PyRAF and then Python"""
         if self.debug > 1:
-            self.write('do_exit: %s\n' % line[i:])
+            self.write('do_exit: {}\n'.format(line[i:]))
 
         # write out history - ignore write errors
         hfile = os.getenv('HOME', '.') + os.sep + '.pyraf_history'
@@ -301,7 +301,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
     def do_logfile(self, line='', i=0):
         """Start or stop logging commands"""
         if self.debug > 1:
-            self.write('do_logfile: %s\n' % line[i:])
+            self.write('do_logfile: {}\n'.format(line[i:]))
         args = line[i:].split()
         if len(args) == 0:  # turn off logging (if on)
             if self.logfile:
@@ -320,21 +320,22 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
                 elif args[0] == 'append':
                     del args[0]
             if args:
-                self.write('Ignoring unknown options: %s\n' % " ".join(args))
+                self.write('Ignoring unknown options: {}\n'
+                           .format(" ".join(args)))
             try:
                 oldlogfile = self.logfile
                 self.logfile = open(filename, oflag)
                 if oldlogfile:
                     oldlogfile.close()
             except OSError as e:
-                self.write("error opening logfile %s\n%s\n" %
-                           (filename, str(e)))
+                self.write("error opening logfile {}\n{}\n"
+                           .format(filename, str(e)))
         return ""
 
     def do_clemulate(self, line='', i=0):
         """Turn CL emulation on or off"""
         if self.debug > 1:
-            self.write('do_clemulate: %s\n' % line[i:])
+            self.write('do_clemulate: {}\n'.format(line[i:]))
         self.clemulate = 1
         if line[i:] != "":
             try:
@@ -348,7 +349,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
     def do_complete(self, line='', i=0, default=1):
         """Turn command completion on or off"""
         if self.debug > 1:
-            self.write('do_complete: %s\n' % line[i:])
+            self.write('do_complete: {}\n'.format(line[i:]))
         self.complete = default
         if line[i:] != "":
             try:
@@ -368,7 +369,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
     def do_debug(self, line='', i=0):
         """Turn debug output on or off"""
         if self.debug > 1:
-            self.write('do_debug: %s\n' % line[i:])
+            self.write('do_debug: {}\n'.format(line[i:]))
         self.debug = 1
         if line[i:] != "":
             try:
@@ -382,7 +383,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
     def do_fulltraceback(self, line='', i=0):
         """Print full version of last traceback"""
         if self.debug > 1:
-            self.write('do_fulltraceback: %s\n' % line[i:])
+            self.write('do_fulltraceback: {}\n'.format(line[i:]))
         self.showtraceback(reprint=1)
         return ""
 
@@ -394,7 +395,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
         i = index in line of first non-blank character following cmd
         """
         if self.debug > 1:
-            self.write('default: %s - %s\n' % (cmd, line[i:]))
+            self.write('default: {} - {}\n'.format(cmd, line[i:]))
         if len(cmd) == 0:
             if line[i:i + 1] == '!':
                 # '!' is shell escape
@@ -460,14 +461,14 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
 
         # if we get to here then it looks like CL code
         if self.debug > 1:
-            self.write('CL: %s\n' % line)
+            self.write('CL: {}\n'.format(line))
         try:
             code = iraf.clExecute(line, locals=self.locals, mode='single')
             if self.logfile is not None:
                 # log CL code as comment
                 cllines = line.split('\n')
                 for oneline in cllines:
-                    self.logfile.write('# %s\n' % oneline)
+                    self.logfile.write('# {}\n'.format(oneline))
                 self.logfile.write(code)
                 self.logfile.flush()
         except:

--- a/pyraf/pycmdline.py
+++ b/pyraf/pycmdline.py
@@ -286,7 +286,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
             import readline
             readline.set_history_length(hlen)  # hlen<0 means unlimited
             readline.write_history_file(hfile)  # clobber any old version
-        except (ImportError, IOError):
+        except (ImportError, OSError):
             pass
 
         # any irafinst tmp files?
@@ -326,7 +326,7 @@ Set debugging flag.  If argument is omitted, default is 1 (debugging on.)
                 self.logfile = open(filename, oflag)
                 if oldlogfile:
                     oldlogfile.close()
-            except IOError as e:
+            except OSError as e:
                 self.write("error opening logfile %s\n%s\n" %
                            (filename, str(e)))
         return ""

--- a/pyraf/pycmdline.py
+++ b/pyraf/pycmdline.py
@@ -22,7 +22,7 @@ Uses standard code module plus some ideas from cmd.py module
 
 R. White, 2000 February 20
 """
-from __future__ import division, print_function
+
 
 import string
 import re

--- a/pyraf/pycmdline.py
+++ b/pyraf/pycmdline.py
@@ -33,10 +33,10 @@ import keyword
 import traceback
 import linecache
 from stsci.tools import capable, minmatch
-import iraf
-import irafinst
-import wutil
-from pyrafglobals import pyrafDir
+from . import iraf
+from . import irafinst
+from . import wutil
+from .pyrafglobals import pyrafDir
 
 
 class CmdConsole(code.InteractiveConsole):
@@ -70,7 +70,7 @@ class CmdConsole(code.InteractiveConsole):
         # history is a list of lines entered by user (allocated in blocks)
         self.history = 100 * [None]
         self.nhistory = 0
-        import irafcompleter
+        from . import irafcompleter
         self.completer = irafcompleter.IrafCompleter()
 
     def addHistory(self, line):

--- a/pyraf/pyrafTk.py
+++ b/pyraf/pyrafTk.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function
 
 import sys
 import tkinter
-import wutil
+from . import wutil
 
 
 class _PyrafTk(tkinter.Tk):

--- a/pyraf/pyrafTk.py
+++ b/pyraf/pyrafTk.py
@@ -2,7 +2,7 @@
 
 R. L. White, 2000 November 17
 """
-from __future__ import division, print_function
+
 
 import sys
 import tkinter

--- a/pyraf/pyrafTk.py
+++ b/pyraf/pyrafTk.py
@@ -5,16 +5,16 @@ R. L. White, 2000 November 17
 from __future__ import division, print_function
 
 import sys
-import Tkinter as TKNTR  # requires 2to3
+import tkinter
 import wutil
 
 
-class _PyrafTk(TKNTR.Tk):
+class _PyrafTk(tkinter.Tk):
     """Modified Tk class that prints short pyraf tracebacks"""
 
     def __init__(self, function):
         self._pyraf_showtraceback = function
-        TKNTR.Tk.__init__(self)
+        tkinter.Tk.__init__(self)
 
     def report_callback_exception(self, exc, val, tb):
         sys.stderr.write("Exception in tkinter callback\n")
@@ -29,9 +29,9 @@ def setTkErrorHandler(function):
     If Tk root already exists, this function has no effect.
     """
 
-    if TKNTR._default_root is None and wutil.hasGraphics:
+    if tkinter._default_root is None and wutil.hasGraphics:
         try:
             root = _PyrafTk(function)
             root.withdraw()
-        except TKNTR.TclError:
+        except tkinter.TclError:
             pass

--- a/pyraf/pyrafglobals.py
+++ b/pyraf/pyrafglobals.py
@@ -7,7 +7,7 @@ This is defined so it is safe to say 'from pyrafglobals import *'
 
 Broken out from irafglobals.py which was signed "R. White, 2000 January 5"
 """
-from __future__ import division, print_function
+
 
 import os as _os
 import sys as _sys

--- a/pyraf/splash.py
+++ b/pyraf/splash.py
@@ -7,14 +7,14 @@ from __future__ import division, print_function
 
 import os
 import sys
-import Tkinter as TKNTR  # requires 2to3
+import tkinter
 from stsci.tools.irafglobals import IrafPkg
 import wutil
 
 logo = "pyraflogo_rgb_web.gif"
 
 
-class SplashScreen(TKNTR.Toplevel):
+class SplashScreen(tkinter.Toplevel):
     """Base class for splash screen
 
     Subclass and override createWidgets().
@@ -26,8 +26,8 @@ class SplashScreen(TKNTR.Toplevel):
     Based closely on news posting by Alexander Schliep, 07 Apr 1999
     """
 
-    def __init__(self, master=None, borderwidth=4, relief=TKNTR.RAISED, **kw):
-        TKNTR.Toplevel.__init__(self,
+    def __init__(self, master=None, borderwidth=4, relief=tkinter.RAISED, **kw):
+        tkinter.Toplevel.__init__(self,
                                 master,
                                 relief=relief,
                                 borderwidth=borderwidth,
@@ -98,11 +98,11 @@ class PyrafSplash(SplashScreen):
 
     def createWidgets(self):
         """Create pyraf splash image"""
-        self.img = TKNTR.PhotoImage(file=self.filename)
+        self.img = tkinter.PhotoImage(file=self.filename)
         width = self.img.width() + 20
         iheight = self.img.height()
         height = iheight + 10 + 15 * self.nlines
-        self.canvas = TKNTR.Canvas(self,
+        self.canvas = tkinter.Canvas(self,
                                    width=width,
                                    height=height,
                                    background=self["background"])
@@ -217,6 +217,6 @@ def splash(label="PyRAF Execution Monitor", background="LightYellow", **kw):
     if wutil.hasGraphics:
         try:
             return IrafMonitorSplash(label, background=background, **kw)
-        except TKNTR.TclError:
+        except tkinter.TclError:
             pass
     return None

--- a/pyraf/splash.py
+++ b/pyraf/splash.py
@@ -9,7 +9,7 @@ import os
 import sys
 import tkinter
 from stsci.tools.irafglobals import IrafPkg
-import wutil
+from . import wutil
 
 logo = "pyraflogo_rgb_web.gif"
 
@@ -174,7 +174,7 @@ class IrafMonitorSplash(PyrafSplash):
         PyrafSplash.__init__(self, text=[None, label], **kw)
         # self.stack tracks messages displayed in monitor
         self.stack = []
-        import iraftask
+        from . import iraftask
         iraftask.executionMonitor = self.monitor
 
     def monitor(self, task=None):
@@ -203,7 +203,7 @@ class IrafMonitorSplash(PyrafSplash):
 
     def Destroy(self, event=None):
         """Shut down window and disable monitor"""
-        import iraftask
+        from . import iraftask
         if iraftask.executionMonitor == self.monitor:
             iraftask.executionMonitor = None
         PyrafSplash.Destroy(self, event)

--- a/pyraf/splash.py
+++ b/pyraf/splash.py
@@ -46,7 +46,7 @@ class SplashScreen(tkinter.Toplevel):
         ymax = self.winfo_screenheight()
         x0 = (xmax - self.winfo_reqwidth()) // 2
         y0 = (ymax - self.winfo_reqheight()) // 2
-        self.geometry("+%d+%d" % (x0, y0))
+        self.geometry("+{:d}+{:d}".format(x0, y0))
 
     def createWidgets(self):
         # Implement in derived class
@@ -73,7 +73,7 @@ class PyrafSplash(SplashScreen):
         if not os.path.exists(filename):
             tfilename = os.path.join(os.path.dirname(__file__), filename)
             if not os.path.exists(tfilename):
-                raise ValueError("Splash image `%s' not found" % filename)
+                raise ValueError("Splash image `{}' not found".format(filename))
             filename = tfilename
         self.filename = filename
         self.nlines = 1
@@ -189,13 +189,13 @@ class IrafMonitorSplash(PyrafSplash):
             name = task.getName()
             if name != 'cl':
                 if isinstance(task, IrafPkg):
-                    msg = "Loading %s" % name
+                    msg = "Loading {}".format(name)
                 else:
-                    msg = "Running %s" % name
+                    msg = "Running {}".format(name)
             else:
                 # cl task message includes input file name
                 try:
-                    msg = "cl %s" % os.path.basename(sys.stdin.name)
+                    msg = "cl {}".format(os.path.basename(sys.stdin.name))
                 except AttributeError:
                     msg = "cl <pipe>"
             self.stack.append(msg)

--- a/pyraf/splash.py
+++ b/pyraf/splash.py
@@ -3,7 +3,7 @@
 R. White, 2001 Dec 15
 """
 
-from __future__ import division, print_function
+
 
 import os
 import sys

--- a/pyraf/splash.py
+++ b/pyraf/splash.py
@@ -79,7 +79,7 @@ class PyrafSplash(SplashScreen):
         self.nlines = 1
         self.textcolor = textcolor
         if text:
-            if isinstance(text, type("")):
+            if isinstance(text, str):
                 text = text.split("\n")
             self.nlines = len(text)
             self.initialText = text
@@ -135,7 +135,7 @@ class PyrafSplash(SplashScreen):
         """Set text string"""
         if self.text is None:
             return
-        if isinstance(s, type('')):
+        if isinstance(s, str):
             s = s.split("\n")
         s = s[:len(self.text)]
         for i in range(len(s)):

--- a/pyraf/sscanfmodule.c
+++ b/pyraf/sscanfmodule.c
@@ -92,16 +92,6 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 static char scanset[1 << BITSPERCHAR];
 
 
-/*
- * Use PyStr_FromStringAndSize to support both Python 2 and 3.
- * We use them here the same way.
- */
-#if PY_MAJOR_VERSION >= 3
-#define PyStr_FromStringAndSize PyUnicode_FromStringAndSize
-#else
-#define PyStr_FromStringAndSize PyString_FromStringAndSize
-#endif
-
 /* ----------------------------------------------------- */
 
 static char sscanf_sscanf__doc__[] =
@@ -214,7 +204,7 @@ sscanf_sscanf( PyObject *self, PyObject *args )
             if (width < 1)
                 width = 1;
             if (doassign)
-                item = PyStr_FromStringAndSize(start, width);
+                item = PyUnicode_FromStringAndSize(start, width);
             inptr += width;
 
         } else if (c == 'd' || c == 'i' || c == 'l' ||
@@ -269,11 +259,7 @@ sscanf_sscanf( PyObject *self, PyObject *args )
                 if (end == s)
                     break;
                 if (doassign)
-#if PY_MAJOR_VERSION >= 3
                     item = PyLong_FromLong(lval);
-#else
-                    item = PyInt_FromLong(lval);
-#endif
             }
             inptr += end - start;
 
@@ -305,11 +291,7 @@ sscanf_sscanf( PyObject *self, PyObject *args )
                 if (ellmod) {
                     item = PyLong_FromLong(lval);
                 } else {
-#if PY_MAJOR_VERSION >= 3
                     item = PyLong_FromLong(lval);
-#else
-                    item = PyInt_FromLong(lval);
-#endif
                 }
             }
 
@@ -323,7 +305,7 @@ sscanf_sscanf( PyObject *self, PyObject *args )
             if (end == s)
                 break;
             if (doassign)
-                item = PyStr_FromStringAndSize(s, end - s);
+                item = PyUnicode_FromStringAndSize(s, end - s);
             inptr += end - start;
 
         } else if (c == '[') {
@@ -373,7 +355,7 @@ sscanf_sscanf( PyObject *self, PyObject *args )
             if (end == start)
                 break;
             if (doassign)
-                item = PyStr_FromStringAndSize(start, end - start);
+                item = PyUnicode_FromStringAndSize(start, end - start);
             inptr += end - start;
 
         } else {
@@ -425,7 +407,6 @@ static struct PyMethodDef sscanf_methods[] = {
 #define PyInit_sscanf PyInit_sscanfmodule
 #endif
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "sscanf",
@@ -435,23 +416,10 @@ static struct PyModuleDef moduledef = {
         NULL, NULL, NULL, NULL,
 };
 PyObject* PyInit_sscanf(void)
-#else
-void initsscanf(void)
-#endif
 {
    /* Create the module and add the functions */
    PyObject *m;
-#if PY_MAJOR_VERSION >= 3
    m = PyModule_Create(&moduledef);
-#else
-   m = Py_InitModule4("sscanf", sscanf_methods,
-       (char *)NULL, (PyObject *) NULL, PYTHON_API_VERSION);
-   if (PyErr_Occurred())
-       Py_FatalError("can't initialize module sscanf");
-#endif
 
-/* in Py2.*: just return */
-#if PY_MAJOR_VERSION >= 3
    return m;
-#endif
 }

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -50,7 +50,7 @@ import select
 import signal
 import sys
 import time
-from stsci.tools.for2to3 import tostr, BNULLSTR, BNEWLINE, bytes_read, bytes_write
+from stsci.tools.for2to3 import BNULLSTR, BNEWLINE, bytes_read, bytes_write
 
 OS_HAS_FORK = hasattr(os, 'fork')
 
@@ -832,7 +832,7 @@ class RedirProcess(Subprocess):
                     # stderr
                     s = self.readPendingErrChars()  # returns bytes
                     if s:
-                        sys.stderr.write(tostr(s))
+                        sys.stderr.write(s.decode())
                         sys.stderr.flush()
                     else:
                         # EOF
@@ -845,7 +845,7 @@ class RedirProcess(Subprocess):
                     # stdout
                     s = self.readPendingChars()  # returns bytes
                     if s:
-                        sys.stdout.write(tostr(s))
+                        sys.stdout.write(s.decode())
                         sys.stdout.flush()
                     else:
                         # EOF

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -15,7 +15,7 @@ Subprocess class features:
 
  - RecordFile class provides record-oriented IO for file-like stream objects.
 """
-from __future__ import division, print_function
+
 
 __version__ = "Revision: 1.7r "
 

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -156,7 +156,7 @@ class Subprocess:
             except os.error as e:
                 if self.control_stderr:
                     os.dup2(parentErr, 2)  # Reconnect to parent's stderr
-                sys.stderr.write("**execvp failed, '%s'**\n" % str(e))
+                sys.stderr.write("**execvp failed, '{}'**\n".format(str(e)))
                 os._exit(1)
 
         else:  # PARENT ###
@@ -182,10 +182,11 @@ class Subprocess:
             except os.error as xxx_todo_changeme1:
                 (errnum, msg) = xxx_todo_changeme1.args
                 if errnum == 10:
-                    raise SubprocessError("Subprocess '%s' failed." % self.cmd)
+                    raise SubprocessError("Subprocess '{}' failed."
+                                          .format(self.cmd))
                 else:
-                    raise SubprocessError("Subprocess '%s' failed [%d]: %s" %
-                                          (self.cmd, errnum, msg))
+                    raise SubprocessError("Subprocess '{}' failed [{:d}]: {}"
+                                          .format(self.cmd, errnum, msg))
             if pid != self.pid:
                 # flag indicating process is still running
                 self.return_code = None
@@ -203,12 +204,12 @@ class Subprocess:
                 self.return_code = rc
                 if sig:
                     raise SubprocessError(
-                        "Child process '%s' killed by signal %d with return code %d"
-                        % (self.cmd, sig, rc))
+                        "Child process '{}' killed by signal {:d} "
+                        "with return code {:d}".format(self.cmd, sig, rc))
                 else:
                     raise SubprocessError(
-                        "Child process '%s' exited with return code %d" %
-                        (self.cmd, rc))
+                        "Child process '{}' exited with return code {:d}"
+                        .format(self.cmd, rc))
 
     ### Write input to subprocess ###
 
@@ -219,10 +220,10 @@ class Subprocess:
         printtime seconds."""
 
         if not self.pid:
-            raise SubprocessError("No child process for '%s'" % self.cmd)
+            raise SubprocessError("No child process for '{}'".format(self.cmd))
         if not self.control_stdin:
             raise SubprocessError(
-                "Haven't grabbed subprocess input stream for %s." % self)
+                "Haven't grabbed subprocess input stream for {}.".format(self))
 
         # See if subprocess is ready for write.
         # Add a wait in case subprocess is still starting up or is
@@ -241,13 +242,13 @@ class Subprocess:
                 totalwait = totalwait + printtime
                 if select.select([], self.toChild_fdlist, [], printtime)[1]:
                     if os.write(self.toChild, strval) != len(strval):
-                        raise SubprocessError("Write error to %s" % self)
+                        raise SubprocessError("Write error to {}".format(self))
                     return  # ===>
-            raise SubprocessError("Write to %s blocked" % self)
+            raise SubprocessError("Write to {} blocked".format(self))
         except OSError as e:
             raise SubprocessError(
-                "Select error for %s: file descriptors %s\n%s" %
-                (self, self.toChild_fdlist, str(e)))
+                "Select error for {}: file descriptors {}\n{}"
+                .format(self, self.toChild_fdlist, str(e)))
 
     def writeline(self, line=''):
         """Write STRING, with added newline termination, to subprocess."""
@@ -257,7 +258,7 @@ class Subprocess:
         """Close write pipe to subprocess (signals EOF to subprocess)"""
         if not self.control_stdin:
             raise SubprocessError(
-                "Haven't grabbed subprocess input stream for %s." % self)
+                "Haven't grabbed subprocess input stream for {}.".format(self))
         os.close(self.toChild)
         self.parentPipes.remove(self.toChild)
         self.toChild = None
@@ -270,7 +271,7 @@ class Subprocess:
         """Read N chars (blocking), or all pending if no N specified."""
         if not self.control_stdout:
             raise SubprocessError(
-                "Haven't grabbed subprocess output stream for %s." % self)
+                "Haven't grabbed subprocess output stream for {}.".format(self))
         if n is None:
             return self.readPendingChars()
         else:
@@ -280,7 +281,7 @@ class Subprocess:
         """Read N chars from stderr (blocking), or all pending if no N specified."""
         if not self.control_stderr:
             raise SubprocessError(
-                "Haven't grabbed subprocess error stream for %s." % self)
+                "Haven't grabbed subprocess error stream for {}.".format(self))
         if n is None:
             return self.readPendingErrChars()
         else:
@@ -290,7 +291,7 @@ class Subprocess:
         """Read all currently pending subprocess output as a single string."""
         if not self.control_stdout:
             raise SubprocessError(
-                "Haven't grabbed subprocess output stream for %s." % self)
+                "Haven't grabbed subprocess output stream for {}.".format(self))
         return self.readbuf.readPendingChars(max)
 
     def readPendingErrChars(self, max=None):  # returns bytes
@@ -298,7 +299,7 @@ class Subprocess:
         string."""
         if not self.control_stderr:
             raise SubprocessError(
-                "Haven't grabbed subprocess error stream for %s." % self)
+                "Haven't grabbed subprocess error stream for {}.".format(self))
         return self.errbuf.readPendingChars(max)
 
     def readPendingLine(self):  # returns bytes
@@ -306,7 +307,7 @@ class Subprocess:
         (newline inclusive)."""
         if not self.control_stdout:
             raise SubprocessError(
-                "Haven't grabbed subprocess output stream for %s." % self)
+                "Haven't grabbed subprocess output stream for {}.".format(self))
         return self.readbuf.readPendingLine()
 
     def readPendingErrLine(self):  # returns bytes
@@ -314,7 +315,7 @@ class Subprocess:
         line (newline inclusive)."""
         if not self.control_stderr:
             raise SubprocessError(
-                "Haven't grabbed subprocess error stream for %s." % self)
+                "Haven't grabbed subprocess error stream for {}.".format(self))
         return self.errbuf.readPendingLine()
 
     def readline(self):
@@ -322,7 +323,7 @@ class Subprocess:
         then."""
         if not self.control_stdout:
             raise SubprocessError(
-                "Haven't grabbed subprocess output stream for %s." % self)
+                "Haven't grabbed subprocess output stream for {}.".format(self))
         return self.readbuf.readline()
 
     def readlineErr(self):
@@ -330,7 +331,7 @@ class Subprocess:
         then."""
         if not self.control_stderr:
             raise SubprocessError(
-                "Haven't grabbed subprocess error stream for %s." % self)
+                "Haven't grabbed subprocess error stream for {}.".format(self))
         return self.errbuf.readline()
 
     ### Subprocess Control ###
@@ -358,9 +359,9 @@ class Subprocess:
         elif not self.pid:
             status = 'sans process'
         elif not self.cont():
-            status = "(unresponding) '%s'" % self.cmd
+            status = "(unresponding) '{}'".format(self.cmd)
         else:
-            status = "'%s'" % self.cmd
+            status = "'{}'".format(self.cmd)
             active = 1
         if boolean:
             return active
@@ -425,14 +426,14 @@ class Subprocess:
         elif sig == signal.SIGKILL:
             sigval = 'KILLed '
         else:
-            sigval = 'Signal %d ' % sig
+            sigval = 'Signal {:d} '.format(sig)
         if rc:
-            retval = 'Status %d ' % rc
+            retval = 'Status {:d} '.format(rc)
         else:
             retval = ''
         sys.stderr.write(
-            "\n(%ssubproc %d '%s' %s/ %s)\n" %
-            (sigval, self.pid, self.cmd, retval, hex(id(self))[2:]))
+            "\n({}subproc {:d} '{}' {}/ {})\n"
+            .format(sigval, self.pid, self.cmd, retval, hex(id(self))[2:]))
         sys.stderr.flush()
 
     def stop(self, verbose=False):
@@ -442,11 +443,11 @@ class Subprocess:
             os.kill(self.pid, signal.SIGSTOP)
         except os.error:
             if verbose:
-                print("Stop failed for '%s' - '%s'" %
-                      (self.cmd, sys.exc_info()[1]))
+                print("Stop failed for '{}' - '{}'"
+                      .format(self.cmd, sys.exc_info()[1]))
             return 0
         if verbose:
-            print("Stopped '%s'" % self.cmd)
+            print("Stopped '{}'".format(self.cmd))
         return 'stopped'
 
     def cont(self, verbose=False):
@@ -456,11 +457,11 @@ class Subprocess:
             os.kill(self.pid, signal.SIGCONT)
         except os.error:
             if verbose:
-                print("Continue failed for '%s' - '%s'" %
-                      (self.cmd, sys.exc_info()[1]))
+                print("Continue failed for '{}' - '{}'"
+                      .format(self.cmd, sys.exc_info()[1]))
             return 0
         if verbose:
-            print("Continued '%s'" % self.cmd)
+            print("Continued '{}'".format(self.cmd))
         return 'continued'
 
     def die(self):
@@ -474,7 +475,7 @@ class Subprocess:
         if not self.pid:
             raise SubprocessError("No process")
         elif not self.cont():
-            raise SubprocessError("Can't signal subproc %s" % self)
+            raise SubprocessError("Can't signal subproc {}".format(self))
 
         # Try sending first a TERM and then a KILL signal.
         sigs = [('TERM', signal.SIGTERM), ('KILL', signal.SIGKILL)]
@@ -489,8 +490,8 @@ class Subprocess:
                 return  # ===>
         # Only got here if subprocess is not gone:
         raise SubprocessError(
-            "Failed kill of subproc %d, '%s', with signals %s" %
-            (self.pid, self.cmd, [x[0] for x in sigs]))
+            "Failed kill of subproc {:d}, '{}', with signals {}"
+            .format(self.pid, self.cmd, [x[0] for x in sigs]))
 
     def __del__(self):
         """Terminate the subprocess"""
@@ -680,7 +681,7 @@ class RecordFile:
     def write_record(self, s):
         "Write so self.read knows exactly how much to read."
         f = self.__dict__['file']
-        f.write("%s\n%s" % (len(s), s))
+        f.write("{}\n{}".format(len(s), s))
         if hasattr(f, 'flush'):
             f.flush()
 
@@ -692,8 +693,8 @@ class RecordFile:
             try:
                 l = int(line)
             except ValueError:
-                raise OSError("corrupt %s file structure" %
-                              self.__class__.__name__)
+                raise OSError("corrupt {} file structure"
+                              .format(self.__class__.__name__))
             return f.read(l)
         else:
             # EOF.
@@ -708,7 +709,7 @@ class RecordFile:
             raise AttributeError(attr)
 
     def __repr__(self):
-        return "<%s of %s at %s>" % (self.__class__.__name__,
+        return "<{} of {} at {}>".format(self.__class__.__name__,
                                      self.__dict__['file'], hex(id(self))[2:])
 
 
@@ -722,9 +723,9 @@ def record_trial(s):
     c.write(s)
     c.seek(0)
     r = c.read()
-    show = " start:\t %s\n end:\t %s\n" % (repr(s), repr(r))
+    show = " start:\t {}\n end:\t {}\n".format(repr(s), repr(r))
     if r != s:
-        raise OSError("String distorted:\n%s" % show)
+        raise OSError("String distorted:\n{}".format(show))
 
 
 #############################################################################
@@ -746,7 +747,7 @@ def systemRedir(cmd):
         process.run()
     except KeyboardInterrupt:
         process.die()
-        sys.stderr.write("\nKilled process `%s'\n" % process.cmd)
+        sys.stderr.write("\nKilled process `{}'\n".format(process.cmd))
         sys.stderr.flush()
         raise
     return process.return_code
@@ -818,9 +819,9 @@ class RedirProcess(Subprocess):
                 # select error occurs if a file descriptor has been closed
                 # this should not happen -- raise an exception
                 raise SubprocessError(
-                    "Select error for %s: file descriptors %s\n%s" %
-                    (self, self.toChild_fdlist + self.fromChild_fdlist,
-                     str(e)))
+                    "Select error for {}: file descriptors {}\n{}"
+                    .format(self, self.toChild_fdlist + self.fromChild_fdlist,
+                            str(e)))
             if readable:
                 # stderr is first in fromChild_fdlist (if present)
                 if doErr and (self.fromChild_fdlist[0] in readable):

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -721,7 +721,7 @@ def record_trial(s):
     """Exercise encapsulated write/read with an arbitrary string.
 
     Raise IOError if the string gets distorted through transmission!"""
-    from StringIO import StringIO
+    from io import StringIO
     sf = StringIO()
     c = RecordFile(sf)
     c.write(s)

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -103,7 +103,7 @@ class Subprocess:
         """Fork a subprocess with designated COMMAND (default, self.cmd)."""
         if cmd:
             self.cmd = cmd
-        if isinstance(self.cmd, (str, unicode)):
+        if isinstance(self.cmd, str):
             cmd = self.cmd.split()
         else:
             cmd = self.cmd

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -50,7 +50,6 @@ import select
 import signal
 import sys
 import time
-from stsci.tools.for2to3 import bytes_read, bytes_write
 
 OS_HAS_FORK = hasattr(os, 'fork')
 
@@ -245,7 +244,7 @@ class Subprocess:
                 ## if totalwait: print "waiting for subprocess..."
                 totalwait = totalwait + printtime
                 if select.select([], self.toChild_fdlist, [], printtime)[1]:
-                    if bytes_write(self.toChild, strval) != len(strval):
+                    if os.write(self.toChild, strval) != len(strval):
                         raise SubprocessError("Write error to %s" % self)
                     return  # ===>
             raise SubprocessError("Write to %s blocked" % self)
@@ -555,7 +554,7 @@ class ReadBuf:
             self.eof = 1
             return b''  # ===>
         if sel[0]:
-            got = bytes_read(self.fd, self.chunkSize)
+            got = os.read(self.fd, self.chunkSize)
             if got:
                 if max and (len(got) > max):
                     self.buf = got[max:]
@@ -605,7 +604,7 @@ class ReadBuf:
                 self.eof = 1
                 return got
             if sel[0]:
-                newgot = bytes_read(self.fd, self.chunkSize)
+                newgot = os.read(self.fd, self.chunkSize)
                 if newgot:
                     got = got + newgot
                     to = got.find(b'\n')
@@ -651,7 +650,7 @@ class ReadBuf:
                 self.eof = 1
                 return got
             if sel[0]:
-                newgot = bytes_read(self.fd, self.chunkSize)
+                newgot = os.read(self.fd, self.chunkSize)
                 if newgot:
                     got = got + newgot
                     if len(got) >= nchars:

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -53,13 +53,9 @@ import time
 
 OS_HAS_FORK = hasattr(os, 'fork')
 
-try:
 
-    class SubprocessError(Exception):
-        pass
-except TypeError:
-    # string based exceptions
-    SubprocessError = 'SubprocessError'
+class SubprocessError(Exception):
+    pass
 
 
 class Subprocess:

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -244,7 +244,7 @@ class Subprocess:
                         raise SubprocessError("Write error to %s" % self)
                     return  # ===>
             raise SubprocessError("Write to %s blocked" % self)
-        except select.error as e:
+        except OSError as e:
             raise SubprocessError(
                 "Select error for %s: file descriptors %s\n%s" %
                 (self, self.toChild_fdlist, str(e)))
@@ -346,7 +346,7 @@ class Subprocess:
             try:
                 readable, writable, errors = select.select(
                     self.fromChild_fdlist, self.toChild_fdlist, [], 0)
-            except select.error:
+            except OSError:
                 status = 0
         return status
 
@@ -544,7 +544,7 @@ class ReadBuf:
 
         try:
             sel = select.select([self.fd], [], [self.fd], 0)
-        except select.error:
+        except OSError:
             # select error occurs if self.fd been closed
             # treat like EOF
             self.eof = 1
@@ -594,7 +594,7 @@ class ReadBuf:
         while True:  # (we'll only loop if block set)
             try:
                 sel = select.select(fdlist, [], fdlist, waittime)
-            except select.error:
+            except OSError:
                 # select error occurs if self.fd has been closed
                 # treat like EOF
                 self.eof = 1
@@ -640,7 +640,7 @@ class ReadBuf:
         while True:
             try:
                 sel = select.select(fdlist, [], fdlist)
-            except select.error:
+            except OSError:
                 # select error occurs if self.fd has been closed
                 # treat like EOF
                 self.eof = 1
@@ -692,7 +692,7 @@ class RecordFile:
             try:
                 l = int(line)
             except ValueError:
-                raise IOError("corrupt %s file structure" %
+                raise OSError("corrupt %s file structure" %
                               self.__class__.__name__)
             return f.read(l)
         else:
@@ -724,7 +724,7 @@ def record_trial(s):
     r = c.read()
     show = " start:\t %s\n end:\t %s\n" % (repr(s), repr(r))
     if r != s:
-        raise IOError("String distorted:\n%s" % show)
+        raise OSError("String distorted:\n%s" % show)
 
 
 #############################################################################
@@ -814,7 +814,7 @@ class RedirProcess(Subprocess):
             try:
                 readable, writable, errors = select.select(
                     self.fromChild_fdlist, self.toChild_fdlist, [], timeout)
-            except select.error as e:
+            except OSError as e:
                 # select error occurs if a file descriptor has been closed
                 # this should not happen -- raise an exception
                 raise SubprocessError(
@@ -861,7 +861,7 @@ class RedirProcess(Subprocess):
                     if s:
                         try:
                             self.write(s)  # inside, converts PY3K str to bytes
-                        except IOError as xxx_todo_changeme:
+                        except OSError as xxx_todo_changeme:
                             # broken pipe may be OK
                             # just call it an EOF and see what happens
                             (errnum, msg) = xxx_todo_changeme.args

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -50,7 +50,7 @@ import select
 import signal
 import sys
 import time
-from stsci.tools.for2to3 import BNULLSTR, BNEWLINE, bytes_read, bytes_write
+from stsci.tools.for2to3 import bytes_read, bytes_write
 
 OS_HAS_FORK = hasattr(os, 'fork')
 
@@ -535,17 +535,17 @@ class ReadBuf:
         pending.  Returns bytes."""
 
         if (max is not None) and (max <= 0):
-            return BNULLSTR  # ===>
+            return b''  # ===>
 
         if self.buf:
             if max and (len(self.buf) > max):
                 got, self.buf = self.buf[0:max], self.buf[max:]
             else:
-                got, self.buf = self.buf, BNULLSTR
+                got, self.buf = self.buf, b''
             return got  # ===>
 
         if self.eof:
-            return BNULLSTR  # ===>
+            return b''  # ===>
 
         try:
             sel = select.select([self.fd], [], [self.fd], 0)
@@ -553,7 +553,7 @@ class ReadBuf:
             # select error occurs if self.fd been closed
             # treat like EOF
             self.eof = 1
-            return BNULLSTR  # ===>
+            return b''  # ===>
         if sel[0]:
             got = bytes_read(self.fd, self.chunkSize)
             if got:
@@ -564,9 +564,9 @@ class ReadBuf:
                     return got  # ===>
             else:
                 self.eof = 1
-                return BNULLSTR  # ===>
+                return b''  # ===>
         else:
-            return BNULLSTR  # ===>
+            return b''  # ===>
 
     def readPendingLine(self, block=0):
         """Return pending output from FILE, up to first newline (inclusive).
@@ -577,15 +577,15 @@ class ReadBuf:
         1024) characters."""
 
         if self.buf:
-            to = self.buf.find(BNEWLINE)
+            to = self.buf.find(b'\n')
             if to != -1:
                 got, self.buf = self.buf[:to + 1], self.buf[to + 1:]
                 return got  # ===>
-            got, self.buf = self.buf, BNULLSTR
+            got, self.buf = self.buf, b''
         elif self.eof:
-            return BNULLSTR  # ===>
+            return b''  # ===>
         else:
-            got = BNULLSTR
+            got = b''
 
         # 'got' contains the (former) contents of the buffer, but it
         # doesn't include a newline.
@@ -608,7 +608,7 @@ class ReadBuf:
                 newgot = bytes_read(self.fd, self.chunkSize)
                 if newgot:
                     got = got + newgot
-                    to = got.find(BNEWLINE)
+                    to = got.find(b'\n')
                     if to != -1:
                         got, self.buf = got[:to + 1], got[to + 1:]
                         return got  # ===>
@@ -630,16 +630,16 @@ class ReadBuf:
         Returns a shorter string on EOF.  Returns bytes."""
 
         if nchars <= 0:
-            return BNULLSTR
+            return b''
         if self.buf:
             if len(self.buf) >= nchars:
                 got, self.buf = self.buf[:nchars], self.buf[nchars:]
                 return got  # ===>
-            got, self.buf = self.buf, BNULLSTR
+            got, self.buf = self.buf, b''
         elif self.eof:
-            return BNULLSTR  # ===>
+            return b''  # ===>
         else:
-            got = BNULLSTR
+            got = b''
 
         fdlist = [self.fd]
         while True:

--- a/pyraf/tests/test_basic.py
+++ b/pyraf/tests/test_basic.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 import six
 
 import os

--- a/pyraf/tests/test_basic.py
+++ b/pyraf/tests/test_basic.py
@@ -1,6 +1,4 @@
-
-import six
-
+import io
 import os
 
 import pytest
@@ -48,7 +46,7 @@ class TestPyraf(object):
             assert f[0].data.shape == (512, 512)
 
     def test_imhead(self):
-        out = six.StringIO()
+        out = io.StringIO()
         iraf.imhead('dev$pix', Stdout=out)
         assert out.getvalue() == 'dev$pix[512,512][short]: m51  B  600s\n'
 

--- a/pyraf/tests/test_clcache.py
+++ b/pyraf/tests/test_clcache.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+
 
 import os
 

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -1,5 +1,5 @@
 """These were tests under cli in pandokia."""
-from __future__ import absolute_import, division
+
 
 import pytest
 

--- a/pyraf/tests/test_core_nongraphics.py
+++ b/pyraf/tests/test_core_nongraphics.py
@@ -1,5 +1,5 @@
 """These were tests under core/irafparlist and core/subproc in pandokia."""
-from __future__ import absolute_import, division, print_function
+
 
 import time
 import uuid

--- a/pyraf/tests/test_core_nongraphics.py
+++ b/pyraf/tests/test_core_nongraphics.py
@@ -6,7 +6,7 @@ import uuid
 
 import pytest
 
-from .utils import HAS_IRAF, IS_PY2
+from .utils import HAS_IRAF
 
 if HAS_IRAF:
     from pyraf.irafpar import IrafParList
@@ -206,8 +206,6 @@ def test_irafparlist_getParDict(_ipl, _pars):
 
 
 @pytest.mark.skipif(not HAS_IRAF, reason='PyRAF must be installed to run')
-@pytest.mark.xfail(IS_PY2,
-                   reason="BUG: raises 'TypeError: number coercion failed'")
 def test_irafparlist_getParList(_ipl, _pars):
     for par in _pars:
         _ipl.addParam(par)

--- a/pyraf/tests/test_core_nongraphics.py
+++ b/pyraf/tests/test_core_nongraphics.py
@@ -30,8 +30,8 @@ def test_subproc_wait():
 def test_subproc_write_readline(_proc):
     """Buffer readback test; readline
     """
-    _proc.write('test string one\n')
-    _proc.write('test string two\n')
+    _proc.write(b'test string one\n')
+    _proc.write(b'test string two\n')
     time.sleep(0.01)
 
     assert _proc.readline() == b'test string one\n'
@@ -42,12 +42,12 @@ def test_subproc_write_readline(_proc):
 def test_subproc_write_readPendingChars(_proc):
     """Buffer readback test; readPendingChars
     """
-    test_inputs = ('one', 'two', 'three')
+    test_inputs = (b'one', b'two', b'three')
     for test_input in test_inputs:
-        _proc.write(test_input + '\n')
+        _proc.write(test_input + b'\n')
         time.sleep(0.01)
 
-    expected = tuple(_proc.readPendingChars().decode().splitlines())
+    expected = tuple(_proc.readPendingChars().splitlines())
     assert test_inputs == expected
 
 
@@ -65,7 +65,7 @@ def test_subproc_stop_resume_write_read(_proc):
     resume, then read the buffered data back from the pipe.
     """
     assert _proc.stop()
-    _proc.write('test string\n')
+    _proc.write(b'test string\n')
     assert not len(_proc.readPendingChars())
     assert _proc.cont()
     assert _proc.readline() == b'test string\n'

--- a/pyraf/tests/test_describe.py
+++ b/pyraf/tests/test_describe.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import pytest
 

--- a/pyraf/tests/test_graphics.py
+++ b/pyraf/tests/test_graphics.py
@@ -158,7 +158,6 @@ def test_dumpspecs():
     # verify it (is version dependent)
     expected = """python ver = {major}.{minor}
 platform = {platform}
-PY3K = {py3k}
 c.OF_GRAPHICS = False
 /dev/console owner = <skipped>
 tkinter use unattempted.

--- a/pyraf/tests/test_graphics.py
+++ b/pyraf/tests/test_graphics.py
@@ -163,8 +163,7 @@ c.OF_GRAPHICS = False
 tkinter use unattempted.
 """.format(major=sys.version_info.major,
            minor=sys.version_info.minor,
-           platform=sys.platform,
-           py3k=(sys.version_info.major >= 3))
+           platform=sys.platform)
 
     assert expected.strip() == out_str.strip(), \
         'Unexpected output from wutil.dumpspecs: {}'.format(out_str)

--- a/pyraf/tests/test_graphics.py
+++ b/pyraf/tests/test_graphics.py
@@ -1,7 +1,6 @@
 """These were tests under core/graphics_checks in pandokia."""
 
-import six
-
+import io
 import glob
 import os
 import sys
@@ -145,7 +144,7 @@ def getNewTmpPskFile(theBeforeList, title, preferred=None):
 @pytest.mark.skipif(not HAS_IRAF, reason='Need IRAF to run')
 def test_dumpspecs():
     # get dumpspecs output
-    out_f = six.StringIO()
+    out_f = io.StringIO()
     wutil.dumpspecs(outstream=out_f, skip_volatiles=True)
     out_str = out_f.getvalue()
     out_f.close()

--- a/pyraf/tests/test_graphics.py
+++ b/pyraf/tests/test_graphics.py
@@ -1,5 +1,5 @@
 """These were tests under core/graphics_checks in pandokia."""
-from __future__ import absolute_import, print_function
+
 import six
 
 import glob

--- a/pyraf/tests/test_invocation.py
+++ b/pyraf/tests/test_invocation.py
@@ -5,7 +5,7 @@ import subprocess
 import pytest
 
 import pyraf
-from .utils import HAS_IRAF, HAS_PYRAF_EXEC, IS_PY2
+from .utils import HAS_IRAF, HAS_PYRAF_EXEC
 
 cl_cases = (
     (('print(1)'), '1'),
@@ -89,8 +89,6 @@ def test_invoke_command(_with_pyraf, test_input, expected):
     """
     result = _with_pyraf.run(['-c', test_input])
     assert result.stdout.startswith(expected)
-    if IS_PY2:
-        assert not result.stderr
     assert not result.code, result.stderr
 
 
@@ -131,6 +129,4 @@ def test_invoke_command_ipython(_with_pyraf, test_input, expected):
     """
     result = _with_pyraf.run('-y', stdin=test_input)
     assert expected in result.stdout
-    if IS_PY2:
-        assert not result.stderr
     assert not result.code, result.stderr

--- a/pyraf/tests/test_invocation.py
+++ b/pyraf/tests/test_invocation.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import subprocess
 

--- a/pyraf/tests/test_using_tasks.py
+++ b/pyraf/tests/test_using_tasks.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import math
 import os

--- a/pyraf/tests/test_using_tasks.py
+++ b/pyraf/tests/test_using_tasks.py
@@ -12,7 +12,7 @@ if HAS_IRAF:
     from pyraf import iraf
 
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
     from io import StringIO
 

--- a/pyraf/tests/utils.py
+++ b/pyraf/tests/utils.py
@@ -4,7 +4,6 @@ import sys
 from astropy.utils.data import get_pkg_data_contents
 from distutils.spawn import find_executable
 
-IS_PY2 = sys.version_info < (3, 0)
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 HAS_PYRAF_EXEC = bool(find_executable('pyraf'))
 

--- a/pyraf/textattrib.py
+++ b/pyraf/textattrib.py
@@ -19,7 +19,7 @@ From experiments, these are some properties of IRAF text:
 This implementation will allow some of these properties to be overriden
 by a system-wide configuration state. See gkiopengl.py
 """
-from __future__ import division, print_function
+
 
 from . import fontdata
 

--- a/pyraf/textattrib.py
+++ b/pyraf/textattrib.py
@@ -21,7 +21,7 @@ by a system-wide configuration state. See gkiopengl.py
 """
 from __future__ import division, print_function
 
-import fontdata
+from . import fontdata
 
 CHARPATH_LEFT = 2
 CHARPATH_RIGHT = 3

--- a/pyraf/tkplottext.py
+++ b/pyraf/tkplottext.py
@@ -23,7 +23,7 @@ from __future__ import division, print_function
 
 import numpy
 import math
-from textattrib import (CHARPATH_LEFT, CHARPATH_RIGHT, CHARPATH_UP,
+from .textattrib import (CHARPATH_LEFT, CHARPATH_RIGHT, CHARPATH_UP,
                         CHARPATH_DOWN, JUSTIFIED_CENTER, JUSTIFIED_RIGHT,
                         JUSTIFIED_LEFT, JUSTIFIED_NORMAL, JUSTIFIED_TOP,
                         JUSTIFIED_BOTTOM)

--- a/pyraf/tkplottext.py
+++ b/pyraf/tkplottext.py
@@ -19,7 +19,7 @@ From experiments, these are some properties of IRAF text:
 This implementation will allow some of these properties to be overriden
 by a system-wide configuration state. See gkiopengl.py
 """
-from __future__ import division, print_function
+
 
 import numpy
 import math

--- a/pyraf/tpar.py
+++ b/pyraf/tpar.py
@@ -226,7 +226,7 @@ class Binder:
                 return self.bindings["ready"]()
             else:
                 return "ready"
-        self.debug("pos: %s    key: %s" % (pos, key))
+        self.debug("pos: {}    key: {}".format(pos, key))
         if key in self.mode_keys:
             self.chord.append(key)
             return None
@@ -243,8 +243,8 @@ class Binder:
                 key = f
             else:
                 key = f()
-            self.debug("pos: %s  visited: %s  key: %s mapping: %s" %
-                       (pos, " --> ".join(visited), key, f))
+            self.debug("pos: {}  visited: {}  key: {} mapping: {}"
+                       .format(pos, " --> ".join(visited), key, f))
         return key
 
     def debug(self, s):
@@ -433,15 +433,15 @@ class StringTparOption(urwid.Columns):
             help = ") " + help
         else:
             help = "  " + help
-        self._name = urwid.Text("%-10s=" % name)
+        self._name = urwid.Text("{:<10s}=".format(name))
         self._edit = PyrafEdit("",
                                "",
                                wrap="clip",
                                align="right",
                                inform=inform)
         self._edit.verify = self.verify
-        self._value = urwid.Text("%10s" % value, align="right")
-        self._help = urwid.Text("%-30s" % help)
+        self._value = urwid.Text("{:10s}".format(value), align="right")
+        self._help = urwid.Text("{:<30s}".format(help))
         urwid.Columns.__init__(self, [('weight', 0.20, self._name),
                                       ('weight', 0.20, self._edit),
                                       ('weight', 0.20, self._value),
@@ -653,9 +653,9 @@ class TparHeader(urwid.Pile):
 
     def __init__(self, package, task=None):
         top = urwid.Text(("header", self.banner))
-        s = "%8s= %-10s\n" % ("PACKAGE", package)
+        s = "{:>8}= {:<10}\n".format("PACKAGE", package)
         if task is not None:
-            s += "%8s= %-10s" % ("TASK", task)
+            s += "{:>8}= {:<10}".format("TASK", task)
         info = urwid.Text(("body", s))
         urwid.Pile.__init__(self, [top, info])
 
@@ -861,7 +861,7 @@ class TparDisplay(Binder):
         if len(dlist) != len(self.paramList):
             # whoops, lengths don't match
             raise ValueError("Mismatch between default, current par lists"
-                             " for task %s (try unlearn)" % self.taskName)
+                             " for task {} (try unlearn)".format(self.taskName))
         pardict = {}
         for par in dlist:
             pardict[par.name] = par
@@ -873,7 +873,7 @@ class TparDisplay(Binder):
                 dsort.append(pardict[par.name])
         except KeyError:
             raise ValueError("Mismatch between default, current par lists"
-                             " for task %s (try unlearn)" % self.taskName)
+                             " for task {} (try unlearn)".format(self.taskName))
         self.defaultParamList = dsort
 
     # Method to create the parameter entries
@@ -923,7 +923,7 @@ class TparDisplay(Binder):
                                           focus=True)
                 elif k == 'window resize':
                     size = self.ui.get_cols_rows()
-                    self.inform("resize %s" % (str(size)))
+                    self.inform("resize {}".format(str(size)))
                 k = self.keypress(size, k)
                 self.view.keypress(size, k)
 
@@ -987,8 +987,8 @@ class TparDisplay(Binder):
             try:
                 f(file, emph)
             except Exception as e:
-                self.inform("command '%s' failed with exception '%s'" %
-                            (cmd, e))
+                self.inform("command '{}' failed with exception '{}'"
+                            .format(cmd, e))
 
     def save_as(self):
         """ Save the parameter settings to a user-specified file.  Any
@@ -1171,7 +1171,7 @@ class TparDisplay(Binder):
         self.save(emph)
 
         def go_continue():
-            print("\nTask %s is running...\n" % self.taskName)
+            print("\nTask {} is running...\n".format(self.taskName))
             self.run_task()
 
         self.done = go_continue
@@ -1206,10 +1206,10 @@ class TparDisplay(Binder):
 
     def write_pset(self, file, overwrite):
         if os.path.exists(file) and not overwrite:
-            self.inform("File '%s' exists and overwrite (!) not used." %
-                        (file,))
+            self.inform("File '{}' exists and overwrite (!) not used."
+                        .format(file))
         # XXXX write out parameters to file
-        self.inform("write pset: %s" % (file,))
+        self.inform("write pset: {}".format(file))
 
     def set_all_entries_from_par_list(self, aParList):
         """ Set all the parameter entry values in the GUI to the values
@@ -1359,16 +1359,14 @@ class TparDisplay(Binder):
     # Process invalid input values and invoke a query dialog
     def process_bad_entries(self, badEntriesList, taskname):
 
-        format = "%20s %20s %20s\n"
+        tpl = "{:>20s} {:>20s} {:>20s}\n"
         badEntriesString = "\nTask " + taskname.upper() + \
                            " -- Invalid values have been entered.\n\n"
-        badEntriesString += format % \
-            ("Parameter", "Bad Value", "Reset Value")
+        badEntriesString += tpl.format("Parameter", "Bad Value", "Reset Value")
         for i in range(len(badEntriesList)):
-            badEntriesString += format % \
-                (badEntriesList[i][0].strip(),
-                 badEntriesList[i][1].strip(),
-                 badEntriesList[i][2].strip())
+            badEntriesString += tpl.format(badEntriesList[i][0].strip(),
+                                           badEntriesList[i][1].strip(),
+                                           badEntriesList[i][2].strip())
 
             badEntriesString += "\nOK to continue using"\
                 " the reset\nvalues or cancel to re-enter\nvalues?\n"

--- a/pyraf/tpar.py
+++ b/pyraf/tpar.py
@@ -38,8 +38,8 @@ try:
     import urwid.curses_display
     import urwid.raw_display
     import urwid
-    import urwutil
-    import urwfiledlg
+    from . import urwutil
+    from . import urwfiledlg
     urwid.set_encoding("ascii")  # gives better performance than 'utf8'
     if 0 == urwid.__version__.find('0.9.8') or 0 == urwid.__version__.find(
             '0.9.7'):
@@ -53,11 +53,11 @@ except Exception as e:
     urwid.the_error = str(e)
 
 # PyRAF modules
-import iraf
-import irafpar
-import irafhelp
-import iraftask
-import iraffunctions
+from . import iraf
+from . import irafpar
+from . import irafhelp
+from . import iraftask
+from . import iraffunctions
 
 TPAR_HELP_EMACS = """                                EDIT COMMANDS (emacs)
 

--- a/pyraf/tpar.py
+++ b/pyraf/tpar.py
@@ -203,7 +203,7 @@ TPAR_BINDINGS_VI = {
 }
 
 
-class Binder(object):
+class Binder:
     """The Binder class manages keypresses for urwid and adds the
     ability to bind specific inputs to actions.
     """

--- a/pyraf/tpar.py
+++ b/pyraf/tpar.py
@@ -9,7 +9,7 @@ contexts or for people who prefer text interfaces to GUIs.
 
 Todd Miller, 2006 May 30  derived from epar.py and IRAF CL epar.
 """
-from __future__ import division, print_function
+
 
 # XXXX Debugging tip:  uncomment self.inform() in the debug() method below
 

--- a/pyraf/tpar.py
+++ b/pyraf/tpar.py
@@ -886,13 +886,7 @@ class TparDisplay(Binder):
 
     def main(self):
         # Create the Screen using curses_display.
-        # On OSX in py2.6 and greater, this causes issues (see #117),
-        # where raw_display seems to work just as well so use it.
-        if sys.platform == 'darwin' and sys.version_info[0] == 2 and \
-           sys.version_info[1] > 5:
-            self.ui = urwid.raw_display.Screen()
-        else:
-            self.ui = urwid.curses_display.Screen()
+        self.ui = urwid.curses_display.Screen()
         self.ui.register_palette(self.palette)
         self.ui.run_wrapper(self.run)  # raw_display has alternate_buffer=True
         self.done()

--- a/pyraf/urwfiledlg.py
+++ b/pyraf/urwfiledlg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env  python
+#!/usr/bin/env  python3
 """
 A filechooser for urwid.
 Author: Rebecca Breu (rebecca@rbreu.de)

--- a/pyraf/urwfiledlg.py
+++ b/pyraf/urwfiledlg.py
@@ -9,7 +9,7 @@ copy is based on r49 of urwid/contrib/trunk/rbreu_filechooser.py, updated
 2006.10.17.  Only minor changes were made - mostly to handle use with differing
 versions of urwid.  Many thanks to author Rebecca Breu.
 """
-from __future__ import division, print_function
+
 
 from urwid import (Text, AttrWrap, WidgetWrap, BoxAdapter, ListBox, AttrWrap,
                    Columns, Edit, Button, GridFlow, CheckBox, Pile,

--- a/pyraf/urwutil.py
+++ b/pyraf/urwutil.py
@@ -23,7 +23,7 @@ the DialogDisplay and the InputDialogDisplay classes.  Unsure why this
 functionality is not delivered with a standard urwid installation, so we will
 include this file until it comes with urwid.  This is slightly modified.
 """
-from __future__ import division, print_function
+
 
 import sys
 import urwid

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -98,7 +98,7 @@ try:
         # ONLY if an XWindow was successfully initialized.
         #  WJH (10June2004)
         if xutil.getFocalWindowID() == -1:
-            raise EnvironmentError()
+            raise OSError()
 
         # Successful intialization. Reset dummy methods with
         # those from 'xutil' now.
@@ -127,7 +127,7 @@ try:
 
 except ImportError:
     _has_xutil = 0  # Unsuccessful init of XWindow
-except EnvironmentError:
+except OSError:
     _has_xutil = 0  # Unsuccessful init of XWindow
 
 # Clean up the namespace a bit...
@@ -175,7 +175,7 @@ def getTopID(WindowID):
                 return wid
             else:
                 wid = pid
-    except EnvironmentError:
+    except OSError:
         return None
 
 
@@ -218,7 +218,7 @@ def getTermWindowSize():
         if xsize <= 0:
             xsize = 80
         return ysize, xsize
-    except IOError:
+    except OSError:
         return (24, 80)  # assume generic size
 
 
@@ -268,7 +268,7 @@ class TerminalFocusEntity(FocusEntity):
                 scrnPosDict = aqutil.getPointerGlobalPosition()
                 self.lastScreenX = scrnPosDict['x']
                 self.lastScreenY = scrnPosDict['y']
-        except EnvironmentError:
+        except OSError:
             self.windowID = None
         self.lastX = 30
         self.lastY = 30

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -480,7 +480,7 @@ class FocusController:
                 focusTarget.gwidget.focus_set()
 
         current = self.focusStack[-1]
-        if isinstance(focusTarget, type("")):
+        if isinstance(focusTarget, str):
             next = self.focusEntities[focusTarget]
         else:
             next = focusTarget

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -136,29 +136,8 @@ try:
 except NameError:
     pass  # may not have imported it
 
-magicConstant = None
-try:
-    import IOCTL
-    magicConstant = IOCTL.TIOCGWINSZ
-except ImportError:
-    if sys.platform == 'sunos5':
-        magicConstant = ord('T') * 256 + 104
-    elif sys.platform.startswith('linux'):
-        magicConstant = 0x5413
-    elif sys.platform[:4] == 'osf1':
-        magicConstant = 0x40087468
-    elif sys.platform.startswith('win'):
-        magicConstant = None  # this is unused on windows (so far)
-    elif sys.platform == 'darwin':
-        try:
-            import termios
-            magicConstant = termios.TIOCGWINSZ
-        except ImportError:
-            magicConstant = 1074275912
-    else:
-        raise ImportError(
-            "wutil.py: Needs definition of TIOCGWINSZ constant for platform %s"
-            % sys.platform)
+import termios
+magicConstant = termios.TIOCGWINSZ
 
 
 def getScreenDepth():
@@ -361,9 +340,6 @@ class TerminalFocusEntity(FocusEntity):
     def getWindowSize(self):
         """return a tuple containing the x,y size of the terminal window
         in characters"""
-
-        if magicConstant is None:
-            raise Exception("platform isn't supported: " + sys.platform)
 
         # define string to serve as memory area to receive copy of structure
         # created by IOCTL call

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -550,7 +550,6 @@ def dumpspecs(outstream=None, skip_volatiles=False):
     out += "\nplatform = " + str(sys.platform)
     if not skip_volatiles:
         out += "\nPyRAF ver = " + pyrver
-    out += "\nPY3K = " + str(capable.PY3K)
     out += "\nc.OF_GRAPHICS = " + str(capable.OF_GRAPHICS)
     dco = 'not yet known'
     if hasattr(capable, 'get_dc_owner'):  # rm hasattr at/after v2.2

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -518,12 +518,11 @@ def dumpspecs(outstream=None, skip_volatiles=False):
         out += "\nPyRAF ver = " + pyrver
     out += "\nc.OF_GRAPHICS = " + str(capable.OF_GRAPHICS)
     dco = 'not yet known'
-    if hasattr(capable, 'get_dc_owner'):  # rm hasattr at/after v2.2
-        if skip_volatiles:
-            out += "\n/dev/console owner = <skipped>"
-        else:
-            dco = capable.get_dc_owner(False, True)
-            out += "\n/dev/console owner = " + str(dco)
+    if skip_volatiles:
+        out += "\n/dev/console owner = <skipped>"
+    else:
+        dco = capable.get_dc_owner(False, True)
+        out += "\n/dev/console owner = " + str(dco)
 
     if not capable.OF_GRAPHICS:
         out += "\ntkinter use unattempted."

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -123,10 +123,10 @@ try:
         # If on OSX w/out X11, use aqutil
         if WUTIL_ON_MAC and not _skipDisplay:  # as opposed to the PC (future?)
             try:
-                import aqutil
+                from . import aqutil
                 # override the few Mac-specific functions needed
-                from aqutil import getFocalWindowID, setFocusTo, getParentID
-                from aqutil import moveCursorTo, getPointerPosition
+                from .aqutil import getFocalWindowID, setFocusTo, getParentID
+                from .aqutil import moveCursorTo, getPointerPosition
                 _has_aqutil = 1
             except ImportError:
                 _has_aqutil = 0

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -9,6 +9,7 @@ from __future__ import division, print_function
 import struct
 import sys
 import os
+import tkinter
 
 try:
     import fcntl
@@ -560,13 +561,10 @@ def dumpspecs(outstream=None, skip_volatiles=False):
             out += "\n/dev/console owner = " + str(dco)
 
     if not capable.OF_GRAPHICS:
-        if hasattr(capable, 'TKINTER_IMPORT_FAILED'):
-            out += "\ntkinter import failed."
-        else:
-            out += "\ntkinter use unattempted."
+        out += "\ntkinter use unattempted."
     else:
-        out += "\nTclVersion = " + str(capable.TKNTR.TclVersion)
-        out += "\nTkVersion = " + str(capable.TKNTR.TkVersion)
+        out += "\nTclVersion = " + str(tkinter.TclVersion)
+        out += "\nTkVersion = " + str(tkinter.TkVersion)
         out += "\nWUTIL_ON_MAC = " + str(WUTIL_ON_MAC)
         out += "\nWUTIL_ON_WIN = " + str(WUTIL_ON_WIN)
         out += "\nWUTIL_USING_X = " + str(WUTIL_USING_X)
@@ -639,8 +637,6 @@ if _skipDisplay:
             print("No graphics/display intended for this session.")
         else:
             print("No graphics/display possible for this session.")
-            if hasattr(capable, 'TKINTER_IMPORT_FAILED'):
-                print("tkinter import failed.")
 else:
     if _has_xutil or _has_aqutil:
         hasGraphics = focusController.hasGraphics

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -4,7 +4,7 @@ These are python stubs that are overloaded by a c version implementations.
 If the c versions do not exist, then these routines will do nothing
 
 """
-from __future__ import division, print_function
+
 
 import struct
 import sys

--- a/pyraf/wutil.py
+++ b/pyraf/wutil.py
@@ -10,14 +10,7 @@ import struct
 import sys
 import os
 import tkinter
-
-try:
-    import fcntl
-except ImportError:
-    if 0 == sys.platform.find('win') or sys.platform == 'cygwin':
-        fcntl = None  # not used on win (yet) but IS on darwin
-    else:
-        raise
+import fcntl
 
 
 # empty placeholder versions for X
@@ -246,7 +239,7 @@ def getTermWindowSize():
         if xsize <= 0:
             xsize = 80
         return ysize, xsize
-    except (IOError, AttributeError):
+    except IOError:
         return (24, 80)  # assume generic size
 
 
@@ -277,9 +270,6 @@ class FocusEntity:
         """return a window ID that can be used to find the top window
         of the window heirarchy."""
         raise NotImplementedError("class FocusEntity cannot be used directly")
-
-
-# XXXX find more portable scheme for handling absence of FCNTL
 
 
 class TerminalFocusEntity(FocusEntity):

--- a/pyraf/xutil.c
+++ b/pyraf/xutil.c
@@ -62,7 +62,7 @@ int MyXlibErrorHandler(Display *d, XErrorEvent *myerror) {
 
 int MyXlibIOErrorHandler(Display *d) {
   /* just put a constant string in the error message */
-  strncat(XErrorMsg,IOError,80);
+  strncat(XErrorMsg,IOError,79);
   longjmp(ErrorEnv, 1);
   /* Pointless, but it shuts up some compiler warning messages */
   return 0;
@@ -72,13 +72,12 @@ int MyXlibIOErrorHandler(Display *d) {
 void moveCursorTo(int win, int rx, int ry, int x, int y) {
   Window w;
   /*  Display *XOpenDisplay(char *); */
-  int s;
   if (d == NULL) {
     printf("could not open XWindow display\n");
     return;
   }
   w = (Window) win;
-  s = XGrabPointer(d,w,True,ButtonPressMask | EnterWindowMask,GrabModeSync,
+  XGrabPointer(d,w,True,ButtonPressMask | EnterWindowMask,GrabModeSync,
         GrabModeSync,None,None,CurrentTime);
   XWarpPointer(d,None,w,0,0,0,0,x,y);
   XUngrabPointer(d,CurrentTime);
@@ -420,7 +419,6 @@ static PyMethodDef xutil_funcs[] = {
   {NULL, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "xutil",
@@ -430,19 +428,6 @@ static struct PyModuleDef moduledef = {
         NULL, NULL, NULL, NULL,
 };
 PyObject* PyInit_xutil(void)
-#else
-void initxutil(void)
-#endif
 {
-   PyObject *m;
-#if PY_MAJOR_VERSION >= 3
-   m = PyModule_Create(&moduledef);
-#else
-   m = Py_InitModule("xutil", xutil_funcs);
-#endif
-
-/* in Py2.*: just return */
-#if PY_MAJOR_VERSION >= 3
-   return m;
-#endif
+   return PyModule_Create(&moduledef);
 }

--- a/scripts/pyraf
+++ b/scripts/pyraf
@@ -36,7 +36,6 @@ Long versions of options:
 
 # R. White, 2000 January 21
 
-from __future__ import division
 import sys, os, shutil
 
 # set search path to include directory above this script and current directory

--- a/scripts/pyraf
+++ b/scripts/pyraf
@@ -1,4 +1,4 @@
-#! python
+#! /usr/bin/env python3
 """
 Copyright (C) 2003 Association of Universities for Research in Astronomy
 (AURA)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ author = Rick White, Perry Greenfield, Chris Sontag
 url = https://iraf-community.github.io/pyraf.html
 description = Pythonic interface to IRAF that can be used in place of the existing IRAF CL
 long_description = file:README.rst
-requires-python = >=2.7
+requires-python = >=3.0
 classifiers =
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: BSD License
@@ -22,7 +22,6 @@ packages =
     pyraf/tests
 scripts = scripts/pyraf
 tests_require = pytest
-use_2to3 = True
 zip_safe = False
     
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages =
     pyraf
     pyraf/tests
 scripts = scripts/pyraf
-tests_require = pytest six
+tests_require = pytest
 use_2to3 = True
 zip_safe = False
     

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#! /usr/bin/env python3
 import sys
 import os
 

--- a/tools/cachecompare.py
+++ b/tools/cachecompare.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """cachecompare.py: Compare contents of new CL to old cache
 """
-from __future__ import division, print_function
+
 
 import os
 import pyraf

--- a/tools/cachecompare.py
+++ b/tools/cachecompare.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """cachecompare.py: Compare contents of new CL to old cache
 """
 

--- a/tools/cachesearch.py
+++ b/tools/cachesearch.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """cachesearch.py: Check all entries in CL cache for a particular string
 """
-from __future__ import division, print_function
+
 
 import os
 import re

--- a/tools/cachesearch.py
+++ b/tools/cachesearch.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """cachesearch.py: Check all entries in CL cache for a particular string
 """
 

--- a/tools/checkcompileall.py
+++ b/tools/checkcompileall.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """checkcompileall.py: Read the output from compileallcl and print just the errors
 """
-from __future__ import division, print_function
+
 import re
 import sys
 

--- a/tools/checkcompileall.py
+++ b/tools/checkcompileall.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """checkcompileall.py: Read the output from compileallcl and print just the errors
 """
 

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -143,7 +143,7 @@ They screw up subsequent loading of imred/digiphot tasks.
         pkg_list = iraf.getPkgList()
 
     t1 = time.time()
-    print("Finished package and task loading (%f seconds)" % (t1 - t0,))
+    print("Finished package and task loading ({:f} seconds)".format(t1 - t0))
     print("Compiled %d CL tasks -- %d failed" % (ntask_total, ntask_failed))
     sys.stdout.flush()
 

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """compileallcl.py: Load all the packages in IRAF and compile all
 the CL scripts
 

--- a/tools/compileallcl.py
+++ b/tools/compileallcl.py
@@ -8,7 +8,7 @@ is moved to ~/iraf/pyraf/clcache.old.
 Set the -r flag to recompile (default is to close the system cache
 and move the user cache so that everything gets compiled from scratch.)
 """
-from __future__ import division, print_function
+
 
 import os
 import sys

--- a/tools/fixcache.py
+++ b/tools/fixcache.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # rename clcache files
 
 

--- a/tools/fixcache.py
+++ b/tools/fixcache.py
@@ -11,7 +11,7 @@ def fixit(trylist, verbose=0):
         if os.path.exists(cachedir):
             break
     else:
-        raise OSError("clcache directory not found (tried %s)" % (trylist,))
+        raise OSError("clcache directory not found (tried {})".format(trylist))
     flist = os.listdir(cachedir)
     fcount = 0
     rcount = 0

--- a/tools/fixcache.py
+++ b/tools/fixcache.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # rename clcache files
 
-from __future__ import division, print_function
+
 import os
 
 

--- a/tools/loadall.py
+++ b/tools/loadall.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """loadall.py: Load all the main packages in IRAF with verbose turned on
 """
 

--- a/tools/loadall.py
+++ b/tools/loadall.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """loadall.py: Load all the main packages in IRAF with verbose turned on
 """
-from __future__ import division, print_function
+
 
 import sys
 import traceback


### PR DESCRIPTION
This PR removes all Python 2 specific code and strengthens the code for improved possibilities with Python 3.
Aside from this, the deprecation warnings for `numpy.fromstring()` and the `imp` module are fixed. 

There is a new branch [python2](https://github.com/iraf-community/pyraf/tree/python2) starting just before this PR.