### PR TITLE
Remove support of ancient ipython versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,10 @@ classifiers =
 setup_requires =
     setuptools
     setuptools_scm
+install_requires =
+    numpy
+    astropy
+    stsci.tools>=4.0.1
 packages =
     pyraf
     pyraf/tests

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,9 @@
 #! /usr/bin/env python3
-import sys
 import os
 
 from setuptools import setup, Extension
 
-IPYTHON_VERSION = ''
-if sys.hexversion < 0x030000f0:
-    IPYTHON_VERSION = '<6.0'
-
-setup(install_requires=[
-          'numpy', 'astropy', 'stsci.tools',
-          'ipython{}'.format(IPYTHON_VERSION)
-      ],
-      ext_modules=[Extension('pyraf.sscanf', ['pyraf/sscanfmodule.c']),
+setup(ext_modules=[Extension('pyraf.sscanf', ['pyraf/sscanfmodule.c']),
                    Extension('pyraf.xutil', ['pyraf/xutil.c'],
                              libraries=['X11'])],
       use_scm_version={'write_to': os.path.join('pyraf', 'version.py')},


### PR DESCRIPTION
These versions are not used at Python 3 anyway, so we can remove the old code.