### PR TITLE
Don't install xutil on MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,19 @@
 #! /usr/bin/env python3
 import os
+import platform
 
 from setuptools import setup, Extension
 
-setup(ext_modules=[Extension('pyraf.sscanf', ['pyraf/sscanfmodule.c']),
-                   Extension('pyraf.xutil', ['pyraf/xutil.c'],
-                             libraries=['X11'])],
-      use_scm_version={'write_to': os.path.join('pyraf', 'version.py')},
-      )
+modules = [Extension('pyraf.sscanf', ['pyraf/sscanfmodule.c'])]
+
+# On a Mac, xutil is not required since the graphics is done directly with Aqua.
+# If one still wants to include it, the parameters
+#     library_dirs="/usr/X11/libs"
+#     include_dirs="/usr/X11/include"
+# need to be added to the Extension
+if platform.system() not in ('Darwin', 'Windows'):
+    modules.append(Extension('pyraf.xutil', ['pyraf/xutil.c'],
+                             libraries=['X11']))
+
+setup(ext_modules=modules,
+      use_scm_version={'write_to': os.path.join('pyraf', 'version.py')})


### PR DESCRIPTION
On MacOS, the graphics works without X11; therefore the `xutil` module is not required there (instead `aqutil` is used). While the build *could* work there, it requires the installation of XQuartz (or similar), which is quite a heavy dependency.

To enable a simple installation on Macs, we therefore disable the build of the `xutil` extension.