### PR TITLE
Improve check for the existence of a GUI

### DIFF
--- a/pyraf/tests/test_plot.py
+++ b/pyraf/tests/test_plot.py
@@ -7,7 +7,12 @@ from stsci.tools import capable
 if HAS_IRAF:
     from pyraf import iraf
 
-no_graphics = 'DISPLAY' not in os.environ
+no_graphics = False
+try:
+    import tkinter
+    tkinter.Tk().destroy()
+except Exception:
+    no_graphics = True
 
 markers = [None, 'point', 'box', 'plus', 'cross', 'circle']
 graphics = ['tkplot', 'matplotlib']


### PR DESCRIPTION
Currently, we check for the existence of the DISPLAY variable, which not really works f.e. on a Mac. This is now improved by trying a simple Tk init and destroy. See also [this StackOverflow discussion](https://stackoverflow.com/questions/69043362/how-do-i-find-out-in-python-whether-a-gui-is-available).