### PR TITLE
Remove numpy.int

### DIFF
--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -424,7 +424,7 @@ class GkiBuffer:
                     break
                 self.lastTranslate = ip
                 self.lastOpcode = opcode
-                arg = buffer[ip + 3:ip + arglen].astype(numpy.int)
+                arg = buffer[ip + 3:ip + arglen].astype(int)
                 ip = ip + arglen
                 if ((opcode < 0) or (opcode > GKI_MAX_OP_CODE) or
                     (opcode in GKI_ILLEGAL_LIST)):


### PR DESCRIPTION
This is [deprecated in numpy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) and shall be replaced with the standard int.