### PR TITLE
Consequently use relative imports within the package (and more...)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-# Spacetelescope Open Source Code of Conduct
+# Code of Conduct
 
-We expect all "spacetelescope" organization projects to adopt a code of conduct that ensures a productive, respectful environment for all open source contributors and participants. We are committed to providing a strong and enforced code of conduct and expect everyone in our community to follow these guidelines when interacting with others in all forums. Our goal is to keep ours a positive, inclusive, successful, and growing community. The community of participants in open source Astronomy projects is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth. 
+We are committed to providing a strong and enforced code of conduct and expect everyone in our community to follow these guidelines when interacting with others in all forums. Our goal is to keep ours a positive, inclusive, successful, and growing community. The community of participants in open source Astronomy projects is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth. 
 
 
 As members of the community,
@@ -15,7 +15,7 @@ As members of the community,
 
 - We pledge to be conscientious of the perceptions of the wider community and to respond to criticism respectfully. We will strive to model behaviors that encourage productive debate and disagreement, both within our community and where we are criticized. We will treat those outside our community with the same respect as people within our community.
 
-- We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct. We will take action when members of our community violate this code such as such as contacting conduct@stsci.edu (all emails sent to this address will be treated with the strictest confidence) or talking privately with the person.
+- We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct. We will take action when members of our community violate this code.
 
 This code of conduct applies to all community situations online and offline, including mailing lists, forums, social media, conferences, meetings, associated social events, and one-to-one interactions.
 

--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -1017,8 +1017,8 @@ def _getCLVarType(name):
     global _CLVarDict
     try:
         if not _CLVarDict:
-            import pyraf.iraf
-            d = pyraf.iraf.cl.getParDict()
+            from . import iraf
+            d = iraf.cl.getParDict()
             # construct type dictionary for all variables
             # don't use minimum matching -- require exact match
             for pname, pobj in d.items():

--- a/pyraf/cllinecache.py
+++ b/pyraf/cllinecache.py
@@ -27,7 +27,7 @@ def checkcache(filename=None, orig_checkcache=linecache.checkcache):
         else:
             return
 
-    import pyraf.iraf  # used below
+    from . import iraf  # used below
 
     for filename in filenames:
         #    for filename in cache.keys():
@@ -41,7 +41,7 @@ def checkcache(filename=None, orig_checkcache=linecache.checkcache):
             else:
                 size, mtime, lines, taskname = entry
                 try:
-                    taskobj = pyraf.iraf.getTask(taskname)
+                    taskobj = iraf.getTask(taskname)
                     fullname = taskobj.getFullpath()
                     stat = os.stat(fullname)
                     newsize = stat[ST_SIZE]

--- a/pyraf/generic.py
+++ b/pyraf/generic.py
@@ -82,8 +82,7 @@ class GenericScanner:
         return '|'.join(rv)
 
     def error(self, s, pos):
-        print("Lexical error at position {}".format(pos))
-        raise SystemExit()
+        raise SyntaxError("Lexical error at position {}".format(pos))
 
     def tokenize(self, s):
         pos = 0
@@ -272,10 +271,7 @@ class GenericParser:
         return None
 
     def error(self, token, value=None):
-        print("Syntax error at or near `{}' token".format(token))
-        if value is not None:
-            print(str(value))
-        raise SystemExit()
+        raise SyntaxError("Syntax error at or near `{}' token: {}".format(token, value))
 
     def parse(self, tokens):
         tree = {}

--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -48,9 +48,7 @@ from . import irafgwcs
 from . import fontdata
 from .textattrib import (CHARPATH_RIGHT, JUSTIFIED_NORMAL, FONT_ROMAN,
                         FQUALITY_NORMAL)
-
-# use this form since the iraf import is circular
-import pyraf.iraf
+from . import iraf
 
 nIrafColors = 16
 
@@ -512,8 +510,7 @@ class GkiKernel:
         # set this without knowing what you are doing - it breaks some commonly
         # used command-line redirection within PyRAF. (thus default = False)
         if self.gkiPreferTtyIpc is None:
-            self.gkiPreferTtyIpc = pyraf.iraf.envget('gkiprefertty',
-                                                     '') == 'yes'
+            self.gkiPreferTtyIpc = iraf.envget('gkiprefertty','') == 'yes'
         return self.gkiPreferTtyIpc
 
     def createFunctionTables(self):
@@ -1014,14 +1011,14 @@ class GkiController(GkiProxy):
         """Starting with stdgraph, drill until a device is found in
         the graphcap or isn't"""
         if not device:
-            device = pyraf.iraf.envget("stdgraph", "")
+            device = iraf.envget("stdgraph", "")
         graphcap = getGraphcap()
         # protect against circular definitions
         devstr = device
         tried = {devstr: None}
         while devstr not in graphcap:
             pdevstr = devstr
-            devstr = pyraf.iraf.envget(pdevstr, "")
+            devstr = iraf.envget(pdevstr, "")
             if not devstr:
                 raise IrafError(
                     "No entry found for specified stdgraph device `{}'"
@@ -1236,8 +1233,7 @@ graphcapDict = {}
 def getGraphcap(filename=None):
     """Get graphcap file from filename (or cached version if possible)"""
     if filename is None:
-        filename = pyraf.iraf.osfn(
-            pyraf.iraf.envget('graphcap', 'dev$graphcap'))
+        filename = iraf.osfn(iraf.envget('graphcap', 'dev$graphcap'))
     if filename not in graphcapDict:
         graphcapDict[filename] = graphcap.GraphCap(filename)
     return graphcapDict[filename]
@@ -1260,7 +1256,7 @@ def printPlot(window=None):
     gkibuff = window.gkibuffer.get()
     if len(gkibuff):
         graphcap = getGraphcap()
-        stdplot = pyraf.iraf.envget('stdplot', '')
+        stdplot = iraf.envget('stdplot', '')
         if not stdplot:
             msg = "No hardcopy device defined in stdplot"
         elif stdplot not in graphcap:

--- a/pyraf/ipython_api.py
+++ b/pyraf/ipython_api.py
@@ -25,8 +25,8 @@ __license__ = release.license
 # (bypassing the __init__ mechanism.)
 
 import sys
-from pyraf import iraf, __version__
-from pyraf.irafpar import makeIrafPar
+from . import iraf, __version__
+from .irafpar import makeIrafPar
 from stsci.tools.irafglobals import yes, no, INDEF, EOF
 
 _locals = globals()
@@ -40,7 +40,7 @@ if '-nobanner' not in sys.argv and '--no-banner' not in sys.argv:
 # Keep the command-line object in namespace too for access to history
 
 # --------------------------------------------------------------------------
-from pyraf.irafcompleter import IrafCompleter
+from .irafcompleter import IrafCompleter
 
 
 class IPythonIrafCompleter(IrafCompleter):

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -8,9 +8,7 @@ from stsci.tools.irafglobals import Verbose
 from . import pyrafglobals
 from . import iraftask
 from . import irafexecute
-
-# this is better than what 2to3 does, since the iraf import is circular
-import pyraf.iraf
+from . import iraf
 
 executionMonitor = None
 
@@ -122,7 +120,7 @@ def _ecl_parent_task():
     while f and not _ecl_runframe(f):
         f = f.f_back
     if not f:
-        return pyraf.iraf.cl
+        return iraf.cl
     return f.f_locals["self"]
 
 
@@ -178,7 +176,7 @@ class EclBase:
         specialKW = self._specialKW(kw)
 
         # Special Stdout, Stdin, Stderr keywords are used to redirect IO
-        redirKW, closeFHList = pyraf.iraf.redirProcess(kw)
+        redirKW, closeFHList = iraf.redirProcess(kw)
 
         # set parameters
         kw['_setMode'] = 1
@@ -227,7 +225,7 @@ class EclBase:
 
     def _run(self, redirKW, specialKW):
         # OVERRIDE IrafTask._run for primitive (SPP, C, etc.) tasks to avoid exception trap.
-        irafexecute.IrafExecute(self, pyraf.iraf.getVarDict(), **redirKW)
+        irafexecute.IrafExecute(self, iraf.getVarDict(), **redirKW)
 
     def _ecl_push_err(self):
         """Method call emitted in compiled CL code to start an iferr
@@ -251,7 +249,7 @@ class EclBase:
         """IrafTask version of handle error:  register error with calling task but continue."""
         self._ecl_record_error(e)
         if erract.flpr:
-            pyraf.iraf.flpr(self)
+            iraf.flpr(self)
         parent = _ecl_parent_task()
         parent._ecl_record_error(e)
         self._ecl_trace(parent._ecl_err_msg(e))
@@ -332,10 +330,7 @@ class EclBase:
                     self.DOLLARerr_dzvalue)
                 return self.DOLLARerr_dzvalue
             else:
-                pyraf.iraf.error(1,
-                                 "divide by zero",
-                                 self._name,
-                                 suppress=False)
+                iraf.error(1, "divide by zero", self._name, suppress=False)
         return a / b
 
     def _ecl_safe_modulo(self, a, b):
@@ -348,10 +343,7 @@ class EclBase:
                     self.DOLLARerr_dzvalue)
                 return self.DOLLARerr_dzvalue
             else:
-                pyraf.iraf.error(1,
-                                 "modulo by zero",
-                                 self._name,
-                                 suppress=False)
+                iraf.error(1, "modulo by zero", self._name, suppress=False)
         return a % b
 
 

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -17,9 +17,7 @@ from . import wutil
 from . import gki
 from . import irafukey
 from . import irafgwcs
-
-# use this form since the iraf import is circular
-import pyraf.iraf
+from . import iraf
 
 # test_probe is a flag that a testing system can use to tell pyraf
 # (when used as a library, e.g. in stsci_regtest) to print various
@@ -27,8 +25,8 @@ import pyraf.iraf
 # This is different from verbose, because it is more selective.
 #
 # There is no interface to activate this feature.  Use:
-#   import pyraf.irafexecute
-#   pyraf.irafexecute.test_probe = True
+#   from . import irafexecute
+#   irafexecute.test_probe = True
 test_probe = False
 
 # stdgraph = None
@@ -70,7 +68,7 @@ def _getExecutable(arg):
     elif isinstance(arg, str):
         if os.path.exists(arg):
             return arg
-        task = pyraf.iraf.getTask(arg, found=1)
+        task = iraf.getTask(arg, found=1)
         if task is not None:
             return task.getFullpath()
     raise IrafProcessError("Cannot find task or executable {}".format(arg))
@@ -231,13 +229,13 @@ class _ProcessCache:
         if self._plimit <= len(self._locked):
             return
         for taskname in args:
-            task = pyraf.iraf.getTask(taskname, found=1)
+            task = iraf.getTask(taskname, found=1)
             if task is None:
                 print("No such task `{}'".format(taskname))
             elif task.__class__.__name__ == "IrafTask":
                 # cache only executable tasks (not CL tasks, etc.)
                 executable = task.getFullpath()
-                process = self.get(task, pyraf.iraf.getVarDict())
+                process = self.get(task, iraf.getVarDict())
                 self.add(process)
                 if executable in self._data:
                     self._locked[executable] = 1
@@ -288,7 +286,7 @@ class _ProcessCache:
         """
         if args:
             for taskname in args:
-                task = pyraf.iraf.getTask(taskname, found=1)
+                task = iraf.getTask(taskname, found=1)
                 if task is not None:
                     self.terminate(task)
         else:
@@ -972,10 +970,10 @@ class IrafProcess:
             if not (cmd.find(IPCOUT) >= 0):
                 # normal case -- execute the CL script code
                 # redirect I/O (but don't use graphics status line)
-                pyraf.iraf.clExecute(cmd,
-                                     Stdout=self.default_stdout,
-                                     Stdin=self.default_stdin,
-                                     Stderr=self.default_stderr)
+                iraf.clExecute(cmd,
+                               Stdout=self.default_stdout,
+                               Stdin=self.default_stdin,
+                               Stderr=self.default_stderr)
             else:
                 #
                 # Bizzaro protocol -- redirection to file with special
@@ -995,10 +993,10 @@ class IrafProcess:
                 # strip the redirection off and capture output of command
                 buffer = io.StringIO()
                 # redirect other I/O (but don't use graphics status line)
-                pyraf.iraf.clExecute(cmd[:ll] + "\n",
-                                     Stdout=buffer,
-                                     Stdin=self.default_stdin,
-                                     Stderr=self.default_stderr)
+                iraf.clExecute(cmd[:ll] + "\n",
+                               Stdout=buffer,
+                               Stdin=self.default_stdin,
+                               Stderr=self.default_stderr)
                 # send it off to the task with special flag line at end
                 buffer.write(IPCDONEMSG)
                 self.writeString(buffer.getvalue())
@@ -1016,16 +1014,16 @@ class IrafProcess:
             self.msg = self.msg[mcmd.end():]
         elif mcmd.group('curpack'):
             # current package request
-            self.writeString(pyraf.iraf.curpack() + '\n')
+            self.writeString(iraf.curpack() + '\n')
             self.msg = self.msg[mcmd.end():]
         elif mcmd.group('sysescape'):
             # OS escape
             tmsg = mcmd.group('sys_cmd')
             # use my version of system command so redirection works
-            sysstatus = pyraf.iraf.clOscmd(tmsg,
-                                           Stdin=self.stdin,
-                                           Stdout=self.stdout,
-                                           Stderr=self.stderr)
+            sysstatus = iraf.clOscmd(tmsg,
+                                     Stdin=self.stdin,
+                                     Stdout=self.stdout,
+                                     Stderr=self.stderr)
             self.writeString(str(sysstatus) + "\n")
             self.msg = self.msg[mcmd.end():]
             # self.stdout.write(self.msg + "\n")

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -165,7 +165,7 @@ def Init(doprint=1, hush=0, savefile=None):
                         _os.environ[key] = value
                 iraf = _os.environ['iraf']
             except OSError:
-                raise SystemExit("""
+                raise OSError("""
 Your "iraf" environment variable is not defined and could not be
 determined from /usr/local/bin/cl.  This is are needed to find IRAF
 tasks.  Before starting pyraf, define ot by doing (for example):

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -1764,8 +1764,8 @@ def imaccess(filename):
     # Any error output is taken to mean failure.
     sout = _io.StringIO()
     serr = _io.StringIO()
-    import pyraf.iraf
-    pyraf.iraf.imhead(filename, Stdout=sout, Stderr=serr)
+    from . import iraf
+    iraf.imhead(filename, Stdout=sout, Stderr=serr)
     errstr = serr.getvalue().lower()
     outstr = sout.getvalue().lower()
     if errstr:
@@ -1801,8 +1801,8 @@ def deftask(taskname):
     if taskname == INDEF:
         return INDEF
     try:
-        import pyraf.iraf
-        getattr(pyraf.iraf, taskname)
+        from . import iraf
+        getattr(iraf, taskname)
         return 1
     except AttributeError:
         # treat all errors (including ambiguous task names) as a missing task
@@ -1911,8 +1911,8 @@ def fscan(theLocals, line, *namelist, **kw):
     # expression, or an IRAF list parameter)
     global _nscan
     try:
-        import pyraf.iraf
-        line = eval(line, {'iraf': pyraf.iraf}, theLocals)
+        from . import iraf
+        line = eval(line, {'iraf': iraf}, theLocals)
     except EOFError:
         _weirdEOF(theLocals, namelist)
         _nscan = 0
@@ -1990,8 +1990,8 @@ def fscanf(theLocals, line, format, *namelist, **kw):
     # expression, or an IRAF list parameter)
     global _nscan
     try:
-        import pyraf.iraf
-        line = eval(line, {'iraf': pyraf.iraf}, theLocals)
+        from . import iraf
+        line = eval(line, {'iraf': iraf}, theLocals)
         # format also needs to be evaluated
         format = eval(format, theLocals)
     except EOFError:

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -179,20 +179,6 @@ Also be sure to run the "mkiraf" command to create a logion.cl
 """)
 
         arch = _os.environ.get('IRAFARCH')
-        # stacksize problem on linux
-
-        if arch == 'redhat' or \
-                arch == 'linux' or \
-                arch == 'linuxppc' or \
-                arch == 'suse':
-            import resource
-            if resource.getrlimit(resource.RLIMIT_STACK)[1] == -1:
-                resource.setrlimit(resource.RLIMIT_STACK, (-1, -1))
-            else:
-                pass
-        else:
-            pass
-
         # ensure trailing slash is present
         iraf = _os.path.join(iraf, '')
         host = _os.environ.get('host', _os.path.join(iraf, 'unix', ''))

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -41,26 +41,15 @@ import re
 import os
 import sys
 import types
-try:
-    import io
-except ImportError:  # only for Python 2.5
-    io = None
+import io
 
 from stsci.tools import minmatch, irafutils
 from stsci.tools.irafglobals import IrafError, IrafTask, IrafPkg
 from . import describe
+from . import iraf
 
-# use this form since the iraf import is circular
-import pyraf.iraf
-
-# print info on numpy arrays if numpy is available
-
-try:
-    import numpy
-    _numpyArrayType = numpy.ndarray
-except ImportError:
-    # no numpy available, so we won't encounter arrays
-    _numpyArrayType = None
+import numpy
+_numpyArrayType = numpy.ndarray
 
 _MODULE = 0
 _FUNCTION = 1
@@ -151,7 +140,7 @@ Other keywords are passed on to the IRAF help task if it is called.
 """
 
     # handle I/O redirection keywords
-    redirKW, closeFHList = pyraf.iraf.redirProcess(kw)
+    redirKW, closeFHList = iraf.redirProcess(kw)
     if '_save' in kw:
         del kw['_save']
 
@@ -169,7 +158,7 @@ Other keywords are passed on to the IRAF help task if it is called.
         except KeyError as e:
             raise e.__class__("Error in keyword " + key + "\n" + str(e))
 
-    resetList = pyraf.iraf.redirApply(redirKW)
+    resetList = iraf.redirApply(redirKW)
 
     # try block for I/O redirection
 
@@ -177,7 +166,7 @@ Other keywords are passed on to the IRAF help task if it is called.
         _help(an_obj, variables, functions, modules, tasks, packages, hidden,
               padchars, regexp, html, irafkw)
     finally:
-        rv = pyraf.iraf.redirReset(resetList, closeFHList)
+        rv = iraf.redirReset(resetList, closeFHList)
     return rv
 
 
@@ -212,7 +201,7 @@ def _help(an_obj, variables, functions, modules, tasks, packages, hidden,
         # IRAF task names
         if re.match(r'[A-Za-z_][A-Za-z0-9_.]*$', an_obj) or \
             (re.match(r'[^\0]*$', an_obj) and
-             os.path.exists(pyraf.iraf.Expand(an_obj, noerror=1))):
+             os.path.exists(iraf.Expand(an_obj, noerror=1))):
             if _printIrafHelp(an_obj, html, irafkw):
                 return
 
@@ -438,11 +427,11 @@ def _irafHelp(taskname, irafkw):
         taskname = taskname.getName()
     else:
         # expand IRAF variables in case this is name of a help file
-        taskname = pyraf.iraf.Expand(taskname, noerror=1)
+        taskname = iraf.Expand(taskname, noerror=1)
     try:
         if 'page' not in irafkw:
             irafkw['page'] = 1
-        pyraf.iraf.system.help(taskname, **irafkw)
+        iraf.system.help(taskname, **irafkw)
         return 1
     except IrafError as e:
         print(str(e))

--- a/pyraf/irafimport.py
+++ b/pyraf/irafimport.py
@@ -62,7 +62,7 @@ def _irafImport(name, globals={}, locals={}, fromlist=[], level=-1):
 
     # e.g. "import pyraf.iraf" (return module is for pyraf, not iraf)
     if not fromlist and name == 'pyraf.iraf' and level == 0:
-        assert 'pyraf' in sys.modules, 'Unexpected import error - contact STScI'
+        assert 'pyraf' in sys.modules, 'Unexpected import error'
         if IMPORT_DEBUG:
             print("irafimport: pyraf.iraf case: n=" + name + ", fl=" +
                   str(fromlist) + ", l=" + str(level) +

--- a/pyraf/irafnames.py
+++ b/pyraf/irafnames.py
@@ -8,8 +8,8 @@ R. White, 1999 March 26
 
 import __main__
 from stsci.tools import irafglobals
-# this is better than what 2to3 does, since the iraf import is circular
-import pyraf.iraf
+
+from . import iraf
 
 
 def _addName(task, module):
@@ -50,7 +50,7 @@ class IrafNameStrategy:
 class IrafNameClean(IrafNameStrategy):
 
     def addTask(self, task):
-        _addName(task, pyraf.iraf)
+        _addName(task, iraf)
 
 
 # IrafNamePkg also adds packages to __main__ name space
@@ -68,7 +68,7 @@ class IrafNamePkg(IrafNameClean):
 class IrafNameTask(IrafNameClean):
 
     def addTask(self, task):
-        _addName(task, pyraf.iraf)
+        _addName(task, iraf)
         _addName(task, __main__)
 
 

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -16,10 +16,7 @@ from stsci.tools.basicpar import (warning, _StringMixin, IrafPar, IrafParS,
 # also import basicpar.IrafPar* class names for cached scripts
 from stsci.tools.basicpar import (IrafParB, IrafParI, IrafParR, IrafParAB,
                                   IrafParAI, IrafParAR, IrafParAS)
-
-if __name__.find('.') >= 0:  # not a unit test
-    # use this form since the iraf import is circular
-    import pyraf.iraf
+from . import iraf
 
 # -----------------------------------------------------
 # IRAF parameter factory
@@ -207,7 +204,7 @@ class IrafParPset(IrafParS):
         if len(f) > 1 and f[-1] == 'par':
             # must be a file name
             from .iraffunctions import IrafTaskFactory
-            irf_val = pyraf.iraf.Expand(self.value)
+            irf_val = iraf.Expand(self.value)
             return IrafTaskFactory(taskname=irf_val.split(".")[0],
                                    value=irf_val)
         else:
@@ -221,12 +218,12 @@ class IrafParPset(IrafParS):
                         '>') and self.name in self.value:
                     # don't lookup task for self.value, it is something like:
                     # "<IrafCLTask ccdproc (mscsrc$ccdproc.cl) Pkg: mscred Bin: mscbin$>"
-                    return pyraf.iraf.getTask(self.name)
+                    return iraf.getTask(self.name)
                     # this is only a safe assumption to make in a PSET
                 else:
-                    return pyraf.iraf.getTask(self.value)
+                    return iraf.getTask(self.value)
             else:
-                return pyraf.iraf.getTask(self.name)
+                return iraf.getTask(self.name)
 
 
 # -----------------------------------------------------
@@ -309,7 +306,7 @@ class IrafParL(_StringMixin, IrafPar):
             # non-null value means we're reading from a file
             try:
                 if not self.fh:
-                    self.fh = open(pyraf.iraf.Expand(self.value))
+                    self.fh = open(iraf.Expand(self.value))
                     if self.fh.isatty():
                         self.lines = None
                     else:
@@ -895,14 +892,14 @@ class IrafParList(taskpars.TaskPars):
         if isinstance(value, str) and value and value[0] == ")":
             # parameter indirection: ')task.param'
             try:
-                task = pyraf.iraf.getTask(self.__name)
+                task = iraf.getTask(self.__name)
                 value = task.getParam(value[1:], native=native, mode="h")
             except KeyError:
                 # if task is not known, use generic function to get param
-                value = pyraf.iraf.clParGet(value[1:],
-                                            native=native,
-                                            mode="h",
-                                            prompt=prompt)
+                value = iraf.clParGet(value[1:],
+                                      native=native,
+                                      mode="h",
+                                      prompt=prompt)
         return value
 
     def setParam(self, param, value, scope='', check=0, idxHint=None):
@@ -1104,7 +1101,7 @@ class IrafParList(taskpars.TaskPars):
         if not filename:
             raise ValueError("No filename specified to save parameters")
         # but not if user turned off parameter writes
-        writepars = int(pyraf.iraf.envget("writepars", 1))
+        writepars = int(iraf.envget("writepars", 1))
         if writepars < 1:
             msg = "No parameters written to disk."
             print(msg)
@@ -1113,7 +1110,7 @@ class IrafParList(taskpars.TaskPars):
         if hasattr(filename, 'write'):
             fh = filename
         else:
-            absFileName = pyraf.iraf.Expand(filename)
+            absFileName = iraf.Expand(filename)
             absDir = os.path.dirname(absFileName)
             if len(absDir) and not os.path.isdir(absDir):
                 os.makedirs(absDir)
@@ -1293,7 +1290,7 @@ def _updateSpecialParFileDict(dirToCheck=None, strict=False):
     # usual places (which calls us recursively).
     if dirToCheck is None:
         # Check the auxilliary par dir
-        uparmAux = pyraf.iraf.envget("uparm_aux", "")
+        uparmAux = iraf.envget("uparm_aux", "")
         if 'UPARM_AUX' in os.environ:
             uparmAux = os.environ['UPARM_AUX']
         if len(uparmAux) > 0:

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -6,17 +6,13 @@ import pytest
 from .utils import diff_outputs, HAS_IRAF
 
 if HAS_IRAF:
-    from pyraf import iraf
-
-    try:
-        from pyraf import sscanf  # C-extension
-    except ImportError:
-        sscanf = None
+    from .. import iraf
+    from .. import sscanf
 
     # Turn off the test probe output since it comes with
     # path info that is ever changing
-    import pyraf
-    pyraf.irafexecute.test_probe = False
+    from .. import irafexecute
+    irafexecute.test_probe = False
 
 
 @pytest.mark.skipif(not HAS_IRAF, reason='Need IRAF to run')
@@ -63,9 +59,6 @@ def test_sscanf(tmpdir):
     """A basic unit test that sscanf was built/imported correctly and
     can run.
     """
-    assert sscanf is not None, \
-        'Error importing sscanf during iraffunctions init'
-
     # aliveness
     l = sscanf.sscanf("seven 6 4.0 -7", "%s %d %g %d")
     assert l == ['seven', 6, 4.0, -7]

--- a/pyraf/tests/test_core_nongraphics.py
+++ b/pyraf/tests/test_core_nongraphics.py
@@ -9,8 +9,8 @@ import pytest
 from .utils import HAS_IRAF
 
 if HAS_IRAF:
-    from pyraf.irafpar import IrafParList
-    from pyraf.subproc import Subprocess
+    from ..irafpar import IrafParList
+    from ..subproc import Subprocess
     from stsci.tools import basicpar
     from stsci.tools.basicpar import parFactory
 

--- a/pyraf/tests/test_plot.py
+++ b/pyraf/tests/test_plot.py
@@ -71,7 +71,7 @@ def test_plot_graph(marker, graphics):
 @pytest.mark.parametrize('graphics', graphics)
 def test_plot_contour(graphics):
     os.environ['PYRAFGRAPHICS'] = graphics
-    iraf.contour("dev$pix", Stdout='/dev/null')
+    iraf.contour("dev$pix", Stderr='/dev/null')
 
 
 @pytest.mark.skipif(not HAS_IRAF, reason='Need IRAF to run')
@@ -79,4 +79,4 @@ def test_plot_contour(graphics):
 @pytest.mark.parametrize('graphics', graphics)
 def test_plot_surface(graphics):
     os.environ['PYRAFGRAPHICS'] = graphics
-    iraf.surface("dev$pix", Stdout='/dev/null')
+    iraf.surface("dev$pix", Stderr='/dev/null')

--- a/pyraf/tests/test_tasks.py
+++ b/pyraf/tests/test_tasks.py
@@ -39,7 +39,7 @@ def test_load_cl_task(task):
 @pytest.mark.parametrize('task', ['user.date', 'softools.xc'])
 def test_exec_foreign_task(task):
     t = iraf.getTask(task)
-    t()
+    t(Stdout="/dev/null")
 
 
 @pytest.mark.skipif(not HAS_IRAF, reason='Need IRAF to run')


### PR DESCRIPTION
The main commit here changes all remaining internal pyraf imports into relative ones, despite of having them marked as "cyclic". This is not a real problem...
Also, remove the SystemExit() raises within the package -- they will unexpectedly end an interactive session on (some) errors.
Finally, the stacksize problem on LInux is fixed since a long time, so we can remove this as well.
Oh, and some more STScI references are going away.... (including the Code of Conduct, see #88)