### PR TITLE
Update setup.cfg and other metadata

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends iraf iraf-noao iraf-dev build-essential libx11-dev
           sudo apt-get install --no-install-recommends python3-dev python3-pip
-          pip3 install pytest ipython
+          pip3 install ipython
 
       - name: Setup dependencies, Mac
         if: startsWith(matrix.os, 'macos') && matrix.method == 'pip'
@@ -60,7 +60,6 @@ jobs:
           export PATH=${HOME}/.iraf/bin:${PATH}
           mkiraf -t=$TERM -n
           echo "PATH=$PATH" >> $GITHUB_ENV
-          pip3 install pytest
 
       - name: Build PyRAF locally
         if: matrix.method == 'native'
@@ -70,7 +69,7 @@ jobs:
       - name: Install PyRAF via pip
         if: matrix.method == 'pip'
         run: |
-          pip3 install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
+          pip3 install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=pyraf[test]
 
       - name: Run tests (locally built)
         if: matrix.method == 'native'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include MANIFEST.in
 recursive-include pyraf *
 recursive-include tools *.py
 global-exclude *.pyc *.o
+recursive-inclulde docs *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
-include setup.py MANIFEST MANIFEST.in
+include LICENSE.txt
+include README.rst
+include setup.py
+include setup.cfg
+include MANIFEST.in
 recursive-include pyraf *
-recursive-include docs pyraf_tutorial.pdf pyraf_tutorial.ps.gz pyraf_install_src.ps pyraf_install_src.pdf
 recursive-include tools *.py
+global-exclude *.pyc *.o

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -438,7 +438,7 @@ def _irafHelp(taskname, irafkw):
         return 0
 
 
-_HelpURL = "http://stsdas.stsci.edu/cgi-bin/gethelp.cgi?task="
+_HelpURL = "https://iraf.readthedocs.io"
 _Browser = "netscape"
 
 
@@ -448,6 +448,6 @@ def _htmlHelp(taskname):
 
     if isinstance(taskname, IrafTask):
         taskname = taskname.getName()
-    url = _HelpURL + taskname
+    url = f"{_HelpURL}/{taskname}.html"
 
     irafutils.launchBrowser(url, brow_bin=_Browser, subj=taskname)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,10 @@ classifiers =
 setup_requires = setuptools_scm
 install_requires =
     numpy
-    astropy
     stsci.tools>=4.0.1
 packages =
     pyraf
     pyraf/tests
-tests_require = pytest
 zip_safe = False
 python_requires = >=3.6
 
@@ -40,6 +38,9 @@ docs =
     sphinx
     numpydoc
     astropy-sphinx-theme
+test =
+    pytest
+    astropy
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,19 +4,26 @@ author = Rick White, Perry Greenfield, Chris Sontag
 url = https://iraf-community.github.io/pyraf.html
 description = Pythonic interface to IRAF that can be used in place of the existing IRAF CL
 long_description = file:README.rst
-requires-python = >=3.0
+long_description_content_type = text/x-rst
+keywords = astronomy, astrophysics, utility
+edit_on_github = True
+github_project = iraf-community/iraf
+platform = any
+license = BSD 3-Clause
+license_file = LICENSE.txt
 classifiers =
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: BSD License
 	Operating System :: OS Independent
-	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
 	Topic :: Scientific/Engineering :: Astronomy
-	Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-setup_requires =
-    setuptools
-    setuptools_scm
+setup_requires = setuptools_scm
 install_requires =
     numpy
     astropy
@@ -26,6 +33,7 @@ packages =
     pyraf/tests
 tests_require = pytest
 zip_safe = False
+python_requires = >=3.6
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
This includes

 * metadata
 * Python version

For the Python version: we depend on stsci.tools >= 4.0.1, which by itself has a minimal Python version 3.6. So we can set this as well.

Fixes: #88