### PR TITLE
Fix integer division with Python 3 in ecl mode

### DIFF
--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -330,7 +330,10 @@ class EclBase:
                 return self.DOLLARerr_dzvalue
             else:
                 iraf.error(1, "divide by zero", self._name, suppress=False)
-        return a / b
+        if isinstance(a, int) and isinstance(b, int):
+            return a // b
+        else:
+            return a / b
 
     def _ecl_safe_modulo(self, a, b):
         """_ecl_safe_modulus is used to wrap the modulus operator for ECL code and trap mod-by-zero errors."""

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -7,6 +7,7 @@ from .utils import diff_outputs, HAS_IRAF
 
 if HAS_IRAF:
     from .. import iraf
+    from .. import pyrafglobals
     from .. import sscanf
 
     # Turn off the test probe output since it comes with
@@ -16,7 +17,9 @@ if HAS_IRAF:
 
 
 @pytest.mark.skipif(not HAS_IRAF, reason='Need IRAF to run')
-def test_division(tmpdir):
+@pytest.mark.parametrize('use_ecl', [False, True])
+def test_division(use_ecl, tmpdir):
+    pyrafglobals.use_ecl = use_ecl
     outfile = str(tmpdir.join('output.txt'))
 
     # First show straight Python


### PR DESCRIPTION
There was a separate place for division in ECL mode (due to an extended error handling in this case). This place needed to be    extended to handle integer/integer division.
This chance is then taken to run some tests also in ecl mode.