### PR TITLE
Explicitly use the first cache for writing in clcache.py

### DIFF
--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -13,8 +13,8 @@ from . import pyrafglobals
 from . import sqliteshelve
 
 
-if 'CLCACHE_PATH' in os.environ:
-    clcache_path = os.environ['CLCACHE_PATH'].split(':')
+if 'PYRAF_CLCACHE_PATH' in os.environ:
+    clcache_path = os.environ['PYRAF_CLCACHE_PATH'].split(':')
     if 'disable' in clcache_path:
         clcache_path = []
 else:

--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -68,56 +68,37 @@ class _CodeCache:
     """
 
     def __init__(self, cacheFileList):
-        cacheList = []
-        flist = []
-        nwrite = 0
-        for file in cacheFileList:
-            db = self._cacheOpen(file)
-            if db is not None:
-                cacheList.append(db[0:2])
-                nwrite = nwrite + db[0]
-                flist.append(db[2])
-        self.clFileDict = _FileContentsCache()
-        self.cacheList = cacheList
-        self.cacheFileList = flist
-        self.nwrite = nwrite
-        # flag indicating preference for system cache
-        self.useSystem = False
-        if not cacheList:
-            self.warning("Warning: unable to open any CL script cache, "
-                         "performance may be slow")
-        elif nwrite == 0:
-            self.warning("Unable to open any CL script cache for writing")
-
-    def _cacheOpen(self, filename):
-        """Open shelve database in filename and check version
-
-        Returns tuple (writeflag, shelve-object, filename) on success or
-        None on failure.
-        This may modify the filename if necessary to open the correct version of
-        the cache.
-        """
-        # filenames to try, open flags to use
-        filelist = [(f'{filename}', "w")]
-        msg = []
-        for fname, flag in filelist:
-            # first try opening the cache read-write
+        self.writeCache = None
+        self.cacheList = []
+        self.cacheFileList = []
+        write_flag = 'w'
+        if cacheFileList:
             try:
-                fh = sqliteshelve.open(fname, flag)
-                writeflag = True
-            except OSError:
-                # initial open failed -- try opening the cache read-only
-                try:
-                    fh = sqliteshelve.open(fname, "r")
-                    writeflag = False
-                except OSError:
-                    # give up on this file and try the next one
-                    msg.append(f"Unable to open CL script cache {fname}")
-                    continue
-            return (writeflag, fh, fname)
-        # failed to open either cache
-        self.warning("\n".join(msg))
-        return None
+                fname = cacheFileList[0]
+                self.writeCache = sqliteshelve.open(fname, 'w')
+                self.cacheList.append(self.writeCache)
+                self.cacheFileList.append(fname)
+                cacheFileList = cacheFileList[1:]
+            except OSError as e:
+                self.warning("Unable to open CL script cache "
+                             f"{fname} for writing")
+
+        if self.writeCache is None:
+            self.warning("Using in-memory cache as primary CL script cache")
+            self.writeCache = dict()
+            self.cacheList.append(self.writeCache)
+            self.cacheFileList.append(':mem:')
+
+        for fname in cacheFileList:
+            try:
+                db = sqliteshelve.open(fname, 'r')
+                self.cacheList.append(db)
+                self.cacheFileList.append(fname)
+            except OSError as e:
+                self.warning("Unable to open CL script cache "
+                             f"{fname} for reading", 1)
+
+        self.clFileDict = _FileContentsCache()
 
     def warning(self, msg, level=0):
         """Print warning message to stderr, using verbose flag"""
@@ -127,27 +108,16 @@ class _CodeCache:
             sys.stderr.write(msg + "\n")
             sys.stderr.flush()
 
-    def writeSystem(self, value=True):
-        """Add scripts to system cache instead of user cache"""
-
-        if not value:
-            self.useSystem = False
-        elif self.cacheList:
-            writeflag, cache = self.cacheList[-1]
-            if writeflag:
-                self.useSystem = True
-            else:
-                self.warning("System CL script cache is not writable")
-        else:
-            self.warning("No CL script cache is active")
-
     def close(self):
         """Close all cache files"""
 
-        for writeflag, cache in self.cacheList:
-            cache.close()
-        self.cacheList = []
-        self.nwrite = 0
+        for cache in self.cacheList:
+            try:
+                cache.close()
+            except AttributeError:
+                pass
+        self.cacheList.clear()
+        self.writeCache = None
         # Note that this does not delete clFileDict since the
         # in-memory info for files already read is still OK
         # (Just in case there is some reason to close cache files
@@ -170,19 +140,8 @@ class _CodeCache:
 
     def add(self, index, pycode):
         """Add pycode to cache with key = index.  Ignores if index=None."""
-
-        if index is None or self.nwrite == 0:
-            return
-        if self.useSystem:
-            # system cache is last in list
-            cacheList = self.cacheList[:]
-            cacheList.reverse()
-        else:
-            cacheList = self.cacheList
-        for writeflag, cache in cacheList:
-            if writeflag:
-                cache[index] = pycode
-                return
+        if index is not None and self.writeCache is not None:
+            self.writeCache[index] = pycode
 
     def get(self, filename, mode="proc", source=None):
         """Get pycode from cache for this file.
@@ -199,14 +158,14 @@ class _CodeCache:
         if index is None:
             return None, None
 
-        for i in range(len(self.cacheList)):
-            writeflag, cache = self.cacheList[i]
+        for cache in self.cacheList:
             if index in cache:
                 pycode = cache[index]
                 pycode.index = index
                 pycode.setFilename(filename)
                 return index, pycode
-        return index, None
+        else:
+            return index, None
 
     def remove(self, filename):
         """Remove pycode from cache for this file or IrafTask object.
@@ -225,24 +184,16 @@ class _CodeCache:
                 raise TypeError(
                     "Filename parameter must be a string or IrafCLTask")
         index = self.getIndex(filename)
-        # system cache is last in list
-        irange = list(range(len(self.cacheList)))
-        if self.useSystem:
-            irange.reverse()
-        nremoved = 0
-        for i in irange:
-            writeflag, cache = self.cacheList[i]
-            if index in cache:
-                if writeflag:
-                    del cache[index]
-                    self.warning(f"Removed {filename} from CL script cache "
-                                 f"{self.cacheFileList[i]}", 2)
-                    nremoved = nremoved + 1
-                else:
-                    self.warning(f"Cannot remove {filename} from read-only "
-                                 f"CL script cache {self.cacheFileList[i]}")
-        if nremoved == 0:
-            self.warning(f"Did not find {filename} in CL script cache", 2)
+        if self.writeCache:
+            if index in self.writeCache:
+                del self.writeCache[index]
+                self.warning(f"Removed {filename} from CL script cache "
+                             f"{self.cacheFileList[0]}", 2)
+            else:
+                self.warning(f"Did not find {filename} in CL script cache", 2)
+        else:
+            self.warning(f"Cannot remove {filename} from read-only "
+                         f"CL script cache {self.cacheFileList[0]}")
 
 
 codeCache = _CodeCache([os.path.join(d, 'clcache') for d in clcache_path])

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -3337,8 +3337,8 @@ _clExecuteCount = 0
 def clExecute(s,
               locals=None,
               mode="proc",
-              local_vars_dict={},
-              local_vars_list=[],
+              local_vars_dict=None,
+              local_vars_list=None,
               verbose=0,
               **kw):
     """Execute a single cl statement"""

--- a/pyraf/sqliteshelve.py
+++ b/pyraf/sqliteshelve.py
@@ -59,6 +59,8 @@ class Shelf:
                            " where type = 'table' and tbl_name = 'shelf'")
             rows = cursor.fetchall()
             if len(rows) == 0:
+                if self.readonly:
+                    raise OSError(f'No table "shelf" in {fname}')
                 cursor.execute("create table shelf"
                                " (id integer primary key autoincrement,"
                                " key_str text,"


### PR DESCRIPTION
This simplifies the code and makes the behavior more predictable, as it is clear that only the first entry will be used for writing.
    
Also this gives the opportunity to have an internal dictionary as a fallback cache. This speeds up the computation a bit. Also the cache tables for code with and without ECL are combined into one. This simplifies the internal handling (as the check for the version at the opening is not needed anymore) and the user does not have to deal with different files for use with and without ECL.

The environment variable that can change the default cache paths is `PYRAF_CLCACHE_PATH`. Setting it do `disable` will disable the cache, and rely on the internal fallback.

Some bugs found in this process are also fixed.


