### PR TITLE
Various small bugfixes

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -60,7 +60,6 @@ jobs:
           export PATH=${HOME}/.iraf/bin:${PATH}
           mkiraf -t=$TERM -n
           echo "PATH=$PATH" >> $GITHUB_ENV
-          echo "host=${iraf}unix/" >> $GITHUB_ENV
           pip3 install pytest
 
       - name: Build PyRAF locally
@@ -81,7 +80,6 @@ jobs:
       - name: Run tests (installed package)
         if: matrix.method == 'pip'
         run: |
-          if [ $RUNNER_OS = 'macOS' ] ; then export IRAFARCH=macintel ; fi
           python3 -m pytest -s --pyargs pyraf
 
       - name: "Upload coverage to Codecov"

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ PyRAF is licensed under a 3-clause BSD style license - see the
 Documentation
 -------------
 
-* `The PyRAF Tutorial <pyraf.readthedocs.io>`_
+* `The PyRAF Tutorial <https://pyraf.readthedocs.io>`_
 
 
 .. |CI Status| image:: https://github.com/iraf-community/pyraf/actions/workflows/citest.yml/badge.svg

--- a/pyraf/__main__.py
+++ b/pyraf/__main__.py
@@ -39,7 +39,8 @@ def main():
     parser.add_argument('-m','--commandwrapper',
                         help='Run command line wrapper to provide extra'
                              ' capabilities (default)',
-                        action='store_true', dest='commandwrapper')
+                        action='store_true', dest='commandwrapper',
+                        default=True)
     parser.add_argument('-i','--no-commandwrapper',
                         help='No command line wrapper, just run standard'
                              ' interactive Python shell',

--- a/pyraf/__main__.py
+++ b/pyraf/__main__.py
@@ -5,7 +5,9 @@ import shutil
 import argparse
 
 from stsci.tools import capable
+from stsci.tools.irafglobals import yes, no, INDEF, EOF
 from . import iraf
+from .irafpar import makeIrafPar
 
 try:
     import IPython

--- a/pyraf/epar.py
+++ b/pyraf/epar.py
@@ -6,7 +6,7 @@ M.D. De La Pena, 2000 February 04
 
 from stsci.tools import capable
 if capable.OF_GRAPHICS:
-    from Tkinter.tkMessageBox import askokcancel, showwarning, showerror
+    from tkinter.messagebox import askokcancel, showwarning, showerror
     import os
     import io
     from stsci.tools import listdlg, eparoption, editpar, irafutils

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -179,6 +179,17 @@ Also be sure to run the "mkiraf" command to create a logion.cl
 """)
 
         arch = _os.environ.get('IRAFARCH', '')
+
+        # stacksize problem on linux
+        # https://iraf-community.github.io/iraf-v216/issues/61
+        if arch in ('redhat', 'linux', 'linuxppc', 'suse'):
+            import resource
+            try:
+                hardlimit = resource.getrlimit(resource.RLIMIT_STACK)[1]
+                resource.setrlimit(resource.RLIMIT_STACK, (hardlimit, hardlimit))
+            except (ValueError, OSError):
+                pass  # Ignore the error and hope the best...
+
         # ensure trailing slash is present
         iraf = _os.path.join(iraf, '')
         host = _os.environ.get('host', _os.path.join(iraf, 'unix', ''))


### PR DESCRIPTION
This PR collects various small bug fixes found during testing.

* another Tkinter leftover, this was forgotten during the py2->py3 transition, and is required for the graphical parameter editor.
* restore default (commandwrapper) mode for pyraf script,
* add necessary imports in `__main__.py`
* Re-introduce stack limit unsetting on old Linux systems.

Fixes: #99 