### PR TITLE
Replace removed mkmanpage package test with mkhelpdb test

### DIFF
--- a/pyraf/tests/test_tasks.py
+++ b/pyraf/tests/test_tasks.py
@@ -27,7 +27,7 @@ def test_load_package(pkg):
     'lists.average', 'lists.raverage', 'system.allocate',
     'system.deallocate', 'system.devstatus', 'system.diskspace',
     'system.devices', 'system.references', 'system.phelp',
-    'tv.bpmedit', 'softools.mkmanpage', 'color.rgbdisplay',
+    'tv.bpmedit', 'softools.mkhelpdb', 'color.rgbdisplay',
     'astutil.astradius',
 ])
 def test_load_cl_task(task):


### PR DESCRIPTION
IRAF 2.17 remove the "mkmanpage" command, so we can't use it as a command to test PyRAF.