### PR TITLE
Resolve CL syntax error when assigning value to array element on Py 3 (#115)

### DIFF
--- a/pyraf/clscan.py
+++ b/pyraf/clscan.py
@@ -268,6 +268,12 @@ class _StartScanner(_LaxScanner, _StrictStartScanner):
 
 class _CommandScanner_1(_BasicScanner_1):
 
+    def t_lbracket(self, s, m, parent):
+        r'\['
+        parent.addToken(type=s)
+        # push to compute mode
+        parent.current.append(_COMPUTE_MODE)
+
     def t_string(self, s, m, parent):
         r'[^ \t\n()\\;{}&]+(\\(.|\n)[^ \t\n()\\;{}&]*)*'
         # What other characters are forbidden in unquoted strings?
@@ -283,12 +289,6 @@ class _CommandScanner_1(_BasicScanner_1):
         s = irafutils.removeEscapes(s).replace('\\', '\\\\')
         parent.addToken(type='STRING', attr=s)
         parent.lineno = parent.lineno + nline
-
-    def t_lbracket(self, s, m, parent):
-        r'\['
-        parent.addToken(type=s)
-        # push to compute mode
-        parent.current.append(_COMPUTE_MODE)
 
     def t_lparen(self, s, m, parent):
         r'\('

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -173,3 +173,15 @@ def test_which(tmpdir, arg, expected):
     kw = {"StderrAppend": stdout}
     iraf.which(*args, **kw)  # catches stdout+err
     assert stdout.getvalue().strip() == expected
+
+
+def test_parse_cl_array_subscripts():
+    # Check that square brackets are parsed correctly
+    # https://github.com/iraf-community/pyraf/issues/115
+    stdout = io.StringIO()
+    iraf.task(xyz='char cenwavvalue[4]\n'
+              'cenwavvalue[1] = "580"\n'
+              'print(cenwavvalue[1])',
+              IsCmdString=True)
+    iraf.xyz(StdoutAppend=stdout)
+    assert stdout.getvalue() == "580\n"


### PR DESCRIPTION
Fixes: #115