### PR TITLE
Handle non-ASCII Unicode and binary files on stdin/stdout/stderr

### DIFF
--- a/pyraf/cl2py.py
+++ b/pyraf/cl2py.py
@@ -90,13 +90,12 @@ def cl2py(filename=None,
                     return pycode
             else:
                 index = None
-            fh = open(efilename)
-            clInput = fh.read()
-            fh.close()
+            with open(efilename, errors="ignore") as fh:
+                clInput = fh.read()
         elif hasattr(filename, 'read'):
             clInput = filename.read()
             if usecache:
-                index, pycode = codeCache.get(filename,
+                index, pycode = codeCache.get(getattr(filename, 'name', None),
                                               mode=mode,
                                               source=clInput)
                 if pycode is not None:
@@ -105,10 +104,7 @@ def cl2py(filename=None,
                     return pycode
             else:
                 index = None
-            if hasattr(filename, 'name'):
-                efilename = filename.name
-            else:
-                efilename = ''
+            efilename = getattr(filename, 'name', '')
         else:
             raise TypeError('filename must be a string or a filehandle')
     elif string is not None:

--- a/pyraf/graphcap.py
+++ b/pyraf/graphcap.py
@@ -85,7 +85,8 @@ class GraphCap(filecache.FileCache):
 
     def updateValue(self):
         """Called on init and if file changes"""
-        lines = open(self.filename).readlines()
+        with open(self.filename, errors="ignore") as fh:
+            lines = fh.readlines()
         mergedlines = merge(lines)
         self.dict = getDevices(mergedlines)
 

--- a/pyraf/irafecl.py
+++ b/pyraf/irafecl.py
@@ -386,7 +386,8 @@ class EclTraceback(EclBase):
         lineno = self._ecl_get_lineno(frame=raising_frame)
         cl_file = self.getFilename()
         try:
-            cl_code = open(cl_file).readlines()[lineno - 1].strip()
+            with open(cl_file, errors="ignore") as fh:
+                cl_code = fh.readlines()[lineno - 1].strip()
         except OSError:
             cl_code = "<source code not available>"
         if hasattr(e, "_ecl_suppress_first_trace") and \
@@ -400,8 +401,8 @@ class EclTraceback(EclBase):
             parent_lineno = self._ecl_get_lineno()
             parent_file = parent.getFilename()
             try:
-                parent_code = open(parent_file).readlines()[parent_lineno -
-                                                            1].strip()
+                with open(parent_file, errors="ignore") as fh:
+                    parent_code = fh.readlines()[parent_lineno - 1].strip()
                 self._ecl_trace("      called as:", repr(parent_code))
             except:
                 pass

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -552,14 +552,15 @@ class IrafProcess:
         self.terminate()
 
     def writeString(self, s):
-        """Convert ascii string to IRAF form and write to IRAF process"""
-
-        self.write(Asc2IrafString(s))
+        """Convert string or bytes to IRAF form and write to IRAF process"""
+        if isinstance(s, str):
+            s = s.encode()
+        self.write(Bytes2Iraf(s))
 
     def readString(self):
         """Read IRAF string from process and convert to ascii string"""
 
-        return Iraf2AscString(self.read())
+        return Iraf2Bytes(self.read()).decode()
 
     def write(self, data):
         """write binary data to IRAF process in blocks of <= 4096 bytes"""
@@ -602,7 +603,7 @@ class IrafProcess:
         Raises an IrafProcessError if an error occurs."""
 
         self.msg = ''
-        self.xferline = ''
+        self.xferline = b''
         # try to speed up loop a bit
         re_match = _re_msg.match
         xfer = self.xfer
@@ -783,29 +784,35 @@ class IrafProcess:
                 txdata = xdata
             else:
                 # normally stdout is translated text data
-                txdata = Iraf2AscString(xdata)
+                txdata = Iraf2Bytes(xdata)
 
             if checkForEscapeSeq:
-                if (txdata[0:5] == "\033+rAw"):
+                if (txdata[0:5] == b"\033+rAw"):
                     # Turn on RAW mode for STDIN
                     self.stdinIsraw = True
                     return
 
-                if (txdata[0:5] == "\033-rAw"):
+                if (txdata[0:5] == b"\033-rAw"):
                     # Turn off RAW mode for STDIN
                     self.stdinIsraw = False
                     return
 
-                if (txdata[0:5] == "\033=rDw"):
+                if (txdata[0:5] == b"\033=rDw"):
                     # ignore IRAF io escape sequences for now
                     # This mode enables screen redraw code
                     return
 
-            self.stdout.write(txdata)
+            if hasattr(self.stdout, "buffer"):
+                self.stdout.buffer.write(txdata)
+            else:
+                self.stdout.write(txdata.decode())
             self.stdout.flush()
         elif chan == 5:
             sys.stdout.flush()
-            self.stderr.write(Iraf2AscString(xdata))
+            if hasattr(self.stderr, "buffer"):
+                self.stderr.buffer.write(Iraf2Bytes(xdata))
+            else:
+                self.stderr.write(Iraf2Bytes(xdata).decode())
             self.stderr.flush()
         elif chan == 6:
             gki.kernel.append(numpy.frombuffer(xdata, dtype=numpy.int16))
@@ -887,8 +894,10 @@ class IrafProcess:
                     # small messages (due to the overhead of handshaking
                     # between the CL task and this main process.)  That's
                     # why it is done this way.
-
-                    line = self.stdin.read(nchars)
+                    if hasattr(self.stdin, 'buffer'):
+                        line = self.stdin.buffer.read(nchars)
+                    else:
+                        line = self.stdin.read(nchars)
                 self.xferline = line
             # Send two messages, the first with the number of characters
             # in the line and the second with the line itself.
@@ -1013,18 +1022,18 @@ class IrafProcess:
 # IRAF string conversions using numpy module
 
 
-def Asc2IrafString(ascii_string):
-    """translate ascii to IRAF 16-bit string format"""
-    inarr = numpy.frombuffer(ascii_string.encode(), numpy.int8)
+def Bytes2Iraf(b):
+    """translate bytes to IRAF 16-bit string format"""
+    inarr = numpy.frombuffer(b, numpy.int8)
     retval = inarr.astype(numpy.int16).tobytes()
     #   log_task_comm('Asc2IrafString (write to task)', retval, False)
     return retval
 
 
-def Iraf2AscString(iraf_string):
+def Iraf2Bytes(iraf_string):
     """translate 16-bit IRAF characters to ascii"""
     inarr = numpy.frombuffer(iraf_string, numpy.int16)
-    retval = inarr.astype(numpy.int8).tobytes().decode()
+    retval = inarr.astype(numpy.int8).tobytes()
     #   log_task_comm('Iraf2AscString', retval, True)
     return retval
 

--- a/pyraf/irafexecute.py
+++ b/pyraf/irafexecute.py
@@ -1015,7 +1015,7 @@ class IrafProcess:
 
 def Asc2IrafString(ascii_string):
     """translate ascii to IRAF 16-bit string format"""
-    inarr = numpy.frombuffer(ascii_string.encode('ascii'), numpy.int8)
+    inarr = numpy.frombuffer(ascii_string.encode(), numpy.int8)
     retval = inarr.astype(numpy.int16).tobytes()
     #   log_task_comm('Asc2IrafString (write to task)', retval, False)
     return retval
@@ -1024,7 +1024,7 @@ def Asc2IrafString(ascii_string):
 def Iraf2AscString(iraf_string):
     """translate 16-bit IRAF characters to ascii"""
     inarr = numpy.frombuffer(iraf_string, numpy.int16)
-    retval = inarr.astype(numpy.int8).tobytes().decode('ascii')
+    retval = inarr.astype(numpy.int8).tobytes().decode()
     #   log_task_comm('Iraf2AscString', retval, True)
     return retval
 

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -264,7 +264,8 @@ def _getIrafEnv(file='/usr/local/bin/cl', vars=('IRAFARCH', 'iraf')):
         return {'iraf': '/iraf/is/not/here/', 'IRAFARCH': 'arch_is_unused'}
     if not _os.path.exists(file):
         raise OSError(f"CL startup file {file} does not exist")
-    lines = open(file).readlines()
+    with open(file, errors="ignore") as fh:
+        lines = fh.readlines()
     # replace commands that exec cl with commands to print environment vars
     pat = _re.compile(r'^\s*exec\s+')
     newlines = []
@@ -3718,16 +3719,16 @@ def redirProcess(kw):
                         # output file
                         # check to see if it is dev$null
                         if isNullFile(value):
-                            if _sys.platform.startswith('win'):
-                                value = 'NUL'
-                            else:
-                                value = '/dev/null'
+                            value = _os.devnull
                         elif "w" in openArgs and \
                                 envget("clobber", "") != yes and \
                                 _os.path.exists(value):
                             # don't overwrite unless clobber is set
                             raise OSError(f"Output file `{value}' already exists")
-                    fh = open(value, openArgs)
+                    openArgs = {'mode': openArgs}
+                    if 'b' not in openArgs['mode']:
+                        openArgs['errors'] = 'ignore'
+                    fh = open(value, **openArgs)
                     # close this when we're done
                     closeFHList.append(fh)
             elif isinstance(value, int):

--- a/pyraf/irafpar.py
+++ b/pyraf/irafpar.py
@@ -306,7 +306,7 @@ class IrafParL(_StringMixin, IrafPar):
             # non-null value means we're reading from a file
             try:
                 if not self.fh:
-                    self.fh = open(iraf.Expand(self.value))
+                    self.fh = open(iraf.Expand(self.value), errors="ignore")
                     if self.fh.isatty():
                         self.lines = None
                     else:
@@ -1312,9 +1312,8 @@ def _updateSpecialParFileDict(dirToCheck=None, strict=False):
     for supfname in flist:
         buf = []
         try:
-            supfile = open(supfname)
-            buf = supfile.readlines()
-            supfile.close()
+            with open(supfname, errors="ignore") as supfile:
+                buf = supfile.readlines()
         except OSError:
             pass
         if len(buf) < 1:
@@ -1465,9 +1464,8 @@ def _readpar(filename, strict=0):
 
     param_dict = {}
     param_list = []
-    fh = open(os.path.expanduser(filename))
-    lines = fh.readlines()
-    fh.close()
+    with open(os.path.expanduser(filename), errors="ignore") as fh:
+        lines = fh.readlines()
     # reverse order of lines so we can use pop method
     lines.reverse()
     while lines:

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -213,10 +213,12 @@ class Subprocess:
     ### Write input to subprocess ###
 
     def write(self, strval, timeout=10, printtime=2):
-        """Write a STRING to the subprocess.  Times out (and raises an
-        exception) if the process is not ready in timeout seconds.
-        Prints a message indicating that it is waiting every
-        printtime seconds."""
+        """Write a bytes or string to the subprocess.  Times out (and raises
+        an exception) if the process is not ready in timeout seconds.
+        Prints a message indicating that it is waiting every printtime
+        seconds.
+
+        """
 
         if not self.pid:
             raise SubprocessError(f"No child process for '{self.cmd}'")
@@ -240,6 +242,8 @@ class Subprocess:
                 ## if totalwait: print "waiting for subprocess..."
                 totalwait = totalwait + printtime
                 if select.select([], self.toChild_fdlist, [], printtime)[1]:
+                    if not isinstance(strval, bytes):
+                        strval = strval.encode()
                     if os.write(self.toChild, strval) != len(strval):
                         raise SubprocessError(f"Write error to {self}")
                     return  # ===>

--- a/pyraf/subproc.py
+++ b/pyraf/subproc.py
@@ -826,7 +826,10 @@ class RedirProcess(Subprocess):
                     # stderr
                     s = self.readPendingErrChars()  # returns bytes
                     if s:
-                        sys.stderr.write(s.decode())
+                        if hasattr(sys.stderr, "buffer"):
+                            sys.stderr.buffer.write(s)
+                        else:
+                            sys.stderr.write(s.decode())
                         sys.stderr.flush()
                     else:
                         # EOF
@@ -839,7 +842,10 @@ class RedirProcess(Subprocess):
                     # stdout
                     s = self.readPendingChars()  # returns bytes
                     if s:
-                        sys.stdout.write(s.decode())
+                        if hasattr(sys.stdout, "buffer"):
+                            sys.stdout.buffer.write(s)
+                        else:
+                            sys.stdout.write(s.decode())
                         sys.stdout.flush()
                     else:
                         # EOF
@@ -856,7 +862,10 @@ class RedirProcess(Subprocess):
             elif writable:
                 # stdin
                 try:
-                    s = sys.stdin.read(self.maxChunkSize)  # s is 'str' in PY3K
+                    if hasattr(sys.stdin, "buffer"):
+                        s = sys.stdin.buffer.read(self.maxChunkSize)
+                    else:
+                        s = sys.stdin.read(self.maxChunkSize)
                     if s:
                         try:
                             self.write(s)  # inside, converts PY3K str to bytes

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -245,6 +245,7 @@ def test_intrinsic_functions(call, expected):
 @pytest.mark.parametrize('encoding', ['utf-8', 'iso-8859-1'])
 @pytest.mark.parametrize('code,expected', [
     ('print AA #  Ångström\n', 'AA\n'),
+    ('print("test") | cat', 'test\n'),
 ])
 def test_clfile(tmpdir, ecl_flag, encoding, code, expected):
     # Check proper reading of CL files with different encodings

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -239,3 +239,22 @@ def test_intrinsic_functions(call, expected):
         assert int(stdout.getvalue().strip()) == expected
     else:
         assert stdout.getvalue().strip() == expected
+
+
+@pytest.mark.parametrize('ecl_flag', [False, True])
+@pytest.mark.parametrize('encoding', ['utf-8', 'iso-8859-1'])
+@pytest.mark.parametrize('code,expected', [
+    ('print AA #  Ångström\n', 'AA\n'),
+])
+def test_clfile(tmpdir, ecl_flag, encoding, code, expected):
+    # Check proper reading of CL files with different encodings
+    fname = tmpdir / 'cltestfile.cl'
+    with fname.open("w", encoding=encoding) as fp:
+        fp.write(code)
+
+    stdout = io.StringIO()
+
+    with use_ecl(ecl_flag):
+        iraf.task(xyz=str(fname))
+        iraf.xyz(StdoutAppend=stdout)
+        assert stdout.getvalue() == expected


### PR DESCRIPTION
IRAF is not able to handle non-ASCII chars (and will probably never do). We need to be robust here to not fail on files that have
non-ASCII characters, f.e. in comments.

Fixes: #117

Todo:
* [x]  A test still needs to be appended