### PR TITLE
Use StringIO instead of temporary to handle non-persistent CL commands

### DIFF
--- a/pyraf/iraftask.py
+++ b/pyraf/iraftask.py
@@ -1566,6 +1566,13 @@ class IrafCLTask(IrafTask):
         return 1
 
 
+    def isConsistent(self, other):
+        """Returns true if this task is consistent with another task object"""
+        if self.getFilename() is not None or other.getFilename() is not None:
+            return IrafTask.isConsistent(self, other)
+        else:
+            return self._pycode == other._pycode
+
 # -----------------------------------------------------
 # IRAF package class
 # -----------------------------------------------------


### PR DESCRIPTION
This gets rid of the temporary files that are written to `~/.iraf`, and often not (at least in my case) removed after processing.
The `IrafCLTask` class is slaready able to handle `StringIO` instead of files.