### PR TITLE
Use Python's "webbrowser" module instead of irafutils.launchBrowser

### DIFF
--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -435,7 +435,7 @@ def _irafHelp(taskname, irafkw):
         return 0
 
 
-_HelpURL = "https://iraf.readthedocs.io"
+_HelpURL = "https://iraf.readthedocs.io/en/latest/tasks/by-name"
 
 
 def _htmlHelp(taskname):

--- a/pyraf/irafhelp.py
+++ b/pyraf/irafhelp.py
@@ -42,6 +42,7 @@ import os
 import sys
 import types
 import io
+import webbrowser
 from inspect import signature
 
 from stsci.tools import minmatch, irafutils
@@ -435,7 +436,6 @@ def _irafHelp(taskname, irafkw):
 
 
 _HelpURL = "https://iraf.readthedocs.io"
-_Browser = "netscape"
 
 
 def _htmlHelp(taskname):
@@ -446,4 +446,4 @@ def _htmlHelp(taskname):
         taskname = taskname.getName()
     url = f"{_HelpURL}/{taskname}.html"
 
-    irafutils.launchBrowser(url, brow_bin=_Browser, subj=taskname)
+    webbrowser.open(url)


### PR DESCRIPTION
[webbrowser](https://docs.python.org/3/library/webbrowser.html) is available since long and provides a standard conform access to a webbrowser.

HTML help still however does not work yet because the documentation is structured hierarchically on [readthedocs](https://iraf.readthedocs.io/en/latest/tasks/index.html), but the PyRAF help does not have the hierarchical path of the help target. Still unclear where to adjust this.