### PR TITLE
Make iraf.nint() on Py 3 round n+0.5 upwards like CL & Py 2

### DIFF
--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -72,6 +72,7 @@ import stsci.tools.minmatch as _minmatch
 import stsci.tools.irafutils as _irafutils
 import stsci.tools.teal as _teal
 import numpy as _numpy
+from decimal import Decimal as _Decimal, ROUND_HALF_UP as _ROUND_HALF_UP
 from . import subproc as _subproc
 from . import wutil as _wutil
 from . import irafnames as _irafnames
@@ -1276,7 +1277,7 @@ def nint(x):
     """Return nearest integer of x"""
     if x == INDEF:
         return INDEF
-    return int(round(x))
+    return int(_Decimal(x).to_integral_value(rounding=_ROUND_HALF_UP))
 
 
 _radixDigits = list(_string.digits + _string.ascii_uppercase)

--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -205,6 +205,8 @@ def test_parse_cl_array_subscripts():
     ('max(2,3,4,2)', max(2,3,4,2)),
     ('min(2,3,4,2)', min(2,3,4,2)),
     ('mod(123, 7)', 123 % 7),
+    ('nint(1.5)', 2),
+    ('nint(2.5)', 3),
     ('rad(12)', math.radians(12)),
     ('radix(123, 10)', '123'),
     ('radix(123, 16)', '7B'),


### PR DESCRIPTION
Fixes one of the changes due to Python 3 in #127.