### PR TITLE
Increase clcache version

### DIFF
--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -48,7 +48,7 @@ else:
 
 
 def _currentVersion():
-    return "v3" if pyrafglobals._use_ecl else "v2"
+    return "4e" if pyrafglobals._use_ecl else "4c"
 
 
 class _FileContentsCache(filecache.FileCacheDict):


### PR DESCRIPTION
This is a follow-up for #129, which led to the problem described in https://github.com/iraf-community/pyraf/issues/127#issuecomment-1067482719.

Since the old Python files generated with cl2py do not longer work (conflicting use of stsci.tools vs. pyraf.tools), the cache
version needs to be increased. We also now use a single version number "4" and a suffix "e" resp. "c" for the ECL vs. CL variant.