### PR TITLE
Use same string precision for real parameters on Py3 as on Py2

### DIFF
--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -323,3 +323,21 @@ def test_binary_stdout(tmpdir):
     # Require gkidir output to match list above, ignoring spacing:
     assert [' '.join(line.split())
             for line in stdout.getvalue().splitlines() if line] == expected
+
+def test_real_parameter_str_precision():
+    # Check that PyRAF uses the same precision for real parameters on Python 3
+    # as on 2 (see https://github.com/iraf-community/pyraf/issues/127)
+    iraf.task(
+        print_real='''procedure print_real(value)
+                      real value
+                      begin
+                          print(value)
+                      end''',
+        IsCmdString=True
+    )
+    stdout = io.StringIO()
+    iraf.print_real(1.2345678901234567, Stdout=stdout)
+    assert stdout.getvalue() == "1.23456789012\n"
+    stdout = io.StringIO()
+    iraf.print_real(1000000000000000.0, Stdout=stdout)
+    assert stdout.getvalue() == "1e+15\n"

--- a/pyraf/tools/basicpar.py
+++ b/pyraf/tools/basicpar.py
@@ -6,7 +6,7 @@ $Id$
 import re
 import sys
 from . import irafutils, minmatch
-from .irafglobals import INDEF, Verbose, yes, no
+from .irafglobals import INDEF, Verbose, yes, no, clFloat
 
 int_types = (int, )
 
@@ -1463,15 +1463,18 @@ class _RealMixin:
             self.choice = None
 
     # coerce value to real
+    # using clFloat in Py3 reproduces same numerical values as on Py2
     def _coerceOneValue(self,value,strict=0):
         if value == INDEF:
             return INDEF
-        elif value is None or isinstance(value,float):
+        elif value is None or isinstance(value,clFloat):
             return value
+        elif isinstance(value,float):
+            return clFloat(value)
         elif value in ("", "None", "NONE"):
             return None
         elif isinstance(value, int_types):
-            return float(value)
+            return clFloat(value)
         elif isinstance(value,str):
             s2 = irafutils.stripQuotes(value.strip())
             if s2 == "INDEF" or \
@@ -1502,16 +1505,16 @@ class _RealMixin:
             mm = _re_d.search(s2,i1)
             try:
                 if mm is None:
-                    return vsign*(fvalue + float(s2[i1:])/vscale)
+                    return clFloat(vsign*(fvalue + float(s2[i1:])/vscale))
                 else:
-                    return vsign*(fvalue + \
-                            float(s2[i1:mm.start()]+"E"+s2[mm.end():])/vscale)
+                    return clFloat(vsign*(fvalue + \
+                            float(s2[i1:mm.start()]+"E"+s2[mm.end():])/vscale))
             except ValueError:
                 pass
         else:
             # maybe it has a float method
             try:
-                return float(value)
+                return clFloat(value)
             except ValueError:
                 pass
         raise ValueError("Parameter %s: illegal float value %s" %
@@ -1557,10 +1560,12 @@ class _StrictRealMixin(_RealMixin):
 
     # coerce value to real
     def _coerceOneValue(self,value,strict=0):
-        if value is None or isinstance(value,float):
+        if value is None or isinstance(value,clFloat):
             return value
+        elif isinstance(value,float):
+            return clFloat(value)
         elif isinstance(value, int_types):
-            return float(value)
+            return clFloat(value)
         elif isinstance(value,str):
             s2 = irafutils.stripQuotes(value.strip())
             if s2 == '':
@@ -1588,15 +1593,15 @@ class _StrictRealMixin(_RealMixin):
             mm = _re_d.search(s2,i1)
             try:
                 if mm is None:
-                    return vsign*(fvalue + float(s2[i1:])/vscale)
+                    return clFloat(vsign*(fvalue + float(s2[i1:])/vscale))
                 else:
-                    return vsign*(fvalue + \
-                            float(s2[i1:mm.start()]+"E"+s2[mm.end():])/vscale)
+                    return clFloat(vsign*(fvalue + \
+                            float(s2[i1:mm.start()]+"E"+s2[mm.end():])/vscale))
             except ValueError:
                 pass
             # see if it's a stringified float
             try:
-                return float(s2)
+                return clFloat(s2)
             except ValueError:
                 raise ValueError("Parameter %s: illegal float value %s" %
                                  (self.name, repr(value)))

--- a/pyraf/tools/irafglobals.py
+++ b/pyraf/tools/irafglobals.py
@@ -426,6 +426,26 @@ epsilon = _EPSILONClass()
 epsilon.setvalue()
 
 # -----------------------------------------------------
+# Float class that reproduces Py2 str precision on Py3
+# -----------------------------------------------------
+
+class clFloat(float):
+    def __str__(self):
+        return '{:.12}'.format(self)
+    for op in ('__add__', '__radd__', '__sub__', '__rsub__',
+               '__mul__', '__rmul__', '__div__', '__rdiv__',
+               '__truediv__', '__rtruediv__', '__floordiv__', '__rfloordiv__',
+               '__pow__', '__rpow__', '__mod__', '__abs__',
+               '__neg__', '__pos__'):
+        exec(f'def {op}(self, *args):\n'
+             f'    val = super(clFloat, self).{op}(*args)\n'
+              '    return val if val is NotImplemented else clFloat(val)')
+    def __divmod__(self, other):
+        return tuple(clFloat(v) for v in super().__divmod__(other))
+    def __rdivmod__(self, other):
+        return tuple(clFloat(v) for v in super().__rdivmod__(other))
+
+# -----------------------------------------------------
 # tag classes
 # -----------------------------------------------------
 


### PR DESCRIPTION
This addresses many of the numerical differences reported in https://github.com/iraf-community/pyraf/issues/127. However, it turns out that the results of the test from the commit below are different on CL than on either Python 2 or Python 3 without this patch:
```
ecl> print_real(1.2345678901234567)
1.2345678901235
py2> print_real(1.2345678901234567)  # (also py3 with this patch)
1.23456789012
py3> print_real(1.2345678901234567)
1.2345678901234567
```
I'm sure I saw almost identical behaviour from Python 2 & CL when doing some earlier comparison, but clearly the behaviour is not the same in this case, which raises the question of whether you really want a compatibility patch that doesn't emulate CL (though it does give continuity of PyRAF behaviour across Python versions).

Anyway, I have re-tested this with all the latest changes (sorry I kept getting interrupted) and everything passes, except for 14 tests that were already failing on Python 2 for unrelated reasons.