### PR TITLE
Allow for `which` matching additional stsdas tasks to abbreviations

### DIFF
--- a/pyraf/tests/test_cli.py
+++ b/pyraf/tests/test_cli.py
@@ -167,7 +167,18 @@ def test_which(arg, expected):
     args = arg.split(" ")  # convert to a list
     kw = {"StderrAppend": stdout}
     iraf.which(*args, **kw)  # catches stdout+err
-    assert stdout.getvalue().strip() == expected
+    actual_lines = stdout.getvalue().strip().splitlines()
+    expected_lines = expected.splitlines()
+    assert len(actual_lines) == len(expected_lines)
+    for arg, actual_line, expected_line in zip(args, actual_lines,
+                                               expected_lines):
+        if 'ambiguous' in actual_line:
+            if 'ambiguous' in expected_line:
+                assert actual_line.startswith(expected_line.rstrip('"'))
+            else:
+                assert f'{expected_line}.{arg}' in actual_line
+        else:
+            assert actual_line == expected_line
 
 
 def test_parse_cl_array_subscripts():


### PR DESCRIPTION
Is this a good solution for #136? I realized after the fact that this patch may be unnecessarily general, because `stsdas` is the only optional package that can be loaded when running the tests, so `img` & `dis` should be the only 2 cases that will ever fail. However, it's still more robust against any future test cases being added that might only become ambiguous when `stsdas` is loaded (eg. something like `tt` would do it). Anyway, feel free to merge this or use your own fix.

Fixes: #136

Is there any chance of a release candidate that I could test in the relatively near future? :wink: Thanks!
