### PR TITLE
Remove unused `get_pkg_data_contents` import from astropy.utils

### DIFF
--- a/pyraf/tests/utils.py
+++ b/pyraf/tests/utils.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-from astropy.utils.data import get_pkg_data_contents
 from distutils.spawn import find_executable
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')


### PR DESCRIPTION
Just to avoid any future breakage if it changes. It's not referenced anywhere else in the code and the tests distributed with `pyraf` still pass for me.