### PR TITLE
Set stacksize to unlimited for macosx as well

### DIFF
--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -180,7 +180,7 @@ Also be sure to run the "mkiraf" command to create a logion.cl
 
         # stacksize problem on linux
         # https://iraf-community.github.io/iraf-v216/issues/61
-        if arch in ('redhat', 'linux', 'linuxppc', 'suse'):
+        if arch in ('redhat', 'linux', 'linuxppc', 'suse', 'macosx'):
             import resource
             try:
                 hardlimit = resource.getrlimit(resource.RLIMIT_STACK)[1]


### PR DESCRIPTION
AstroConda versions of macosx (32 bit) seem to have the same problem now, so we pragmatically use the workaround here as well.
See https://github.com/iraf-community/pyraf/issues/139#issuecomment-1083964636 and https://github.com/iraf-community/pyraf/issues/99#issuecomment-1083931403.
@jehturner, can you check this? If this works, I would move release date to early next week (unless there is another problem).