### PR TITLE
Fix pickle protocol

### DIFF
--- a/pyraf/clcache.py
+++ b/pyraf/clcache.py
@@ -48,7 +48,8 @@ else:
 
 
 def _currentVersion():
-    return "4e" if pyrafglobals._use_ecl else "4c"
+    v = "4e" if pyrafglobals._use_ecl else "4c"
+    return v + str(sqliteshelve.pickle_protocol)
 
 
 class _FileContentsCache(filecache.FileCacheDict):

--- a/pyraf/sqliteshelve.py
+++ b/pyraf/sqliteshelve.py
@@ -75,7 +75,7 @@ class Shelf:
         """
         if self.readonly:
             raise OSError("Readonly database")
-        pdata = pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
+        pdata = pickle.dumps(value, protocol=4)
         cursor = self.db.cursor()
         try:
             cursor.execute("insert or replace into shelf (key_str, value_str)"

--- a/pyraf/sqliteshelve.py
+++ b/pyraf/sqliteshelve.py
@@ -27,6 +27,10 @@ import sqlite3
 import os
 
 
+pickle_protocol = 4
+"""Protocol version to use for pickling objects"""
+
+
 class Shelf:
     """An SQLite implementation of the Python Shelf interface
 
@@ -75,7 +79,7 @@ class Shelf:
         """
         if self.readonly:
             raise OSError("Readonly database")
-        pdata = pickle.dumps(value, protocol=4)
+        pdata = pickle.dumps(value, protocol=pickle_protocol)
         cursor = self.db.cursor()
         try:
             cursor.execute("insert or replace into shelf (key_str, value_str)"


### PR DESCRIPTION
Protocol version 4 is supported since Python 3.4 and the default starting with Python 3.8.

Fixing the protocol version allows to downgrade the Python version. To make it more robust, also trigger a re-build of the cache entry if the cache was written by an unsupported protocol version.

Fixes #142.