### PR TITLE
Fix blank window issue when resizing

### DIFF
--- a/pyraf/MplCanvasAdapter.py
+++ b/pyraf/MplCanvasAdapter.py
@@ -92,6 +92,7 @@ class MplCanvasAdapter(tkagg.FigureCanvasTkAgg):
                                     int(height / 2),
                                     image=self._tkphoto)
         self.callbacks.process('resize_event', ResizeEvent('resize_event', self))
+        self.draw_idle()
 
     def flush(self):
 


### PR DESCRIPTION
With the matplotlib backend, pyraf window becomes blank when resizing it.
I added `self.draw_idle()` to prevent it.

This is a hotfix of #157 and PR for #160 