### PR TITLE
Require pyobjc on macOS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ setup_requires = setuptools_scm
 install_requires =
     numpy
     configobj
+    pyobjc; sys_platform == "darwin"
 packages =
     pyraf
     pyraf/tests


### PR DESCRIPTION
On macOS, there are three possible ways to create interactive graphics: aqua, x11, matplotlib. 
By default, this should probably be aqua, and aqua requires additionally the **pyobjc** package and its dependencies.

One question however is whether this should be *required*. This PR makes it required as a base for testing and discussion.

Cc @monodera 

This could fix #156
