### PR TITLE
Remove IrafHatchFills

### DIFF
--- a/pyraf/gki.py
+++ b/pyraf/gki.py
@@ -1404,54 +1404,6 @@ class IrafLineStyles:
         self.patterns = [0x0000, 0xFFFF, 0x00FF, 0x5555, 0x33FF]
 
 
-class IrafHatchFills:
-
-    def __init__(self):
-
-        # Each fill pattern is a 32x4 ubyte array (represented as 1-d).
-        # These are computed on initialization rather than using a
-        # 'data' type initialization since they are such simple patterns.
-        # these arrays are stored in a pattern list. Pattern entries
-        # 0-2 should never be used since they are not hatch patterns.
-
-        # so much for these, currently PyOpenGL does not support
-        # glPolygonStipple()! But adding it probably is not too hard.
-
-        self.patterns = [None] * 7
-        # pattern 3, vertical stripes
-        p = numpy.zeros(128, numpy.int8)
-        p[0:4] = [0x92, 0x49, 0x24, 0x92]
-        for i in range(31):
-            p[(i + 1) * 4:(i + 2) * 4] = p[0:4]
-        self.patterns[3] = p
-        # pattern 4, horizontal stripes
-        p = numpy.zeros(128, numpy.int8)
-        p[0:4] = [0xFF, 0xFF, 0xFF, 0xFF]
-        for i in range(10):
-            p[(i + 1) * 12:(i + 1) * 12 + 4] = p[0:4]
-        self.patterns[4] = p
-        # pattern 5, close diagonal striping
-        p = numpy.zeros(128, numpy.int8)
-        p[0:12] = [
-            0x92, 0x49, 0x24, 0x92, 0x24, 0x92, 0x49, 0x24, 0x49, 0x24, 0x92,
-            0x49
-        ]
-        for i in range(9):
-            p[(i + 1) * 12:(i + 2) * 12] = p[0:12]
-        p[120:128] = p[0:8]
-        self.patterns[5] = p
-        # pattern 6, diagonal stripes the other way
-        p = numpy.zeros(128, numpy.int8)
-        p[0:12] = [
-            0x92, 0x49, 0x24, 0x92, 0x49, 0x24, 0x92, 0x49, 0x24, 0x92, 0x49,
-            0x24
-        ]
-        for i in range(9):
-            p[(i + 1) * 12:(i + 2) * 12] = p[0:12]
-        p[120:128] = p[0:8]
-        self.patterns[6] = p
-
-
 class LineAttributes:
 
     def __init__(self):

--- a/pyraf/gkitkbase.py
+++ b/pyraf/gkitkbase.py
@@ -205,7 +205,6 @@ class GkiInteractiveTkBase(gki.GkiKernel, wutil.FocusEntity):
         self.colorManager.setColors(self.gwidget)
         self.wcs = irafgwcs.IrafGWcs()
         self.linestyles = gki.IrafLineStyles()
-        self.hatchfills = gki.IrafHatchFills()
         self.textAttributes = gki.TextAttributes()
         self.lineAttributes = gki.LineAttributes()
         self.fillAttributes = gki.FillAttributes()

--- a/pyraf/iraffunctions.py
+++ b/pyraf/iraffunctions.py
@@ -89,7 +89,7 @@ from . import scanf as sscanf
 
 # FP_EPSILON is the smallest number such that: 1.0 + epsilon > 1.0;  Use None
 # in the finfo ctor to make it use the default precision for a Python float.
-FP_EPSILON = _numpy.finfo(None).eps
+FP_EPSILON = _numpy.finfo(_numpy.float64).eps
 
 # -----------------------------------------------------
 # private dictionaries:


### PR DESCRIPTION
This class was never used, and its only potential usage (commented out) was removed in 2008. So it is safe to completely erase it:

When following the use of **IrafHatchFills** in PyRAF, it looks that the only place is in the initialization of kiInteractiveTkBase: https://github.com/iraf-community/pyraf/blob/151350f040c0b7fb770c65d68c07b5979523ec6e/pyraf/gkitkbase.py#L205-L212

The attribute **hatchfills** is then never references within the PyRAF code base. The only reference I could find is in `gkiopengl.py`; however there it was always commented out (since its introduction before 2000): https://github.com/iraf-community/pyraf/blob/5f6f68df0a0f9e78f0717716ff9afc59f325a59f/lib/gkiopengl.py#L360-L371

This was however removed in 70b0404 2008.

**hatchfills** is also not part of a Tcl/Tk interface, so I doubt it has any use; I think we can simply remove this attribute and the **IrafHatchFills** class. It was probably just forgotten when the OpenGL kernel was removed.

Fixes #172 