### PR TITLE
Fix imexam on NumPy 2

### DIFF
--- a/pyraf/irafdisplay.py
+++ b/pyraf/irafdisplay.py
@@ -148,7 +148,7 @@ class ImageDisplay:
         """Write request to image display"""
 
         a = numpy.array([tid, thingct, subunit, 0, x, y, z, t],
-                        dtype=int).astype(numpy.int16)
+                        dtype=int).astype(numpy.uint16)
         # Compute the checksum
         sum = numpy.add.reduce(a)
         sum = 0xffff - (sum & 0xffff)


### PR DESCRIPTION
A one-line fix for #181, issue 2 (the same as in the copy of `numdisplay` bundled with DRAGONS) -- because NumPy 2 no longer allows implicit downcasting when creating an array.

I notice that you have `int16` here, whereas the same code in numdisplay had `uint16`. IRAF's implementation of the IIS prtocol appears to munge both 18-bit(!) control codes >32767 (or even >65535) and also negative values into 16 bits, so I don't think either is obviously correct, nor that it really matters, as long as we send the expected sequence of 16 bits to the display tool, so I've kept the type as you had it... Should you wish to balk at that, you're welcome to refer to the following, but I think we'll have to concede that it does the same as before and works again  :wink::

https://noirlab.edu/science/sites/default/files/media/archives/documents/scidoc3024.pdf

Thanks!

James.